### PR TITLE
Updates to Thompson-Eidhammer microphysics and MPAS to support future microphysics features

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "src/core_atmosphere/physics/physics_wrf/GSL_cloud_physics"]
 	path = src/core_atmosphere/physics/physics_wrf/GSL_cloud_physics
 	url = https://github.com/AndersJensen-NOAA/GSL_cloud_physics.git
+	branch = mpas_modular

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
-[submodule "src/core_atmosphere/physics/physics_wrf/GSL_cloud_physics"]
-	path = src/core_atmosphere/physics/physics_wrf/GSL_cloud_physics
+[submodule "src/core_atmosphere/physics/GSL_cloud_physics"]
+	path = src/core_atmosphere/physics/GSL_cloud_physics
 	url = https://github.com/AndersJensen-NOAA/GSL_cloud_physics.git
 	branch = develop

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "src/core_atmosphere/physics/physics_wrf/GSL_cloud_physics"]
 	path = src/core_atmosphere/physics/physics_wrf/GSL_cloud_physics
 	url = https://github.com/AndersJensen-NOAA/GSL_cloud_physics.git
-	branch = mpas_modular
+	branch = develop

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/core_atmosphere/physics/physics_wrf/GSL_cloud_physics"]
+	path = src/core_atmosphere/physics/physics_wrf/GSL_cloud_physics
+	url = https://github.com/AndersJensen-NOAA/GSL_cloud_physics.git

--- a/src/core_atmosphere/Makefile
+++ b/src/core_atmosphere/Makefile
@@ -42,7 +42,7 @@ physcore: mpas_atm_dimensions.o
 	( mkdir libphys; cd libphys; ar -x ../physics/libphys.a )
 	( cd ../..; ln -sf ./src/core_atmosphere/physics/physics_wrf/files/*TBL .)
 	( cd ../..; ln -sf ./src/core_atmosphere/physics/physics_wrf/files/*DATA* .)
-	( cd ../..; ln -sf ./src/core_atmosphere/physics/physics_wrf/GSL_cloud_physics/thompson_aerosol_* .)
+	( cd ../..; ln -sf ./src/core_atmosphere/physics/physics_wrf/GSL_cloud_physics/tables/thompson_aerosol_* .)
 
 dycore: mpas_atm_dimensions.o $(PHYSCORE)
 	( cd dynamics; $(MAKE) all PHYSICS="$(PHYSICS)" )

--- a/src/core_atmosphere/Makefile
+++ b/src/core_atmosphere/Makefile
@@ -42,6 +42,7 @@ physcore: mpas_atm_dimensions.o
 	( mkdir libphys; cd libphys; ar -x ../physics/libphys.a )
 	( cd ../..; ln -sf ./src/core_atmosphere/physics/physics_wrf/files/*TBL .)
 	( cd ../..; ln -sf ./src/core_atmosphere/physics/physics_wrf/files/*DATA* .)
+	( cd ../..; ln -sf ./src/core_atmosphere/physics/physics_wrf/GSL_cloud_physics/thompson_aerosol_* .)
 
 dycore: mpas_atm_dimensions.o $(PHYSCORE)
 	( cd dynamics; $(MAKE) all PHYSICS="$(PHYSICS)" )

--- a/src/core_atmosphere/Makefile
+++ b/src/core_atmosphere/Makefile
@@ -42,7 +42,6 @@ physcore: mpas_atm_dimensions.o
 	( mkdir libphys; cd libphys; ar -x ../physics/libphys.a )
 	( cd ../..; ln -sf ./src/core_atmosphere/physics/physics_wrf/files/*TBL .)
 	( cd ../..; ln -sf ./src/core_atmosphere/physics/physics_wrf/files/*DATA* .)
-	( cd ../..; ln -sf ./src/core_atmosphere/physics/physics_wrf/GSL_cloud_physics/tables/thompson_aerosol_* .)
 
 dycore: mpas_atm_dimensions.o $(PHYSCORE)
 	( cd dynamics; $(MAKE) all PHYSICS="$(PHYSICS)" )

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1483,6 +1483,14 @@
                         <var name="nr" array_group="number" units="nb kg^{-1}"
                              description="Rain number concentration"
                              packages="mp_thompson_in"/>
+			
+			<var name="nwfa" array_group="passive" units="nb kg^{-1}"
+                             description="Number of water-friendly aerosols for microphysics"
+                             packages="mp_thompson_in"/>
+
+			<var name="nifa" array_group="passive" units="nb kg^{-1}"
+                             description="Number of ice-friendly aerosols for microphysics"
+                             packages="mp_thompson_in"/>
                 </var_array>
 #endif
 
@@ -1804,6 +1812,14 @@
 
                         <var name="tend_nr" name_in_code="nr" array_group="number" units="nb m^{-3} s^{-1}" 
                              description="Tendency of rain number concentration multiplied by dry air density divided by d(zeta)/dz"
+                             packages="mp_thompson_in"/>
+
+			<var name="tend_nwfa" name_in_code="nwfa" array_group="passive" units="nb m^{-3} s^{-1}" 
+                             description="Tendency of water-friendly aerosols multiplied by dry air density divided by d(zeta)/dz"
+                             packages="mp_thompson_in"/>
+
+			<var name="tend_nifa" name_in_code="nifa" array_group="passive" units="nb m^{-3} s^{-1}" 
+                             description="Tendency of ice-friendly aerosols multiplied by dry air density divided by d(zeta)/dz"
                              packages="mp_thompson_in"/>
                 </var_array>
 #endif

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1879,6 +1879,12 @@
 
                         <var name="lbc_ni" name_in_code="ni" array_group="number" packages="bl_mynn_in;mp_thompson_in" units="m^{-3} s^{-1}"
                              description="Lateral boundary tendency of ice number concentration"/>
+
+                        <var name="lbc_nwfa" name_in_code="nwfa" array_group="passive" packages="mp_thompson_in" units="m^{-3} s^{-1}"
+                             description="Lateral boundary tendency of wfa"/>
+
+                        <var name="lbc_nifa" name_in_code="nifa" array_group="passive" packages="mp_thompson_in" units="m^{-3} s^{-1}"
+                             description="Lateral boundary tendency of ifa"/>
                 </var_array>
         </var_struct>
 

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1480,6 +1480,10 @@
                              description="Cloud ice number concentration"
                              packages="bl_mynn_in;mp_thompson_in"/>
 
+                        <var name="nc" array_group="number" units="nb kg^{-1}"
+                             description="Cloud number concentration"
+                             packages="mp_thompson_in"/>
+
                         <var name="nr" array_group="number" units="nb kg^{-1}"
                              description="Rain number concentration"
                              packages="mp_thompson_in"/>
@@ -1810,6 +1814,10 @@
                              description="Tendency of cloud ice number concentration multiplied by dry air density divided by d(zeta)/dz"
                              packages="bl_mynn_in;mp_thompson_in"/>
 
+			<var name="tend_nc" name_in_code="nc" array_group="number" units="nb m^{-3} s^{-1}" 
+                             description="Tendency of cloud number concentration multiplied by dry air density divided by d(zeta)/dz"
+                             packages="mp_thompson_in"/>
+			
                         <var name="tend_nr" name_in_code="nr" array_group="number" units="nb m^{-3} s^{-1}" 
                              description="Tendency of rain number concentration multiplied by dry air density divided by d(zeta)/dz"
                              packages="mp_thompson_in"/>
@@ -1874,6 +1882,9 @@
                         <var name="lbc_qg" name_in_code="qg" array_group="moist"  packages="mp_thompson_in;mp_wsm6_in" units="kg kg^{-1} s^{-1}"
                              description="Lateral boundary tendency of graupel mixing ratio"/>
 
+                        <var name="lbc_nc" name_in_code="nc" array_group="number" packages="mp_thompson_in" units="m^{-3} s^{-1}"
+                             description="Lateral boundary tendency of cloud number concentration"/>
+			
                         <var name="lbc_nr" name_in_code="nr" array_group="number" packages="mp_thompson_in" units="m^{-3} s^{-1}"
                              description="Lateral boundary tendency of rain number concentration"/>
 

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -367,7 +367,7 @@ module atm_time_integration
       character (len=StrKIND), pointer :: config_convection_scheme
 
       integer, pointer :: num_scalars, index_qv, nCells, nCellsSolve, nEdges, nEdgesSolve, nVertices, nVerticesSolve, nVertLevels
-      integer, pointer :: index_qc, index_qr, index_qi, index_qs, index_qg, index_nr, index_ni, index_nwfa, index_nifa
+      integer, pointer :: index_qc, index_qr, index_qi, index_qs, index_qg, index_nc, index_nr, index_ni, index_nwfa, index_nifa
 
       character(len=StrKIND), pointer :: config_IAU_option
 
@@ -468,7 +468,8 @@ module atm_time_integration
          call mpas_pool_get_dimension(state, 'index_qr', index_qr)
          call mpas_pool_get_dimension(state, 'index_qi', index_qi)
          call mpas_pool_get_dimension(state, 'index_qs', index_qs)
-         call mpas_pool_get_dimension(state, 'index_qg', index_qg)  
+         call mpas_pool_get_dimension(state, 'index_qg', index_qg)
+         call mpas_pool_get_dimension(state, 'index_nc', index_nc)
          call mpas_pool_get_dimension(state, 'index_nr', index_nr)
          call mpas_pool_get_dimension(state, 'index_ni', index_ni)
          call mpas_pool_get_dimension(state, 'index_nwfa', index_nwfa)
@@ -923,6 +924,9 @@ module atm_time_integration
                   if (index_qg > 0) then
                      scalars_driving(index_qg,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qg', rk_timestep(rk_step) )
                   end if
+                  if (index_nc > 0) then
+                     scalars_driving(index_nc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nc', rk_timestep(rk_step) )
+                  end if
                   if (index_nr > 0) then
                      scalars_driving(index_nr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nr', rk_timestep(rk_step) )
                   end if
@@ -1096,6 +1100,9 @@ module atm_time_integration
                if (index_qg > 0) then
                   scalars_driving(index_qg,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qg', rk_timestep(rk_step) )
                end if
+               if (index_nc > 0) then
+                  scalars_driving(index_nc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nc', rk_timestep(rk_step) )
+               end if
                if (index_nr > 0) then
                   scalars_driving(index_nr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nr', rk_timestep(rk_step) )
                end if
@@ -1261,6 +1268,9 @@ module atm_time_integration
          end if
          if (index_qg > 0) then
             scalars_driving(index_qg,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qg', dt )
+         end if
+         if (index_nc > 0) then
+            scalars_driving(index_nc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nc', dt )
          end if
          if (index_nr > 0) then
             scalars_driving(index_nr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nr', dt )

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -367,7 +367,7 @@ module atm_time_integration
       character (len=StrKIND), pointer :: config_convection_scheme
 
       integer, pointer :: num_scalars, index_qv, nCells, nCellsSolve, nEdges, nEdgesSolve, nVertices, nVerticesSolve, nVertLevels
-      integer, pointer :: index_qc, index_qr, index_qi, index_qs, index_qg, index_nr, index_ni
+      integer, pointer :: index_qc, index_qr, index_qi, index_qs, index_qg, index_nr, index_ni, index_nwfa, index_nifa
 
       character(len=StrKIND), pointer :: config_IAU_option
 
@@ -471,6 +471,8 @@ module atm_time_integration
          call mpas_pool_get_dimension(state, 'index_qg', index_qg)  
          call mpas_pool_get_dimension(state, 'index_nr', index_nr)
          call mpas_pool_get_dimension(state, 'index_ni', index_ni)
+         call mpas_pool_get_dimension(state, 'index_nwfa', index_nwfa)
+         call mpas_pool_get_dimension(state, 'index_nifa', index_nifa)
       endif
 
       !
@@ -927,6 +929,12 @@ module atm_time_integration
                   if (index_ni > 0) then
                      scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
                   end if
+                  if (index_nwfa > 0) then
+                     scalars_driving(index_nwfa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nwfa', rk_timestep(rk_step) )
+                  end if
+                  if (index_nifa > 0) then
+                     scalars_driving(index_nifa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nifa', rk_timestep(rk_step) )
+                  end if
                   
                   !$OMP PARALLEL DO
                   do thread=1,nThreads
@@ -1094,6 +1102,12 @@ module atm_time_integration
                if (index_ni > 0) then
                   scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
                end if
+               if (index_nwfa > 0) then
+                  scalars_driving(index_nwfa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nwfa', rk_timestep(rk_step) )
+               end if
+               if (index_nifa > 0) then
+                  scalars_driving(index_nifa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nifa', rk_timestep(rk_step) )
+               end if
                
 !$OMP PARALLEL DO
                do thread=1,nThreads
@@ -1253,6 +1267,12 @@ module atm_time_integration
          end if
          if (index_ni > 0) then
             scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', dt )
+         end if
+         if (index_nwfa > 0) then
+            scalars_driving(index_nwfa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nwfa', dt )
+         end if
+         if (index_nifa > 0) then
+            scalars_driving(index_nifa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nifa', dt )
          end if
       
 !$OMP PARALLEL DO

--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -53,7 +53,7 @@ core_physics_mmm: core_physics_init
 	(cd physics_mmm; $(MAKE) all)
 
 core_microphysics: core_physics_init core_physics_mmm
-	test -s physics_wrf/module_mp_thompson.F && rm physics_wrf/module_mp_thompson.F
+	(if [ -f physics_wrf/module_mp_thompson.F ]; then rm physics_wrf/module_mp_thompson.F; else echo "No old module_mp_thompson.F file found"; fi)
 	(cd GSL_cloud_physics; cp ./drivers/mpas/module_mp_thompson.F90 .; $(MAKE) all COREDEF="$(COREDEF)")
 
 core_physics_wrf: core_physics_init core_physics_mmm

--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -1,10 +1,10 @@
-.SUFFIXES: .F .o
+.SUFFIXES: .F .o .F90
 
 ifeq ($(CORE),atmosphere)
 COREDEF = -Dmpas
 endif
 
-all: lookup_tables core_physics_init core_physics_mmm core_physics_wrf core_physics
+all: lookup_tables core_physics_init core_physics_mmm core_microphysics core_physics_wrf core_physics
 
 dummy:
 	echo "****** compiling physics ******"
@@ -52,13 +52,17 @@ lookup_tables:
 core_physics_mmm: core_physics_init
 	(cd physics_mmm; $(MAKE) all)
 
+core_microphysics: core_physics_init core_physics_mmm
+	test -s physics_wrf/module_mp_thompson.F && rm physics_wrf/module_mp_thompson.F
+	(cd GSL_cloud_physics; cp ./drivers/mpas/module_mp_thompson.F90 .; $(MAKE) all COREDEF="$(COREDEF)")
+
 core_physics_wrf: core_physics_init core_physics_mmm
-	(cd physics_wrf; rm module_mp_thompson.F; cp ./GSL_cloud_physics/module_mp_thompson* .; cp ./GSL_cloud_physics/drivers/mpas/module_mp_thompson.F90 .; $(MAKE) all COREDEF="$(COREDEF)")
+	(cd physics_wrf; $(MAKE) all COREDEF="$(COREDEF)")
 
 core_physics_init: $(OBJS_init)
 	ar -ru libphys.a $(OBJS_init)
 
-core_physics: core_physics_wrf
+core_physics: core_microphysics core_physics_wrf
 	($(MAKE) phys_interface COREDEF="$(COREDEF)")
 	ar -ru libphys.a $(OBJS)
 
@@ -199,6 +203,7 @@ clean:
 	$(RM) *.o *.mod *.f90 libphys.a
 	( cd physics_wrf; $(MAKE) clean )
 	( cd physics_mmm; $(MAKE) clean )
+	( cd GSL_cloud_physics; $(MAKE) clean )
 	@# Certain systems with intel compilers generate *.i files
 	@# This removes them during the clean process
 	$(RM) *.i
@@ -207,7 +212,16 @@ clean:
 	$(RM) $@ $*.mod
 ifeq "$(GEN_F90)" "true"
 	$(CPP) $(CPPFLAGS) $(COREDEF) $(HYDROSTATIC) $(CPPINCLUDES) $< > $*.f90
-	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I./physics_mmm -I./physics_wrf -I.. -I../../framework -I../../external/esmf_time_f90
+	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I./physics_mmm -I./physics_wrf -I./GSL_cloud_physics -I.. -I../../framework -I../../external/esmf_time_f90
 else
-	$(FC) $(CPPFLAGS) $(COREDEF) $(HYDROSATIC) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I./physics_mmm -I./physics_wrf -I.. -I../../framework -I../../external/esmf_time_f90
+	$(FC) $(CPPFLAGS) $(COREDEF) $(HYDROSATIC) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I./physics_mmm -I./physics_wrf -I./GSL_cloud_physics -I.. -I../../framework -I../../external/esmf_time_f90
+endif
+
+.F90.o:
+	$(RM) $@ $*.mod
+ifeq "$(GEN_F90)" "true"
+	$(CPP) $(CPPFLAGS) $(COREDEF) $(HYDROSTATIC) $(CPPINCLUDES) $< > $*.f90
+	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I./physics_mmm -I./physics_wrf -I./GSL_cloud_physics -I.. -I../../framework -I../../external/esmf_time_f90
+else
+	$(FC) $(CPPFLAGS) $(COREDEF) $(HYDROSATIC) $(FFLAGS) -c $*.F90 $(CPPINCLUDES) $(FCINCLUDES) -I./physics_mmm -I./physics_wrf -I./GSL_cloud_physics -I.. -I../../framework -I../../external/esmf_time_f90
 endif

--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -53,7 +53,7 @@ core_physics_mmm: core_physics_init
 	(cd physics_mmm; $(MAKE) all)
 
 core_physics_wrf: core_physics_init core_physics_mmm
-	(cd physics_wrf; $(MAKE) all COREDEF="$(COREDEF)")
+	(cd physics_wrf; cp ./GSL_cloud_physics/* .; $(MAKE) all COREDEF="$(COREDEF)")
 
 core_physics_init: $(OBJS_init)
 	ar -ru libphys.a $(OBJS_init)

--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -53,7 +53,7 @@ core_physics_mmm: core_physics_init
 	(cd physics_mmm; $(MAKE) all)
 
 core_physics_wrf: core_physics_init core_physics_mmm
-	(cd physics_wrf; cp ./GSL_cloud_physics/* .; $(MAKE) all COREDEF="$(COREDEF)")
+	(cd physics_wrf; rm module_mp_thompson.F; cp ./GSL_cloud_physics/module_mp_thompson* .; cp ./GSL_cloud_physics/drivers/mpas/module_mp_thompson.F90 .; $(MAKE) all COREDEF="$(COREDEF)")
 
 core_physics_init: $(OBJS_init)
 	ar -ru libphys.a $(OBJS_init)

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
@@ -19,6 +19,7 @@
 !wrf physics:
  use module_mp_kessler
  use module_mp_thompson
+ use module_mp_thompson_utils
  use module_mp_wsm6,only: wsm6
  use mp_wsm6,only: mp_wsm6_init,refl10cm_wsm6
 
@@ -153,6 +154,7 @@
           if(.not.allocated(ntc_p)) allocate(ntc_p(ims:ime,jms:jme))
           if(.not.allocated(muc_p)) allocate(muc_p(ims:ime,jms:jme))
           if(.not.allocated(ni_p) ) allocate(ni_p(ims:ime,kms:kme,jms:jme))
+          if(.not.allocated(nc_p) ) allocate(nc_p(ims:ime,kms:kme,jms:jme))
           if(.not.allocated(nr_p) ) allocate(nr_p(ims:ime,kms:kme,jms:jme))
 
           if(.not.allocated(rainprod_p)) allocate(rainprod_p(ims:ime,kms:kme,jms:jme))
@@ -227,6 +229,7 @@
           if(allocated(ntc_p)) deallocate(ntc_p)
           if(allocated(muc_p)) deallocate(muc_p)
           if(allocated(ni_p) ) deallocate(ni_p )
+          if(allocated(nc_p) ) deallocate(nc_p )
           if(allocated(nr_p) ) deallocate(nr_p )
 
           if(allocated(rainprod_p)) deallocate(rainprod_p)
@@ -365,6 +368,7 @@
                   th        = th_p        , qv         = qv_p         , qc         = qc_p         , &
                   qr        = qr_p        , qi         = qi_p         , qs         = qs_p         , &
                   qg        = qg_p        , ni         = ni_p         , nr         = nr_p         , &
+                  nc        = nc_p        ,                                                         &
                   pii       = pi_p        , p          = pres_p       , dz         = dz_p         , &
                   w         = w_p         , dt_in      = dt_microp    , itimestep  = itimestep    , &
                   rainnc    = rainnc_p    , rainncv    = rainncv_p    , snownc     = snownc_p     , &

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
@@ -156,6 +156,8 @@
           if(.not.allocated(ni_p) ) allocate(ni_p(ims:ime,kms:kme,jms:jme))
           if(.not.allocated(nc_p) ) allocate(nc_p(ims:ime,kms:kme,jms:jme))
           if(.not.allocated(nr_p) ) allocate(nr_p(ims:ime,kms:kme,jms:jme))
+          if(.not.allocated(nwfa_p) ) allocate(nwfa_p(ims:ime,kms:kme,jms:jme))
+          if(.not.allocated(nifa_p) ) allocate(nifa_p(ims:ime,kms:kme,jms:jme))
 
           if(.not.allocated(rainprod_p)) allocate(rainprod_p(ims:ime,kms:kme,jms:jme))
           if(.not.allocated(evapprod_p)) allocate(evapprod_p(ims:ime,kms:kme,jms:jme))
@@ -231,6 +233,8 @@
           if(allocated(ni_p) ) deallocate(ni_p )
           if(allocated(nc_p) ) deallocate(nc_p )
           if(allocated(nr_p) ) deallocate(nr_p )
+          if(allocated(nwfa_p) ) deallocate(nwfa_p )
+          if(allocated(nifa_p) ) deallocate(nifa_p )
 
           if(allocated(rainprod_p)) deallocate(rainprod_p)
           if(allocated(evapprod_p)) deallocate(evapprod_p)
@@ -368,7 +372,7 @@
                   th        = th_p        , qv         = qv_p         , qc         = qc_p         , &
                   qr        = qr_p        , qi         = qi_p         , qs         = qs_p         , &
                   qg        = qg_p        , ni         = ni_p         , nr         = nr_p         , &
-                  nc        = nc_p        ,                                                         &
+                  nc        = nc_p        , nwfa       = nwfa_p       , nifa       = nifa_p       , &
                   pii       = pi_p        , p          = pres_p       , dz         = dz_p         , &
                   w         = w_p         , dt_in      = dt_microp    , itimestep  = itimestep    , &
                   rainnc    = rainnc_p    , rainncv    = rainncv_p    , snownc     = snownc_p     , &

--- a/src/core_atmosphere/physics/mpas_atmphys_finalize.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_finalize.F
@@ -57,7 +57,7 @@
  if(allocated(tcg_racg) ) deallocate(tcg_racg ) 
  if(allocated(tmr_racg) ) deallocate(tmr_racg )
  if(allocated(tcr_gacr) ) deallocate(tcr_gacr )
- if(allocated(tmg_gacr) ) deallocate(tmg_gacr )
+! if(allocated(tmg_gacr) ) deallocate(tmg_gacr )
  if(allocated(tnr_racg) ) deallocate(tnr_racg )
  if(allocated(tnr_gacr) ) deallocate(tnr_gacr )
  if(allocated(tcs_racs1)) deallocate(tcs_racs1)

--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -486,13 +486,13 @@
 !local pointers:
  character(len=StrKIND),pointer:: microp_scheme
  integer,pointer:: index_qv,index_qc,index_qr,index_qi,index_qs,index_qg
- integer,pointer:: index_ni,index_nr
+ integer,pointer:: index_ni,index_nc,index_nr
  real(kind=RKIND),dimension(:),pointer    :: nt_c,mu_c
  real(kind=RKIND),dimension(:,:),pointer  :: zgrid,w
  real(kind=RKIND),dimension(:,:),pointer  :: zz,exner,pressure_b
  real(kind=RKIND),dimension(:,:),pointer  :: rho_zz,theta_m,pressure_p
  real(kind=RKIND),dimension(:,:),pointer  :: qv,qc,qr,qi,qs,qg
- real(kind=RKIND),dimension(:,:),pointer  :: ni,nr
+ real(kind=RKIND),dimension(:,:),pointer  :: ni,nc,nr
  real(kind=RKIND),dimension(:,:),pointer  :: rainprod,evapprod
  real(kind=RKIND),dimension(:,:),pointer  :: re_cloud,re_ice,re_snow
  real(kind=RKIND),dimension(:,:,:),pointer:: scalars
@@ -530,6 +530,7 @@
  call mpas_pool_get_dimension(state,'index_qs'  ,index_qs  )
  call mpas_pool_get_dimension(state,'index_qg'  ,index_qg  )
  call mpas_pool_get_dimension(state,'index_ni'  ,index_ni  )
+ call mpas_pool_get_dimension(state,'index_nc'  ,index_nc  )
  call mpas_pool_get_dimension(state,'index_nr'  ,index_nr  )
 
  call mpas_pool_get_array(state,'scalars',scalars,time_lev)
@@ -583,6 +584,7 @@
 
        case("mp_thompson")
           ni   => scalars(index_ni,:,:)
+          nc   => scalars(index_nc,:,:)
           nr   => scalars(index_nr,:,:)
 
           do j = jts,jte
@@ -595,6 +597,7 @@
           do k = kts, kte
           do i = its, ite
              ni_p(i,k,j) = ni(k,i)
+             nc_p(i,k,j) = nc(k,i)
              nr_p(i,k,j) = nr(k,i)
              rainprod_p(i,k,j) = rainprod(k,i)
              evapprod_p(i,k,j) = evapprod(k,i)
@@ -632,7 +635,7 @@
 !local pointers:
  character(len=StrKIND),pointer:: microp_scheme
  integer,pointer:: index_qv,index_qc,index_qr,index_qi,index_qs,index_qg
- integer,pointer:: index_ni,index_nr
+ integer,pointer:: index_ni,index_nc,index_nr
  real(kind=RKIND),dimension(:),pointer    :: surface_pressure,tend_sfc_pressure
  real(kind=RKIND),dimension(:,:),pointer  :: zgrid
  real(kind=RKIND),dimension(:,:),pointer  :: zz,exner,exner_b,pressure_b,rtheta_p,rtheta_b
@@ -640,7 +643,7 @@
  real(kind=RKIND),dimension(:,:),pointer  :: rt_diabatic_tend
  real(kind=RKIND),dimension(:,:),pointer  :: dtheta_dt_mp
  real(kind=RKIND),dimension(:,:),pointer  :: qv,qc,qr,qi,qs,qg
- real(kind=RKIND),dimension(:,:),pointer  :: ni,nr
+ real(kind=RKIND),dimension(:,:),pointer  :: ni,nr,nc
  real(kind=RKIND),dimension(:,:),pointer  :: rainprod,evapprod
  real(kind=RKIND),dimension(:,:),pointer  :: re_cloud,re_ice,re_snow
  real(kind=RKIND),dimension(:,:,:),pointer:: scalars
@@ -684,6 +687,7 @@
  call mpas_pool_get_dimension(state,'index_qs'  ,index_qs  )
  call mpas_pool_get_dimension(state,'index_qg'  ,index_qg  )
  call mpas_pool_get_dimension(state,'index_ni'  ,index_ni  )
+ call mpas_pool_get_dimension(state,'index_nc'  ,index_nc  )
  call mpas_pool_get_dimension(state,'index_nr'  ,index_nr  )
 
  call mpas_pool_get_array(state,'scalars',scalars,time_lev)
@@ -770,12 +774,14 @@
 
        case("mp_thompson")
           ni   => scalars(index_ni,:,:)
+          nc   => scalars(index_nc,:,:)
           nr   => scalars(index_nr,:,:)
 
           do j = jts, jte
           do k = kts, kte
           do i = its, ite
              ni(k,i) = ni_p(i,k,j)
+             nc(k,i) = nc_p(i,k,j)
              nr(k,i) = nr_p(i,k,j)
              rainprod(k,i) = rainprod_p(i,k,j)
              evapprod(k,i) = evapprod_p(i,k,j)

--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -486,13 +486,13 @@
 !local pointers:
  character(len=StrKIND),pointer:: microp_scheme
  integer,pointer:: index_qv,index_qc,index_qr,index_qi,index_qs,index_qg
- integer,pointer:: index_ni,index_nc,index_nr
+ integer,pointer:: index_ni,index_nc,index_nr,index_nwfa,index_nifa
  real(kind=RKIND),dimension(:),pointer    :: nt_c,mu_c
  real(kind=RKIND),dimension(:,:),pointer  :: zgrid,w
  real(kind=RKIND),dimension(:,:),pointer  :: zz,exner,pressure_b
  real(kind=RKIND),dimension(:,:),pointer  :: rho_zz,theta_m,pressure_p
  real(kind=RKIND),dimension(:,:),pointer  :: qv,qc,qr,qi,qs,qg
- real(kind=RKIND),dimension(:,:),pointer  :: ni,nc,nr
+ real(kind=RKIND),dimension(:,:),pointer  :: ni,nc,nr,nwfa,nifa
  real(kind=RKIND),dimension(:,:),pointer  :: rainprod,evapprod
  real(kind=RKIND),dimension(:,:),pointer  :: re_cloud,re_ice,re_snow
  real(kind=RKIND),dimension(:,:,:),pointer:: scalars
@@ -532,6 +532,8 @@
  call mpas_pool_get_dimension(state,'index_ni'  ,index_ni  )
  call mpas_pool_get_dimension(state,'index_nc'  ,index_nc  )
  call mpas_pool_get_dimension(state,'index_nr'  ,index_nr  )
+ call mpas_pool_get_dimension(state,'index_nwfa'  ,index_nwfa  )
+ call mpas_pool_get_dimension(state,'index_nifa'  ,index_nifa  )
 
  call mpas_pool_get_array(state,'scalars',scalars,time_lev)
  qv   => scalars(index_qv,:,:)
@@ -586,6 +588,8 @@
           ni   => scalars(index_ni,:,:)
           nc   => scalars(index_nc,:,:)
           nr   => scalars(index_nr,:,:)
+          nwfa   => scalars(index_nwfa,:,:)
+          nifa   => scalars(index_nifa,:,:)
 
           do j = jts,jte
           do i = its,ite
@@ -599,6 +603,8 @@
              ni_p(i,k,j) = ni(k,i)
              nc_p(i,k,j) = nc(k,i)
              nr_p(i,k,j) = nr(k,i)
+             nwfa_p(i,k,j) = nwfa(k,i)
+             nifa_p(i,k,j) = nifa(k,i)
              rainprod_p(i,k,j) = rainprod(k,i)
              evapprod_p(i,k,j) = evapprod(k,i)
           enddo
@@ -635,7 +641,7 @@
 !local pointers:
  character(len=StrKIND),pointer:: microp_scheme
  integer,pointer:: index_qv,index_qc,index_qr,index_qi,index_qs,index_qg
- integer,pointer:: index_ni,index_nc,index_nr
+ integer,pointer:: index_ni,index_nc,index_nr,index_nwfa,index_nifa
  real(kind=RKIND),dimension(:),pointer    :: surface_pressure,tend_sfc_pressure
  real(kind=RKIND),dimension(:,:),pointer  :: zgrid
  real(kind=RKIND),dimension(:,:),pointer  :: zz,exner,exner_b,pressure_b,rtheta_p,rtheta_b
@@ -643,7 +649,7 @@
  real(kind=RKIND),dimension(:,:),pointer  :: rt_diabatic_tend
  real(kind=RKIND),dimension(:,:),pointer  :: dtheta_dt_mp
  real(kind=RKIND),dimension(:,:),pointer  :: qv,qc,qr,qi,qs,qg
- real(kind=RKIND),dimension(:,:),pointer  :: ni,nr,nc
+ real(kind=RKIND),dimension(:,:),pointer  :: ni,nr,nc,nwfa,nifa
  real(kind=RKIND),dimension(:,:),pointer  :: rainprod,evapprod
  real(kind=RKIND),dimension(:,:),pointer  :: re_cloud,re_ice,re_snow
  real(kind=RKIND),dimension(:,:,:),pointer:: scalars
@@ -689,6 +695,8 @@
  call mpas_pool_get_dimension(state,'index_ni'  ,index_ni  )
  call mpas_pool_get_dimension(state,'index_nc'  ,index_nc  )
  call mpas_pool_get_dimension(state,'index_nr'  ,index_nr  )
+ call mpas_pool_get_dimension(state,'index_nwfa'  ,index_nwfa  )
+ call mpas_pool_get_dimension(state,'index_nifa'  ,index_nifa  )
 
  call mpas_pool_get_array(state,'scalars',scalars,time_lev)
  qv   => scalars(index_qv,:,:)
@@ -776,6 +784,8 @@
           ni   => scalars(index_ni,:,:)
           nc   => scalars(index_nc,:,:)
           nr   => scalars(index_nr,:,:)
+          nwfa   => scalars(index_nwfa,:,:)
+          nifa   => scalars(index_nifa,:,:)
 
           do j = jts, jte
           do k = kts, kte
@@ -783,6 +793,8 @@
              ni(k,i) = ni_p(i,k,j)
              nc(k,i) = nc_p(i,k,j)
              nr(k,i) = nr_p(i,k,j)
+             nwfa(k,i) = nwfa_p(i,k,j)
+             nifa(k,i) = nifa_p(i,k,j)
              rainprod(k,i) = rainprod_p(i,k,j)
              evapprod(k,i) = evapprod_p(i,k,j)
           enddo

--- a/src/core_atmosphere/physics/mpas_atmphys_vars.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_vars.F
@@ -196,7 +196,9 @@
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     nc_p,             &!
     ni_p,             &!
-    nr_p               !
+    nr_p,             &!
+    nwfa_p,           &!
+    nifa_p             !
 
 !... arrays located at w (vertical velocity) points, or at interface between layers:
  real(kind=RKIND),dimension(:,:,:),allocatable:: &

--- a/src/core_atmosphere/physics/physics_wrf/Makefile
+++ b/src/core_atmosphere/physics/physics_wrf/Makefile
@@ -19,6 +19,8 @@ OBJS = \
 	module_cu_ntiedtke.o           \
 	module_cu_kfeta.o              \
 	module_mp_kessler.o            \
+	module_mp_thompson_params.o    \
+	module_mp_thompson_main.o      \
 	module_mp_thompson.o           \
 	module_mp_thompson_cldfra3.o   \
 	module_mp_wsm6.o               \
@@ -46,6 +48,10 @@ physics_wrf: $(OBJS)
 	ar -ru ./../libphys.a $(OBJS)
 
 # DEPENDENCIES:
+module_mp_thompson.o: \
+	module_mp_thompson_params.o \
+	module_mp_thompson_main.o
+
 module_bl_mynn.o: \
 	module_cam_error_function.o
 

--- a/src/core_atmosphere/physics/physics_wrf/Makefile
+++ b/src/core_atmosphere/physics/physics_wrf/Makefile
@@ -1,4 +1,4 @@
-.SUFFIXES: .F .o
+.SUFFIXES: .F .o .F90
 
 all: dummy physics_wrf
 
@@ -20,6 +20,7 @@ OBJS = \
 	module_cu_kfeta.o              \
 	module_mp_kessler.o            \
 	module_mp_thompson_params.o    \
+	module_mp_thompson_utils.o     \
 	module_mp_thompson_main.o      \
 	module_mp_thompson.o           \
 	module_mp_thompson_cldfra3.o   \
@@ -50,6 +51,7 @@ physics_wrf: $(OBJS)
 # DEPENDENCIES:
 module_mp_thompson.o: \
 	module_mp_thompson_params.o \
+	module_mp_thompson_utils.o \
 	module_mp_thompson_main.o
 
 module_bl_mynn.o: \
@@ -111,4 +113,11 @@ ifeq "$(GEN_F90)" "true"
 	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I.. -I../physics_mmm -I../../../framework -I../../../external/esmf_time_f90
 else
 	$(FC) $(CPPFLAGS) $(COREDEF) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I.. -I../physics_mmm -I../../../framework -I../../../external/esmf_time_f90
+endif
+
+.F90.o:
+ifeq "$(GEN_F90)" "true"
+	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I.. -I../physics_mmm -I../../../framework -I../../../external/esmf_time_f90
+else
+	$(FC) $(CPPFLAGS) $(COREDEF) $(FFLAGS) -c $*.F90 $(CPPINCLUDES) $(FCINCLUDES) -I.. -I../physics_mmm -I../../../framework -I../../../external/esmf_time_f90
 endif

--- a/src/core_atmosphere/physics/physics_wrf/Makefile
+++ b/src/core_atmosphere/physics/physics_wrf/Makefile
@@ -19,10 +19,6 @@ OBJS = \
 	module_cu_ntiedtke.o           \
 	module_cu_kfeta.o              \
 	module_mp_kessler.o            \
-	module_mp_thompson_params.o    \
-	module_mp_thompson_utils.o     \
-	module_mp_thompson_main.o      \
-	module_mp_thompson.o           \
 	module_mp_thompson_cldfra3.o   \
 	module_mp_wsm6.o               \
 	module_ra_cam.o                \
@@ -49,11 +45,6 @@ physics_wrf: $(OBJS)
 	ar -ru ./../libphys.a $(OBJS)
 
 # DEPENDENCIES:
-module_mp_thompson.o: \
-	module_mp_thompson_params.o \
-	module_mp_thompson_utils.o \
-	module_mp_thompson_main.o
-
 module_bl_mynn.o: \
 	module_cam_error_function.o
 

--- a/src/core_atmosphere/utils/Makefile
+++ b/src/core_atmosphere/utils/Makefile
@@ -15,8 +15,8 @@ build_tables.o: \
 	atmphys_build_tables_thompson.o
 
 atmphys_build_tables_thompson.o: \
-	../physics/physics_wrf/module_mp_thompson.o \
-	../physics/physics_wrf/module_mp_thompson_params.o
+	../physics/GSL_cloud_physics/module_mp_thompson.o \
+	../physics/GSL_cloud_physics/module_mp_thompson_params.o
 
 clean:
 	$(RM) ../../../build_tables
@@ -28,7 +28,7 @@ clean:
 	$(RM) $@ $*.mod
 ifeq "$(GEN_F90)" "true"
 	$(CPP) $(CPPFLAGS) $(PHYSICS) $(CPPINCLUDES) $< > $*.f90
-	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I../../framework -I../../operators -I../physics -I../physics/physics_mmm -I../physics/physics_wrf -I../../external/esmf_time_f90
+	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I../../framework -I../../operators -I../physics -I../physics/physics_mmm -I../physics/physics_wrf -I../physics/GSL_cloud_physics -I../../external/esmf_time_f90
 else
-	$(FC) $(CPPFLAGS) $(PHYSICS) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I../../framework -I../../operators -I../physics -I../physics/physics_mmm -I../physics/physics_wrf -I../../external/esmf_time_f90
+	$(FC) $(CPPFLAGS) $(PHYSICS) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I../../framework -I../../operators -I../physics -I../physics/physics_mmm -I../physics/physics_wrf -I../physics/GSL_cloud_physics -I../../external/esmf_time_f90
 endif

--- a/src/core_atmosphere/utils/Makefile
+++ b/src/core_atmosphere/utils/Makefile
@@ -15,7 +15,8 @@ build_tables.o: \
 	atmphys_build_tables_thompson.o
 
 atmphys_build_tables_thompson.o: \
-	../physics/physics_wrf/module_mp_thompson.o
+	../physics/physics_wrf/module_mp_thompson.o \
+	../physics/physics_wrf/module_mp_thompson_params.o
 
 clean:
 	$(RM) ../../../build_tables

--- a/src/core_atmosphere/utils/atmphys_build_tables_thompson.F
+++ b/src/core_atmosphere/utils/atmphys_build_tables_thompson.F
@@ -8,6 +8,7 @@
 !=================================================================================================================
  module atmphys_build_tables_thompson
  use module_mp_thompson
+ use module_mp_thompson_params, only : NRHG
 
  implicit none
  private
@@ -47,7 +48,7 @@
     call print_parallel_mesg('MP_THOMPSON_QRacrQG_DATA.DBL')
     return
  end if
- call qr_acr_qg(1)
+ call qr_acr_qg(NRHG)
  write(mp_unit) tcg_racg
  write(mp_unit) tmr_racg
  write(mp_unit) tcr_gacr

--- a/src/core_atmosphere/utils/atmphys_build_tables_thompson.F
+++ b/src/core_atmosphere/utils/atmphys_build_tables_thompson.F
@@ -47,11 +47,11 @@
     call print_parallel_mesg('MP_THOMPSON_QRacrQG_DATA.DBL')
     return
  end if
- call qr_acr_qg
+ call qr_acr_qg(1)
  write(mp_unit) tcg_racg
  write(mp_unit) tmr_racg
  write(mp_unit) tcr_gacr
- write(mp_unit) tmg_gacr
+! write(mp_unit) tmg_gacr
  write(mp_unit) tnr_racg
  write(mp_unit) tnr_gacr
  close(unit=mp_unit)

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -1016,6 +1016,12 @@
 
                         <var name="lbc_qr" array_group="moist" units="kg kg^{-1}"
                              description="Rain water mixing ratio on lateral boundary cells"/>
+			
+			<var name="lbc_nwfa" array_group="passive" units="kg^{-1}"
+                             description="Number of water-friendly aerosols for microphysics on LBCs"/>
+
+			<var name="lbc_nifa" array_group="passive" units="kg^{-1}"
+                             description="Number of ice-friendly aerosols for microphysics on LBCs"/>
                 </var_array>
 
         </var_struct>

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -976,6 +976,12 @@
 
                         <var name="qr" array_group="moist" units="kg kg^{-1}"
                              description="Rain water mixing ratio"/>
+
+			<var name="nwfa" array_group="passive" units="kg^{-1}"
+                             description="Number of water-friendly aerosols for microphysics"/>
+
+			<var name="nifa" array_group="passive" units="kg^{-1}"
+                             description="Number of ice-friendly aerosols for microphysics"/>
                 </var_array>
 
                 <!-- Climatology for ocean mixed-layer depth -->

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -243,7 +243,7 @@ module init_atm_cases
             call init_atm_case_gfs(block_ptr, mesh, nCells, nEdges, nVertLevels, fg, state, &
                                    diag, diag_physics, block_ptr % dimensions, block_ptr % configs)
 
-            call init_microphysics_aerosols(mesh, state, diag)
+            call init_microphysics_aerosols(mesh, state, diag, block_ptr % configs)
             
             if (config_met_interp) then
                call physics_initialize_real(mesh, fg, domain % dminfo, block_ptr % dimensions, block_ptr % configs)
@@ -330,7 +330,7 @@ module init_atm_cases
                call init_atm_case_lbc(timeString, block_ptr, mesh, nCells, nEdges, nVertLevels, fg, state, &
                                       diag, lbc_state, block_ptr % dimensions, block_ptr % configs)
 
-               call init_microphysics_aerosols_lbc(mesh, state, diag, lbc_state, nCells, nVertLevels)
+               call init_microphysics_aerosols_lbc(timeString, mesh, state, diag, lbc_state, nCells, nVertLevels)
                
                block_ptr => block_ptr % next
             end do
@@ -7143,7 +7143,7 @@ call mpas_log_write('Done with soil consistency check')
    !
    !> \brief Initialize water- and ice-friendly aerosols for microphysics
    !> \author Anders Jensen
-   !> \date   14 March 2024
+   !> \date   22 March 2024
    !> \details
    !>  This routine reads five unformatted tables that contain, latitude, longitude,
    !>  pressure, water- and ice-friendly monthly climatology data to use with the
@@ -7151,11 +7151,10 @@ call mpas_log_write('Done with soil consistency check')
    !>  using a nearest-grid point option for MPAS initial conditions.
    !>
    !>  This is for testing purposes only. A better interpolation method should
-   !>  be implemented. This is also currently hard-coded for the February
-   !>  data. A time interpolation method should be implemented as well.
+   !>  be implemented. 
    !
    !-----------------------------------------------------------------------   
-   subroutine init_microphysics_aerosols(mesh, state, diag)
+   subroutine init_microphysics_aerosols(mesh, state, diag, configs)
      
      use mpas_io_units, only : mpas_new_unit, mpas_release_unit
      
@@ -7164,6 +7163,7 @@ call mpas_log_write('Done with soil consistency check')
      type (mpas_pool_type), intent(in) :: mesh
      type (mpas_pool_type), intent(in) :: diag
      type (mpas_pool_type), intent(inout) :: state
+     type (mpas_pool_type), intent(inout):: configs
      
      integer, pointer :: index_nwfa
      integer, pointer :: index_nifa
@@ -7172,13 +7172,16 @@ call mpas_log_write('Done with soil consistency check')
 
      integer :: k, m, iCell
      integer :: aerosol_table_unit, istat
-     integer :: lat_index, lon_index, pressure_index, month_index
+     integer :: lat_index, lon_index, pressure_index, month_index, interp_month_index
+     integer :: sim_year, sim_month, sim_day, sim_hour
+     real (kind=RKIND) :: month_fraction, month_interp_weight
      
      real (kind=RKIND) :: tmp_lat, tmp_lon, tmp_prs
      real (kind=RKIND), dimension(:,:), pointer :: ppb, pp
      real (kind=RKIND), dimension(:), pointer :: latCell
      real (kind=RKIND), dimension(:), pointer :: lonCell
      real (kind=RKIND), dimension(:,:,:), pointer :: scalars
+     character (len=StrKIND), pointer :: config_start_time
 
      integer, parameter :: nlon = 288
      integer, parameter :: nlat = 181
@@ -7191,7 +7194,9 @@ call mpas_log_write('Done with soil consistency check')
      real (kind=R4KIND), dimension(nlon, nlat, nprs, nmon) :: prs_aerosol_climo
      
      call mpas_log_write('====== Handling aerosol initialization for microphysics ======')
-     
+
+     call mpas_pool_get_config(configs, 'config_start_time', config_start_time)
+
      call mpas_pool_get_dimension(mesh, 'nCells', nCells)
      call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
      
@@ -7234,6 +7239,58 @@ call mpas_log_write('Done with soil consistency check')
      close(unit=aerosol_table_unit)
      call mpas_release_unit(aerosol_table_unit)
 
+     read(config_start_time(1:13), fmt='(    I4)') sim_year
+     read(config_start_time(1:13), fmt='( 5X,I2)') sim_month
+     read(config_start_time(1:13), fmt='( 8X,I2)') sim_day
+     read(config_start_time(1:13), fmt='(11X,I2)') sim_hour
+
+     month_fraction = 0.0
+     
+     ! 86400 seconds in a day, 3600 seconds in an hour
+     if (sim_month == 1) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (31.0 * 86400.0)
+     else if (sim_month == 2) then
+        if (sim_day > 28) sim_day = 28 ! Ignore leap years
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (28.0 * 86400.0)
+     else if (sim_month == 3) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (31.0 * 86400.0)
+     else if (sim_month == 4) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (30.0 * 86400.0)
+     else if (sim_month == 5) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (31.0 * 86400.0)
+     else if (sim_month == 6) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (30.0 * 86400.0)
+     else if (sim_month == 7) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (31.0 * 86400.0)
+     else if (sim_month == 8) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (31.0 * 86400.0)
+     else if (sim_month == 9) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (30.0 * 86400.0)
+     else if (sim_month == 10) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (31.0 * 86400.0)
+     else if (sim_month == 11) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (30.0 * 86400.0)
+     else if (sim_month == 12) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (31.0 * 86400.0)
+     else
+        call mpas_log_write('Invalid month for microphysics aerosol interpolation')
+     endif
+
+     if (month_fraction > 1.0) month_fraction = 1.0
+
+     ! Interpolate to middle of each month
+     if (month_fraction >= 0.5) then
+        month_interp_weight = 1.5 - month_fraction
+        month_index = sim_month
+        interp_month_index = sim_month + 1
+        if (interp_month_index > 12) interp_month_index = 1
+     else
+        month_interp_weight = month_fraction + 0.5
+        month_index = sim_month
+        interp_month_index = sim_month - 1
+        if (interp_month_index < 1) interp_month_index = 12
+     endif
+     
      do k = 1, nVertLevels
         do iCell = 1, nCells
            ! Lat and lon from model converted from radians to degrees
@@ -7244,7 +7301,7 @@ call mpas_log_write('Done with soil consistency check')
            lat_index = 1
            lon_index = 1
            pressure_index = 30 ! Pressure from monthly climatology is oriented with index=1 is top of atmosphere
-           month_index = 2 ! Hard-coded for February for testing
+!           month_index = 2 ! Hard-coded for February for testing
            
            ! Nearest point interpolation (for testing)
            ! The climatology starts from -180 and goes to 180 (every 1.25 degrees)
@@ -7270,9 +7327,12 @@ call mpas_log_write('Done with soil consistency check')
                  exit
               endif
            enddo
+           
+           scalars(index_nwfa,k,iCell) = month_interp_weight*wfa_aerosol_climo(lon_index,lat_index,pressure_index,month_index) + &
+                (1.0 - month_interp_weight)*wfa_aerosol_climo(lon_index,lat_index,pressure_index,interp_month_index)
 
-           scalars(index_nwfa,k,iCell) = wfa_aerosol_climo(lon_index,lat_index,pressure_index,month_index)
-           scalars(index_nifa,k,iCell) = ifa_aerosol_climo(lon_index,lat_index,pressure_index,month_index)
+           scalars(index_nifa,k,iCell) = month_interp_weight*ifa_aerosol_climo(lon_index,lat_index,pressure_index,month_index) + &
+                (1.0 - month_interp_weight)*ifa_aerosol_climo(lon_index,lat_index,pressure_index,interp_month_index)
         end do
      enddo
    end subroutine init_microphysics_aerosols
@@ -7282,17 +7342,16 @@ call mpas_log_write('Done with soil consistency check')
    !
    !> \brief Add water- and ice-friendly aerosols for microphysics to LBCs
    !> \author Anders Jensen
-   !> \date   15 March 2024
+   !> \date   22 March 2024
    !> \details
    !>  This routine is similar to init_microphysics_aerosols, but adds
    !>  aerosol information to the lateral boundary condition files. 
    !>
    !>  This is for testing purposes only. A better interpolation method should
-   !>  be implemented. This is also currently hard-coded for the February
-   !>  data. A time interpolation method should be implemented as well.
+   !>  be implemented. 
    !
    !-----------------------------------------------------------------------   
-   subroutine init_microphysics_aerosols_lbc(mesh, state, diag, lbc_state, nCells, nVertLevels)
+   subroutine init_microphysics_aerosols_lbc(timestamp, mesh, state, diag, lbc_state, nCells, nVertLevels)
 
      use mpas_io_units, only : mpas_new_unit, mpas_release_unit
      
@@ -7301,7 +7360,8 @@ call mpas_log_write('Done with soil consistency check')
      
      integer, intent(in) :: nCells
      integer, intent(in) :: nVertLevels
-      
+     character(len=*), intent(in) :: timestamp
+     
      type (mpas_pool_type), intent(in) :: mesh
      type (mpas_pool_type), intent(in) :: diag
      type (mpas_pool_type), intent(inout) :: state
@@ -7314,8 +7374,10 @@ call mpas_log_write('Done with soil consistency check')
 
      integer :: k, m, iCell
      integer :: aerosol_table_unit, istat
-     integer :: lat_index, lon_index, pressure_index, month_index
-     
+     integer :: lat_index, lon_index, pressure_index, month_index, interp_month_index
+     integer :: sim_year, sim_month, sim_day, sim_hour
+     real (kind=RKIND) :: month_fraction, month_interp_weight
+          
      real (kind=RKIND) :: tmp_lat, tmp_lon, tmp_prs
      real (kind=RKIND), dimension(:,:), pointer :: ppb, pp
      real (kind=RKIND), dimension(:), pointer :: latCell
@@ -7332,7 +7394,7 @@ call mpas_log_write('Done with soil consistency check')
      real (kind=R4KIND), dimension(nlon, nlat, nprs, nmon) :: ifa_aerosol_climo
      real (kind=R4KIND), dimension(nlon, nlat, nprs, nmon) :: prs_aerosol_climo
      
-     call mpas_log_write('====== Handling aerosol initialization 2 for microphysics ======')
+     call mpas_log_write('====== Handling aerosol LBCs for microphysics ======')
      
 !     call mpas_pool_get_dimension(mesh, 'nCells', nCells)
 !     call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
@@ -7377,6 +7439,58 @@ call mpas_log_write('Done with soil consistency check')
      close(unit=aerosol_table_unit)
      call mpas_release_unit(aerosol_table_unit)
 
+     read(timestamp, fmt='(    I4)') sim_year
+     read(timestamp, fmt='( 5X,I2)') sim_month
+     read(timestamp, fmt='( 8X,I2)') sim_day
+     read(timestamp, fmt='(11X,I2)') sim_hour
+
+     month_fraction = 0.0
+     
+     ! 86400 seconds in a day, 3600 seconds in an hour
+     if (sim_month == 1) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (31.0 * 86400.0)
+     else if (sim_month == 2) then
+        if (sim_day > 28) sim_day = 28 ! Ignore leap years
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (28.0 * 86400.0)
+     else if (sim_month == 3) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (31.0 * 86400.0)
+     else if (sim_month == 4) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (30.0 * 86400.0)
+     else if (sim_month == 5) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (31.0 * 86400.0)
+     else if (sim_month == 6) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (30.0 * 86400.0)
+     else if (sim_month == 7) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (31.0 * 86400.0)
+     else if (sim_month == 8) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (31.0 * 86400.0)
+     else if (sim_month == 9) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (30.0 * 86400.0)
+     else if (sim_month == 10) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (31.0 * 86400.0)
+     else if (sim_month == 11) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (30.0 * 86400.0)
+     else if (sim_month == 12) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (31.0 * 86400.0)
+     else
+        call mpas_log_write('Invalid month for microphysics aerosol interpolation')
+     endif
+
+     if (month_fraction > 1.0) month_fraction = 1.0
+
+     ! Interpolate to middle of each month
+     if (month_fraction >= 0.5) then
+        month_interp_weight = 1.5 - month_fraction
+        month_index = sim_month
+        interp_month_index = sim_month + 1
+        if (interp_month_index > 12) interp_month_index = 1
+     else
+        month_interp_weight = month_fraction + 0.5
+        month_index = sim_month
+        interp_month_index = sim_month - 1
+        if (interp_month_index < 1) interp_month_index = 12
+     endif
+
      do k = 1, nVertLevels
         do iCell = 1, nCells
            ! Lat and lon from model converted from radians to degrees
@@ -7387,7 +7501,7 @@ call mpas_log_write('Done with soil consistency check')
            lat_index = 1
            lon_index = 1
            pressure_index = 30 ! Pressure from monthly climatology is oriented with index=1 is top of atmosphere
-           month_index = 2 ! Hard-coded for February for testing
+!           month_index = 2 ! Hard-coded for February for testing
            
            ! Nearest point interpolation (for testing)
            ! The climatology starts from -180 and goes to 180 (every 1.25 degrees)
@@ -7413,9 +7527,12 @@ call mpas_log_write('Done with soil consistency check')
                  exit
               endif
            enddo
+           
+           scalars(index_nwfa,k,iCell) = month_interp_weight*wfa_aerosol_climo(lon_index,lat_index,pressure_index,month_index) + &
+                (1.0 - month_interp_weight)*wfa_aerosol_climo(lon_index,lat_index,pressure_index,interp_month_index)
 
-           scalars(index_nwfa,k,iCell) = wfa_aerosol_climo(lon_index,lat_index,pressure_index,month_index)
-           scalars(index_nifa,k,iCell) = ifa_aerosol_climo(lon_index,lat_index,pressure_index,month_index)
+           scalars(index_nifa,k,iCell) = month_interp_weight*ifa_aerosol_climo(lon_index,lat_index,pressure_index,month_index) + &
+                (1.0 - month_interp_weight)*ifa_aerosol_climo(lon_index,lat_index,pressure_index,interp_month_index)
         end do
      enddo
    end subroutine init_microphysics_aerosols_lbc

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -330,6 +330,8 @@ module init_atm_cases
                call init_atm_case_lbc(timeString, block_ptr, mesh, nCells, nEdges, nVertLevels, fg, state, &
                                       diag, lbc_state, block_ptr % dimensions, block_ptr % configs)
 
+               call init_microphysics_aerosols_lbc(mesh, state, diag, lbc_state, nCells, nVertLevels)
+               
                block_ptr => block_ptr % next
             end do
 
@@ -7274,5 +7276,148 @@ call mpas_log_write('Done with soil consistency check')
         end do
      enddo
    end subroutine init_microphysics_aerosols
+
+   !-----------------------------------------------------------------------
+   !  routine init_microphysics_aerosols_lbc
+   !
+   !> \brief Add water- and ice-friendly aerosols for microphysics to LBCs
+   !> \author Anders Jensen
+   !> \date   15 March 2024
+   !> \details
+   !>  This routine is similar to init_microphysics_aerosols, but adds
+   !>  aerosol information to the lateral boundary condition files. 
+   !>
+   !>  This is for testing purposes only. A better interpolation method should
+   !>  be implemented. This is also currently hard-coded for the February
+   !>  data. A time interpolation method should be implemented as well.
+   !
+   !-----------------------------------------------------------------------   
+   subroutine init_microphysics_aerosols_lbc(mesh, state, diag, lbc_state, nCells, nVertLevels)
+
+     use mpas_io_units, only : mpas_new_unit, mpas_release_unit
+     
+     implicit none
+
+     
+     integer, intent(in) :: nCells
+     integer, intent(in) :: nVertLevels
+      
+     type (mpas_pool_type), intent(in) :: mesh
+     type (mpas_pool_type), intent(in) :: diag
+     type (mpas_pool_type), intent(inout) :: state
+     type (mpas_pool_type), intent(inout) :: lbc_state
+     
+     integer, pointer :: index_nwfa
+     integer, pointer :: index_nifa
+!     integer, pointer :: nCells
+!     integer, pointer :: nVertLevels
+
+     integer :: k, m, iCell
+     integer :: aerosol_table_unit, istat
+     integer :: lat_index, lon_index, pressure_index, month_index
+     
+     real (kind=RKIND) :: tmp_lat, tmp_lon, tmp_prs
+     real (kind=RKIND), dimension(:,:), pointer :: ppb, pp
+     real (kind=RKIND), dimension(:), pointer :: latCell
+     real (kind=RKIND), dimension(:), pointer :: lonCell
+     real (kind=RKIND), dimension(:,:,:), pointer :: scalars
+
+     integer, parameter :: nlon = 288
+     integer, parameter :: nlat = 181
+     integer, parameter :: nprs = 30
+     integer, parameter :: nmon = 12 ! integer month for monthly climatology
+     real (kind=R4KIND), dimension(nlon) :: lon_aerosol_climo
+     real (kind=R4KIND), dimension(nlat) :: lat_aerosol_climo
+     real (kind=R4KIND), dimension(nlon, nlat, nprs, nmon) :: wfa_aerosol_climo
+     real (kind=R4KIND), dimension(nlon, nlat, nprs, nmon) :: ifa_aerosol_climo
+     real (kind=R4KIND), dimension(nlon, nlat, nprs, nmon) :: prs_aerosol_climo
+     
+     call mpas_log_write('====== Handling aerosol initialization 2 for microphysics ======')
+     
+!     call mpas_pool_get_dimension(mesh, 'nCells', nCells)
+!     call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
+     
+     call mpas_pool_get_dimension(state, 'index_nwfa', index_nwfa)
+     call mpas_pool_get_dimension(state, 'index_nifa', index_nifa)
+
+     call mpas_pool_get_array(lbc_state, 'lbc_scalars', scalars)
+!     call mpas_pool_get_array(state, 'scalars', scalars)
+     call mpas_pool_get_array(mesh, 'latCell', latCell)
+     call mpas_pool_get_array(mesh, 'lonCell', lonCell)
+
+     ! Needed for interpolation to pressure
+     call mpas_pool_get_array(diag, 'pressure_base', ppb)
+     call mpas_pool_get_array(diag, 'pressure_p', pp)
+
+     ! Read in tables
+     call mpas_new_unit(aerosol_table_unit)
+     open(unit=aerosol_table_unit, file="thompson_aerosol_lon.dat", form="unformatted", iostat=istat)
+     if(istat /= 0) call mpas_log_write("Error reading longitude table for aerosol initialization (microphysics)")
+     read(aerosol_table_unit) lon_aerosol_climo
+     close(unit=aerosol_table_unit)
+     
+     open(unit=aerosol_table_unit, file="thompson_aerosol_lat.dat", form="unformatted", iostat=istat)
+     if(istat /= 0) call mpas_log_write("Error reading latitude table for aerosol initialization (microphysics)")
+     read(aerosol_table_unit) lat_aerosol_climo
+     close(unit=aerosol_table_unit)
+
+     open(unit=aerosol_table_unit, file="thompson_aerosol_wfa.dat", form="unformatted", iostat=istat)
+     if(istat /= 0) call mpas_log_write("Error reading WFA table for aerosol initialization (microphysics)")
+     read(aerosol_table_unit) wfa_aerosol_climo
+     close(unit=aerosol_table_unit)
+
+     open(unit=aerosol_table_unit, file="thompson_aerosol_ifa.dat", form="unformatted", iostat=istat)
+     if(istat /= 0) call mpas_log_write("Error reading IFA table for aerosol initialization (microphysics)")
+     read(aerosol_table_unit) ifa_aerosol_climo
+     close(unit=aerosol_table_unit)
+
+     open(unit=aerosol_table_unit, file="thompson_aerosol_prs.dat", form="unformatted", iostat=istat)
+     if(istat /= 0) call mpas_log_write("Error reading pressure table for aerosol initialization (microphysics)")
+     read(aerosol_table_unit) prs_aerosol_climo
+     close(unit=aerosol_table_unit)
+     call mpas_release_unit(aerosol_table_unit)
+
+     do k = 1, nVertLevels
+        do iCell = 1, nCells
+           ! Lat and lon from model converted from radians to degrees
+           tmp_lat = 180.0 / pii * latCell(iCell)
+           tmp_lon = 180.0 / pii * lonCell(iCell) - 360.
+           tmp_prs = ppb(k, iCell) + pp(k, iCell)
+
+           lat_index = 1
+           lon_index = 1
+           pressure_index = 30 ! Pressure from monthly climatology is oriented with index=1 is top of atmosphere
+           month_index = 2 ! Hard-coded for February for testing
+           
+           ! Nearest point interpolation (for testing)
+           ! The climatology starts from -180 and goes to 180 (every 1.25 degrees)
+           do m = 1, nlon
+              if(lon_aerosol_climo(m) .gt. tmp_lon) then
+                 lon_index = m
+                 exit
+              endif
+           enddo
+           
+           ! The climatology starts from -90 and goes to 90 (every 1 degree)
+           do m = 1, nlat
+              if(lat_aerosol_climo(m) .gt. tmp_lat) then
+                 lat_index = m
+                 exit
+              endif
+           enddo
+
+           ! Lowest pressure is biggest index for climatology
+           do m = nprs, 1, -1
+              if(prs_aerosol_climo(lon_index,lat_index,m,month_index) .lt. tmp_prs) then
+                 pressure_index = m
+                 exit
+              endif
+           enddo
+
+           scalars(index_nwfa,k,iCell) = wfa_aerosol_climo(lon_index,lat_index,pressure_index,month_index)
+           scalars(index_nifa,k,iCell) = ifa_aerosol_climo(lon_index,lat_index,pressure_index,month_index)
+        end do
+     enddo
+   end subroutine init_microphysics_aerosols_lbc
      
 end module init_atm_cases

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -242,6 +242,8 @@ module init_atm_cases
 
             call init_atm_case_gfs(block_ptr, mesh, nCells, nEdges, nVertLevels, fg, state, &
                                    diag, diag_physics, block_ptr % dimensions, block_ptr % configs)
+
+            call init_microphysics_aerosols(mesh, state, diag)
             
             if (config_met_interp) then
                call physics_initialize_real(mesh, fg, domain % dminfo, block_ptr % dimensions, block_ptr % configs)
@@ -7134,5 +7136,143 @@ call mpas_log_write('Done with soil consistency check')
 
    end function read_text_array
 
+   !-----------------------------------------------------------------------
+   !  routine init_microphysics_aerosols
+   !
+   !> \brief Initialize water- and ice-friendly aerosols for microphysics
+   !> \author Anders Jensen
+   !> \date   14 March 2024
+   !> \details
+   !>  This routine reads five unformatted tables that contain, latitude, longitude,
+   !>  pressure, water- and ice-friendly monthly climatology data to use with the
+   !>  Thompson-Eidhammer microphysics scheme. The data is then "interpolated"
+   !>  using a nearest-grid point option for MPAS initial conditions.
+   !>
+   !>  This is for testing purposes only. A better interpolation method should
+   !>  be implemented. This is also currently hard-coded for the February
+   !>  data. A time interpolation method should be implemented as well.
+   !
+   !-----------------------------------------------------------------------   
+   subroutine init_microphysics_aerosols(mesh, state, diag)
+     
+     use mpas_io_units, only : mpas_new_unit, mpas_release_unit
+     
+     implicit none
+     
+     type (mpas_pool_type), intent(in) :: mesh
+     type (mpas_pool_type), intent(in) :: diag
+     type (mpas_pool_type), intent(inout) :: state
+     
+     integer, pointer :: index_nwfa
+     integer, pointer :: index_nifa
+     integer, pointer :: nCells
+     integer, pointer :: nVertLevels
 
+     integer :: k, m, iCell
+     integer :: aerosol_table_unit, istat
+     integer :: lat_index, lon_index, pressure_index, month_index
+     
+     real (kind=RKIND) :: tmp_lat, tmp_lon, tmp_prs
+     real (kind=RKIND), dimension(:,:), pointer :: ppb, pp
+     real (kind=RKIND), dimension(:), pointer :: latCell
+     real (kind=RKIND), dimension(:), pointer :: lonCell
+     real (kind=RKIND), dimension(:,:,:), pointer :: scalars
+
+     integer, parameter :: nlon = 288
+     integer, parameter :: nlat = 181
+     integer, parameter :: nprs = 30
+     integer, parameter :: nmon = 12 ! integer month for monthly climatology
+     real (kind=R4KIND), dimension(nlon) :: lon_aerosol_climo
+     real (kind=R4KIND), dimension(nlat) :: lat_aerosol_climo
+     real (kind=R4KIND), dimension(nlon, nlat, nprs, nmon) :: wfa_aerosol_climo
+     real (kind=R4KIND), dimension(nlon, nlat, nprs, nmon) :: ifa_aerosol_climo
+     real (kind=R4KIND), dimension(nlon, nlat, nprs, nmon) :: prs_aerosol_climo
+     
+     call mpas_log_write('====== Handling aerosol initialization for microphysics ======')
+     
+     call mpas_pool_get_dimension(mesh, 'nCells', nCells)
+     call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
+     
+     call mpas_pool_get_dimension(state, 'index_nwfa', index_nwfa)
+     call mpas_pool_get_dimension(state, 'index_nifa', index_nifa)
+     
+     call mpas_pool_get_array(state, 'scalars', scalars)
+     call mpas_pool_get_array(mesh, 'latCell', latCell)
+     call mpas_pool_get_array(mesh, 'lonCell', lonCell)
+
+     ! Needed for interpolation to pressure
+     call mpas_pool_get_array(diag, 'pressure_base', ppb)
+     call mpas_pool_get_array(diag, 'pressure_p', pp)
+
+     ! Read in tables
+     call mpas_new_unit(aerosol_table_unit)
+     open(unit=aerosol_table_unit, file="thompson_aerosol_lon.dat", form="unformatted", iostat=istat)
+     if(istat /= 0) call mpas_log_write("Error reading longitude table for aerosol initialization (microphysics)")
+     read(aerosol_table_unit) lon_aerosol_climo
+     close(unit=aerosol_table_unit)
+     
+     open(unit=aerosol_table_unit, file="thompson_aerosol_lat.dat", form="unformatted", iostat=istat)
+     if(istat /= 0) call mpas_log_write("Error reading latitude table for aerosol initialization (microphysics)")
+     read(aerosol_table_unit) lat_aerosol_climo
+     close(unit=aerosol_table_unit)
+
+     open(unit=aerosol_table_unit, file="thompson_aerosol_wfa.dat", form="unformatted", iostat=istat)
+     if(istat /= 0) call mpas_log_write("Error reading WFA table for aerosol initialization (microphysics)")
+     read(aerosol_table_unit) wfa_aerosol_climo
+     close(unit=aerosol_table_unit)
+
+     open(unit=aerosol_table_unit, file="thompson_aerosol_ifa.dat", form="unformatted", iostat=istat)
+     if(istat /= 0) call mpas_log_write("Error reading IFA table for aerosol initialization (microphysics)")
+     read(aerosol_table_unit) ifa_aerosol_climo
+     close(unit=aerosol_table_unit)
+
+     open(unit=aerosol_table_unit, file="thompson_aerosol_prs.dat", form="unformatted", iostat=istat)
+     if(istat /= 0) call mpas_log_write("Error reading pressure table for aerosol initialization (microphysics)")
+     read(aerosol_table_unit) prs_aerosol_climo
+     close(unit=aerosol_table_unit)
+     call mpas_release_unit(aerosol_table_unit)
+
+     do k = 1, nVertLevels
+        do iCell = 1, nCells
+           ! Lat and lon from model converted from radians to degrees
+           tmp_lat = 180.0 / pii * latCell(iCell)
+           tmp_lon = 180.0 / pii * lonCell(iCell) - 360.
+           tmp_prs = ppb(k, iCell) + pp(k, iCell)
+
+           lat_index = 1
+           lon_index = 1
+           pressure_index = 30 ! Pressure from monthly climatology is oriented with index=1 is top of atmosphere
+           month_index = 2 ! Hard-coded for February for testing
+           
+           ! Nearest point interpolation (for testing)
+           ! The climatology starts from -180 and goes to 180 (every 1.25 degrees)
+           do m = 1, nlon
+              if(lon_aerosol_climo(m) .gt. tmp_lon) then
+                 lon_index = m
+                 exit
+              endif
+           enddo
+           
+           ! The climatology starts from -90 and goes to 90 (every 1 degree)
+           do m = 1, nlat
+              if(lat_aerosol_climo(m) .gt. tmp_lat) then
+                 lat_index = m
+                 exit
+              endif
+           enddo
+
+           ! Lowest pressure is biggest index for climatology
+           do m = nprs, 1, -1
+              if(prs_aerosol_climo(lon_index,lat_index,m,month_index) .lt. tmp_prs) then
+                 pressure_index = m
+                 exit
+              endif
+           enddo
+
+           scalars(index_nwfa,k,iCell) = wfa_aerosol_climo(lon_index,lat_index,pressure_index,month_index)
+           scalars(index_nifa,k,iCell) = ifa_aerosol_climo(lon_index,lat_index,pressure_index,month_index)
+        end do
+     enddo
+   end subroutine init_microphysics_aerosols
+     
 end module init_atm_cases

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -330,7 +330,7 @@ module init_atm_cases
                call init_atm_case_lbc(timeString, block_ptr, mesh, nCells, nEdges, nVertLevels, fg, state, &
                                       diag, lbc_state, block_ptr % dimensions, block_ptr % configs)
 
-               call init_microphysics_aerosols_lbc(mesh, state, diag, lbc_state, nCells, nVertLevels)
+               call init_microphysics_aerosols_lbc(timeString, mesh, state, diag, lbc_state, nCells, nVertLevels)
                
                block_ptr => block_ptr % next
             end do
@@ -7143,7 +7143,7 @@ call mpas_log_write('Done with soil consistency check')
    !
    !> \brief Initialize water- and ice-friendly aerosols for microphysics
    !> \author Anders Jensen
-   !> \date   14 March 2024
+   !> \date   22 March 2024
    !> \details
    !>  This routine reads five unformatted tables that contain, latitude, longitude,
    !>  pressure, water- and ice-friendly monthly climatology data to use with the
@@ -7151,8 +7151,7 @@ call mpas_log_write('Done with soil consistency check')
    !>  using a nearest-grid point option for MPAS initial conditions.
    !>
    !>  This is for testing purposes only. A better interpolation method should
-   !>  be implemented. This is also currently hard-coded for the February
-   !>  data. A time interpolation method should be implemented as well.
+   !>  be implemented. 
    !
    !-----------------------------------------------------------------------   
    subroutine init_microphysics_aerosols(mesh, state, diag, configs)
@@ -7343,17 +7342,16 @@ call mpas_log_write('Done with soil consistency check')
    !
    !> \brief Add water- and ice-friendly aerosols for microphysics to LBCs
    !> \author Anders Jensen
-   !> \date   15 March 2024
+   !> \date   22 March 2024
    !> \details
    !>  This routine is similar to init_microphysics_aerosols, but adds
    !>  aerosol information to the lateral boundary condition files. 
    !>
    !>  This is for testing purposes only. A better interpolation method should
-   !>  be implemented. This is also currently hard-coded for the February
-   !>  data. A time interpolation method should be implemented as well.
+   !>  be implemented. 
    !
    !-----------------------------------------------------------------------   
-   subroutine init_microphysics_aerosols_lbc(mesh, state, diag, lbc_state, nCells, nVertLevels)
+   subroutine init_microphysics_aerosols_lbc(timestamp, mesh, state, diag, lbc_state, nCells, nVertLevels)
 
      use mpas_io_units, only : mpas_new_unit, mpas_release_unit
      
@@ -7362,7 +7360,8 @@ call mpas_log_write('Done with soil consistency check')
      
      integer, intent(in) :: nCells
      integer, intent(in) :: nVertLevels
-      
+     character(len=*), intent(in) :: timestamp
+     
      type (mpas_pool_type), intent(in) :: mesh
      type (mpas_pool_type), intent(in) :: diag
      type (mpas_pool_type), intent(inout) :: state
@@ -7375,8 +7374,10 @@ call mpas_log_write('Done with soil consistency check')
 
      integer :: k, m, iCell
      integer :: aerosol_table_unit, istat
-     integer :: lat_index, lon_index, pressure_index, month_index
-     
+     integer :: lat_index, lon_index, pressure_index, month_index, interp_month_index
+     integer :: sim_year, sim_month, sim_day, sim_hour
+     real (kind=RKIND) :: month_fraction, month_interp_weight
+          
      real (kind=RKIND) :: tmp_lat, tmp_lon, tmp_prs
      real (kind=RKIND), dimension(:,:), pointer :: ppb, pp
      real (kind=RKIND), dimension(:), pointer :: latCell
@@ -7393,7 +7394,7 @@ call mpas_log_write('Done with soil consistency check')
      real (kind=R4KIND), dimension(nlon, nlat, nprs, nmon) :: ifa_aerosol_climo
      real (kind=R4KIND), dimension(nlon, nlat, nprs, nmon) :: prs_aerosol_climo
      
-     call mpas_log_write('====== Handling aerosol initialization 2 for microphysics ======')
+     call mpas_log_write('====== Handling aerosol LBCs for microphysics ======')
      
 !     call mpas_pool_get_dimension(mesh, 'nCells', nCells)
 !     call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
@@ -7438,6 +7439,58 @@ call mpas_log_write('Done with soil consistency check')
      close(unit=aerosol_table_unit)
      call mpas_release_unit(aerosol_table_unit)
 
+     read(timestamp, fmt='(    I4)') sim_year
+     read(timestamp, fmt='( 5X,I2)') sim_month
+     read(timestamp, fmt='( 8X,I2)') sim_day
+     read(timestamp, fmt='(11X,I2)') sim_hour
+
+     month_fraction = 0.0
+     
+     ! 86400 seconds in a day, 3600 seconds in an hour
+     if (sim_month == 1) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (31.0 * 86400.0)
+     else if (sim_month == 2) then
+        if (sim_day > 28) sim_day = 28 ! Ignore leap years
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (28.0 * 86400.0)
+     else if (sim_month == 3) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (31.0 * 86400.0)
+     else if (sim_month == 4) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (30.0 * 86400.0)
+     else if (sim_month == 5) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (31.0 * 86400.0)
+     else if (sim_month == 6) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (30.0 * 86400.0)
+     else if (sim_month == 7) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (31.0 * 86400.0)
+     else if (sim_month == 8) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (31.0 * 86400.0)
+     else if (sim_month == 9) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (30.0 * 86400.0)
+     else if (sim_month == 10) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (31.0 * 86400.0)
+     else if (sim_month == 11) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (30.0 * 86400.0)
+     else if (sim_month == 12) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (31.0 * 86400.0)
+     else
+        call mpas_log_write('Invalid month for microphysics aerosol interpolation')
+     endif
+
+     if (month_fraction > 1.0) month_fraction = 1.0
+
+     ! Interpolate to middle of each month
+     if (month_fraction >= 0.5) then
+        month_interp_weight = 1.5 - month_fraction
+        month_index = sim_month
+        interp_month_index = sim_month + 1
+        if (interp_month_index > 12) interp_month_index = 1
+     else
+        month_interp_weight = month_fraction + 0.5
+        month_index = sim_month
+        interp_month_index = sim_month - 1
+        if (interp_month_index < 1) interp_month_index = 12
+     endif
+
      do k = 1, nVertLevels
         do iCell = 1, nCells
            ! Lat and lon from model converted from radians to degrees
@@ -7448,7 +7501,7 @@ call mpas_log_write('Done with soil consistency check')
            lat_index = 1
            lon_index = 1
            pressure_index = 30 ! Pressure from monthly climatology is oriented with index=1 is top of atmosphere
-           month_index = 2 ! Hard-coded for February for testing
+!           month_index = 2 ! Hard-coded for February for testing
            
            ! Nearest point interpolation (for testing)
            ! The climatology starts from -180 and goes to 180 (every 1.25 degrees)
@@ -7474,12 +7527,14 @@ call mpas_log_write('Done with soil consistency check')
                  exit
               endif
            enddo
+           
+           scalars(index_nwfa,k,iCell) = month_interp_weight*wfa_aerosol_climo(lon_index,lat_index,pressure_index,month_index) + &
+                (1.0 - month_interp_weight)*wfa_aerosol_climo(lon_index,lat_index,pressure_index,interp_month_index)
 
-           scalars(index_nwfa,k,iCell) = wfa_aerosol_climo(lon_index,lat_index,pressure_index,month_index)
-           scalars(index_nifa,k,iCell) = ifa_aerosol_climo(lon_index,lat_index,pressure_index,month_index)
+           scalars(index_nifa,k,iCell) = month_interp_weight*ifa_aerosol_climo(lon_index,lat_index,pressure_index,month_index) + &
+                (1.0 - month_interp_weight)*ifa_aerosol_climo(lon_index,lat_index,pressure_index,interp_month_index)
         end do
      enddo
-
    end subroutine init_microphysics_aerosols_lbc
      
 end module init_atm_cases

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -243,7 +243,7 @@ module init_atm_cases
             call init_atm_case_gfs(block_ptr, mesh, nCells, nEdges, nVertLevels, fg, state, &
                                    diag, diag_physics, block_ptr % dimensions, block_ptr % configs)
 
-            call init_microphysics_aerosols(mesh, state, diag)
+            call init_microphysics_aerosols(mesh, state, diag, block_ptr % configs)
             
             if (config_met_interp) then
                call physics_initialize_real(mesh, fg, domain % dminfo, block_ptr % dimensions, block_ptr % configs)
@@ -7155,7 +7155,7 @@ call mpas_log_write('Done with soil consistency check')
    !>  data. A time interpolation method should be implemented as well.
    !
    !-----------------------------------------------------------------------   
-   subroutine init_microphysics_aerosols(mesh, state, diag)
+   subroutine init_microphysics_aerosols(mesh, state, diag, configs)
      
      use mpas_io_units, only : mpas_new_unit, mpas_release_unit
      
@@ -7164,6 +7164,7 @@ call mpas_log_write('Done with soil consistency check')
      type (mpas_pool_type), intent(in) :: mesh
      type (mpas_pool_type), intent(in) :: diag
      type (mpas_pool_type), intent(inout) :: state
+     type (mpas_pool_type), intent(inout):: configs
      
      integer, pointer :: index_nwfa
      integer, pointer :: index_nifa
@@ -7172,13 +7173,16 @@ call mpas_log_write('Done with soil consistency check')
 
      integer :: k, m, iCell
      integer :: aerosol_table_unit, istat
-     integer :: lat_index, lon_index, pressure_index, month_index
+     integer :: lat_index, lon_index, pressure_index, month_index, interp_month_index
+     integer :: sim_year, sim_month, sim_day, sim_hour
+     real (kind=RKIND) :: month_fraction, month_interp_weight
      
      real (kind=RKIND) :: tmp_lat, tmp_lon, tmp_prs
      real (kind=RKIND), dimension(:,:), pointer :: ppb, pp
      real (kind=RKIND), dimension(:), pointer :: latCell
      real (kind=RKIND), dimension(:), pointer :: lonCell
      real (kind=RKIND), dimension(:,:,:), pointer :: scalars
+     character (len=StrKIND), pointer :: config_start_time
 
      integer, parameter :: nlon = 288
      integer, parameter :: nlat = 181
@@ -7191,7 +7195,9 @@ call mpas_log_write('Done with soil consistency check')
      real (kind=R4KIND), dimension(nlon, nlat, nprs, nmon) :: prs_aerosol_climo
      
      call mpas_log_write('====== Handling aerosol initialization for microphysics ======')
-     
+
+     call mpas_pool_get_config(configs, 'config_start_time', config_start_time)
+
      call mpas_pool_get_dimension(mesh, 'nCells', nCells)
      call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
      
@@ -7234,6 +7240,58 @@ call mpas_log_write('Done with soil consistency check')
      close(unit=aerosol_table_unit)
      call mpas_release_unit(aerosol_table_unit)
 
+     read(config_start_time(1:13), fmt='(    I4)') sim_year
+     read(config_start_time(1:13), fmt='( 5X,I2)') sim_month
+     read(config_start_time(1:13), fmt='( 8X,I2)') sim_day
+     read(config_start_time(1:13), fmt='(11X,I2)') sim_hour
+
+     month_fraction = 0.0
+     
+     ! 86400 seconds in a day, 3600 seconds in an hour
+     if (sim_month == 1) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (31.0 * 86400.0)
+     else if (sim_month == 2) then
+        if (sim_day > 28) sim_day = 28 ! Ignore leap years
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (28.0 * 86400.0)
+     else if (sim_month == 3) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (31.0 * 86400.0)
+     else if (sim_month == 4) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (30.0 * 86400.0)
+     else if (sim_month == 5) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (31.0 * 86400.0)
+     else if (sim_month == 6) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (30.0 * 86400.0)
+     else if (sim_month == 7) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (31.0 * 86400.0)
+     else if (sim_month == 8) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (31.0 * 86400.0)
+     else if (sim_month == 9) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (30.0 * 86400.0)
+     else if (sim_month == 10) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (31.0 * 86400.0)
+     else if (sim_month == 11) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (30.0 * 86400.0)
+     else if (sim_month == 12) then
+        month_fraction = (real(sim_day-1, kind=RKIND)*86400.0 + real(sim_hour, kind=RKIND)*3600.0) / (31.0 * 86400.0)
+     else
+        call mpas_log_write('Invalid month for microphysics aerosol interpolation')
+     endif
+
+     if (month_fraction > 1.0) month_fraction = 1.0
+
+     ! Interpolate to middle of each month
+     if (month_fraction >= 0.5) then
+        month_interp_weight = 1.5 - month_fraction
+        month_index = sim_month
+        interp_month_index = sim_month + 1
+        if (interp_month_index > 12) interp_month_index = 1
+     else
+        month_interp_weight = month_fraction + 0.5
+        month_index = sim_month
+        interp_month_index = sim_month - 1
+        if (interp_month_index < 1) interp_month_index = 12
+     endif
+     
      do k = 1, nVertLevels
         do iCell = 1, nCells
            ! Lat and lon from model converted from radians to degrees
@@ -7244,7 +7302,7 @@ call mpas_log_write('Done with soil consistency check')
            lat_index = 1
            lon_index = 1
            pressure_index = 30 ! Pressure from monthly climatology is oriented with index=1 is top of atmosphere
-           month_index = 2 ! Hard-coded for February for testing
+!           month_index = 2 ! Hard-coded for February for testing
            
            ! Nearest point interpolation (for testing)
            ! The climatology starts from -180 and goes to 180 (every 1.25 degrees)
@@ -7270,9 +7328,12 @@ call mpas_log_write('Done with soil consistency check')
                  exit
               endif
            enddo
+           
+           scalars(index_nwfa,k,iCell) = month_interp_weight*wfa_aerosol_climo(lon_index,lat_index,pressure_index,month_index) + &
+                (1.0 - month_interp_weight)*wfa_aerosol_climo(lon_index,lat_index,pressure_index,interp_month_index)
 
-           scalars(index_nwfa,k,iCell) = wfa_aerosol_climo(lon_index,lat_index,pressure_index,month_index)
-           scalars(index_nifa,k,iCell) = ifa_aerosol_climo(lon_index,lat_index,pressure_index,month_index)
+           scalars(index_nifa,k,iCell) = month_interp_weight*ifa_aerosol_climo(lon_index,lat_index,pressure_index,month_index) + &
+                (1.0 - month_interp_weight)*ifa_aerosol_climo(lon_index,lat_index,pressure_index,interp_month_index)
         end do
      enddo
    end subroutine init_microphysics_aerosols
@@ -7286,7 +7347,7 @@ call mpas_log_write('Done with soil consistency check')
      
      integer, intent(in) :: nCells
      integer, intent(in) :: nVertLevels
-      
+     
      type (mpas_pool_type), intent(in) :: mesh
      type (mpas_pool_type), intent(in) :: diag
      type (mpas_pool_type), intent(inout) :: state

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -330,6 +330,8 @@ module init_atm_cases
                call init_atm_case_lbc(timeString, block_ptr, mesh, nCells, nEdges, nVertLevels, fg, state, &
                                       diag, lbc_state, block_ptr % dimensions, block_ptr % configs)
 
+               call init_microphysics_aerosols_lbc(mesh, state, diag, lbc_state, nCells, nVertLevels)
+               
                block_ptr => block_ptr % next
             end do
 
@@ -7274,5 +7276,135 @@ call mpas_log_write('Done with soil consistency check')
         end do
      enddo
    end subroutine init_microphysics_aerosols
+
+   subroutine init_microphysics_aerosols_lbc(mesh, state, diag, lbc_state, nCells, nVertLevels)
+
+     use mpas_io_units, only : mpas_new_unit, mpas_release_unit
+     
+     implicit none
+
+     
+     integer, intent(in) :: nCells
+     integer, intent(in) :: nVertLevels
+      
+     type (mpas_pool_type), intent(in) :: mesh
+     type (mpas_pool_type), intent(in) :: diag
+     type (mpas_pool_type), intent(inout) :: state
+     type (mpas_pool_type), intent(inout) :: lbc_state
+     
+     integer, pointer :: index_nwfa
+     integer, pointer :: index_nifa
+!     integer, pointer :: nCells
+!     integer, pointer :: nVertLevels
+
+     integer :: k, m, iCell
+     integer :: aerosol_table_unit, istat
+     integer :: lat_index, lon_index, pressure_index, month_index
+     
+     real (kind=RKIND) :: tmp_lat, tmp_lon, tmp_prs
+     real (kind=RKIND), dimension(:,:), pointer :: ppb, pp
+     real (kind=RKIND), dimension(:), pointer :: latCell
+     real (kind=RKIND), dimension(:), pointer :: lonCell
+     real (kind=RKIND), dimension(:,:,:), pointer :: scalars
+
+     integer, parameter :: nlon = 288
+     integer, parameter :: nlat = 181
+     integer, parameter :: nprs = 30
+     integer, parameter :: nmon = 12 ! integer month for monthly climatology
+     real (kind=R4KIND), dimension(nlon) :: lon_aerosol_climo
+     real (kind=R4KIND), dimension(nlat) :: lat_aerosol_climo
+     real (kind=R4KIND), dimension(nlon, nlat, nprs, nmon) :: wfa_aerosol_climo
+     real (kind=R4KIND), dimension(nlon, nlat, nprs, nmon) :: ifa_aerosol_climo
+     real (kind=R4KIND), dimension(nlon, nlat, nprs, nmon) :: prs_aerosol_climo
+     
+     call mpas_log_write('====== Handling aerosol initialization 2 for microphysics ======')
+     
+!     call mpas_pool_get_dimension(mesh, 'nCells', nCells)
+!     call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
+     
+     call mpas_pool_get_dimension(state, 'index_nwfa', index_nwfa)
+     call mpas_pool_get_dimension(state, 'index_nifa', index_nifa)
+
+     call mpas_pool_get_array(lbc_state, 'lbc_scalars', scalars)
+!     call mpas_pool_get_array(state, 'scalars', scalars)
+     call mpas_pool_get_array(mesh, 'latCell', latCell)
+     call mpas_pool_get_array(mesh, 'lonCell', lonCell)
+
+     ! Needed for interpolation to pressure
+     call mpas_pool_get_array(diag, 'pressure_base', ppb)
+     call mpas_pool_get_array(diag, 'pressure_p', pp)
+
+     ! scalars(:,:,:) = 0.0_RKIND
+     
+     ! Read in tables
+     call mpas_new_unit(aerosol_table_unit)
+     open(unit=aerosol_table_unit, file="thompson_aerosol_lon.dat", form="unformatted", iostat=istat)
+     if(istat /= 0) call mpas_log_write("Error reading longitude table for aerosol initialization (microphysics)")
+     read(aerosol_table_unit) lon_aerosol_climo
+     close(unit=aerosol_table_unit)
+     
+     open(unit=aerosol_table_unit, file="thompson_aerosol_lat.dat", form="unformatted", iostat=istat)
+     if(istat /= 0) call mpas_log_write("Error reading latitude table for aerosol initialization (microphysics)")
+     read(aerosol_table_unit) lat_aerosol_climo
+     close(unit=aerosol_table_unit)
+
+     open(unit=aerosol_table_unit, file="thompson_aerosol_wfa.dat", form="unformatted", iostat=istat)
+     if(istat /= 0) call mpas_log_write("Error reading WFA table for aerosol initialization (microphysics)")
+     read(aerosol_table_unit) wfa_aerosol_climo
+     close(unit=aerosol_table_unit)
+
+     open(unit=aerosol_table_unit, file="thompson_aerosol_ifa.dat", form="unformatted", iostat=istat)
+     if(istat /= 0) call mpas_log_write("Error reading IFA table for aerosol initialization (microphysics)")
+     read(aerosol_table_unit) ifa_aerosol_climo
+     close(unit=aerosol_table_unit)
+
+     open(unit=aerosol_table_unit, file="thompson_aerosol_prs.dat", form="unformatted", iostat=istat)
+     if(istat /= 0) call mpas_log_write("Error reading pressure table for aerosol initialization (microphysics)")
+     read(aerosol_table_unit) prs_aerosol_climo
+     close(unit=aerosol_table_unit)
+     call mpas_release_unit(aerosol_table_unit)
+
+     do k = 1, nVertLevels
+        do iCell = 1, nCells
+           ! Lat and lon from model converted from radians to degrees
+           tmp_lat = 180.0 / pii * latCell(iCell)
+           tmp_lon = 180.0 / pii * lonCell(iCell) - 360.
+           tmp_prs = ppb(k, iCell) + pp(k, iCell)
+
+           lat_index = 1
+           lon_index = 1
+           pressure_index = 30 ! Pressure from monthly climatology is oriented with index=1 is top of atmosphere
+           month_index = 2 ! Hard-coded for February for testing
+           
+           ! Nearest point interpolation (for testing)
+           ! The climatology starts from -180 and goes to 180 (every 1.25 degrees)
+           do m = 1, nlon
+              if(lon_aerosol_climo(m) .gt. tmp_lon) then
+                 lon_index = m
+                 exit
+              endif
+           enddo
+           
+           ! The climatology starts from -90 and goes to 90 (every 1 degree)
+           do m = 1, nlat
+              if(lat_aerosol_climo(m) .gt. tmp_lat) then
+                 lat_index = m
+                 exit
+              endif
+           enddo
+
+           ! Lowest pressure is biggest index for climatology
+           do m = nprs, 1, -1
+              if(prs_aerosol_climo(lon_index,lat_index,m,month_index) .lt. tmp_prs) then
+                 pressure_index = m
+                 exit
+              endif
+           enddo
+
+           scalars(index_nwfa,k,iCell) = wfa_aerosol_climo(lon_index,lat_index,pressure_index,month_index)
+           scalars(index_nifa,k,iCell) = ifa_aerosol_climo(lon_index,lat_index,pressure_index,month_index)
+        end do
+     enddo
+   end subroutine init_microphysics_aerosols_lbc
      
 end module init_atm_cases


### PR DESCRIPTION
- Adds water- and ice-friendly aerosols passive tracers (nwfa and nifa) to the initial conditions and model code
- Adds water- and ice-friendly aerosols passive tracers (nwfa and nifa) to lateral boundary conditions
- Updates lookup tables for Thompson microphysics (**hail-aware microphysics will not work yet**)
- Adds subroutines to read in monthly climatology data for water- and ice-friendly aerosols for initial and lateral boundary conditions. **Note, currently using a crude interpolation**
- Points to the Thompson-Eidhammer microphysics here: https://github.com/AndersJensen-NOAA/GSL_cloud_physics.git using branch develop. This version is mostly updated to be consistent with WRFv4.5.
- **After this merge, the submodule version of Thompson will need to be used, so a command like `git submodule update --init --recursive` will need to be run after cloning MPAS**
- Tables needed for aerosol data are in the submodule folder and need to be manually linked to the **run** directory before creating initial and boundary conditions.

Testing: one 24-h 15-km test run on Jet with GNU compilers with aerosols initialized and advected, but not coupled to the microphysics. 
