### PR TITLE
Updating MYNN-EDMF, MYNN sfclayer, and coupling sgs clouds to radiation

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -660,6 +660,9 @@
                         <var name="ch"/>
 			<var name="kpbl"/>
 			<var name="hpbl"/>
+                        <var name="maxmf"/>
+			<var name="maxwidth"/>
+			<var name="ztop_plume"/>
 			<var name="hfx"/>
 			<var name="mavail"/>
 			<var name="mol"/>
@@ -795,7 +798,10 @@
 			<var name="rqvblten"/>
 			<var name="rqcblten"/>
 			<var name="rqiblten"/>
+			<var name="rncblten"/>
 			<var name="rniblten"/>
+			<var name="rnwfablten"/>
+			<var name="rnifablten"/>
 			<var name="rthratensw"/>
 			<var name="rthratenlw"/>
 			<var name="isltyp"/>
@@ -849,9 +855,9 @@
 #endif
 		</stream>
 
-		<stream name="output" 
-                        type="output" 
-                        filename_template="history.$Y-$M-$D_$h.$m.$s.nc" 
+		<stream name="output"
+                        type="output"
+                        filename_template="history.$Y-$M-$D_$h.$m.$s.nc"
                         output_interval="6:00:00"
                         runtime_format="separate_file">
 
@@ -984,9 +990,9 @@
 #endif
 		</stream>
 
-		<stream name="diagnostics" 
-                        type="output" 
-                        filename_template="diag.$Y-$M-$D_$h.$m.$s.nc" 
+		<stream name="diagnostics"
+                        type="output"
+                        filename_template="diag.$Y-$M-$D_$h.$m.$s.nc"
                         output_interval="3:00:00"
                         runtime_format="separate_file">
 
@@ -1504,7 +1510,7 @@
 
                         <var name="qs" array_group="moist" units="kg kg^{-1}"
                              description="Snow mixing ratio"
-                             packages="mp_thompson_in;mp_wsm6_in"/>
+                             packages="bl_mynn_in;mp_thompson_in;mp_wsm6_in"/>
 
                         <var name="qg" array_group="moist" units="kg kg^{-1}"
                              description="Graupel mixing ratio"
@@ -1514,9 +1520,9 @@
                              description="Cloud ice number concentration"
                              packages="bl_mynn_in;mp_thompson_in"/>
 
-                        <var name="nc" array_group="number" units="nb kg^{-1}"
-                             description="Cloud number concentration"
-                             packages="mp_thompson_in"/>
+			<var name="nc" array_group="number" units="nb kg^{-1}"
+                             description="Cloud water number concentration"
+                             packages="bl_mynn_in;mp_thompson_in"/>
 
                         <var name="nr" array_group="number" units="nb kg^{-1}"
                              description="Rain number concentration"
@@ -1524,11 +1530,11 @@
 			
 			<var name="nwfa" array_group="passive" units="nb kg^{-1}"
                              description="Number of water-friendly aerosols for microphysics"
-                             packages="mp_thompson_in"/>
+                             packages="bl_mynn_in;mp_thompson_in"/>
 
 			<var name="nifa" array_group="passive" units="nb kg^{-1}"
                              description="Number of ice-friendly aerosols for microphysics"
-                             packages="mp_thompson_in"/>
+                             packages="bl_mynn_in;mp_thompson_in"/>
                 </var_array>
 #endif
 
@@ -1779,7 +1785,7 @@
 
         <var_struct name="tend" time_levs="1">
 
-                
+
                 <!-- tendencies for prognostic variables -->
                 <var name="tend_u" name_in_code="u" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-2}"
                      description="Tendency of u from dynamics"/>
@@ -1848,9 +1854,9 @@
                              description="Tendency of cloud ice number concentration multiplied by dry air density divided by d(zeta)/dz"
                              packages="bl_mynn_in;mp_thompson_in"/>
 
-			<var name="tend_nc" name_in_code="nc" array_group="number" units="nb m^{-3} s^{-1}" 
-                             description="Tendency of cloud number concentration multiplied by dry air density divided by d(zeta)/dz"
-                             packages="mp_thompson_in"/>
+			<var name="tend_nc" name_in_code="nc" array_group="number" units="nb m^{-3} s^{-1}"
+                             description="Tendency of cloud water number concentration multiplied by dry air density divided by d(zeta)/dz"
+                             packages="bl_mynn_in;mp_thompson_in"/>
 			
                         <var name="tend_nr" name_in_code="nr" array_group="number" units="nb m^{-3} s^{-1}" 
                              description="Tendency of rain number concentration multiplied by dry air density divided by d(zeta)/dz"
@@ -1858,11 +1864,11 @@
 
 			<var name="tend_nwfa" name_in_code="nwfa" array_group="passive" units="nb m^{-3} s^{-1}" 
                              description="Tendency of water-friendly aerosols multiplied by dry air density divided by d(zeta)/dz"
-                             packages="mp_thompson_in"/>
+                             packages="bl_mynn_in;mp_thompson_in"/>
 
 			<var name="tend_nifa" name_in_code="nifa" array_group="passive" units="nb m^{-3} s^{-1}" 
                              description="Tendency of ice-friendly aerosols multiplied by dry air density divided by d(zeta)/dz"
-                             packages="mp_thompson_in"/>
+                             packages="bl_mynn_in;mp_thompson_in"/>
                 </var_array>
 #endif
         </var_struct>
@@ -1910,14 +1916,14 @@
                         <var name="lbc_qi" name_in_code="qi" array_group="moist"  packages="bl_mynn_in;cu_tiedtke_in;mp_thompson_in;mp_wsm6_in" units="kg kg^{-1} s^{-1}"
                              description="Lateral boundary tendency of ice mixing ratio"/>
 
-                        <var name="lbc_qs" name_in_code="qs" array_group="moist"  packages="mp_thompson_in;mp_wsm6_in" units="kg kg^{-1} s^{-1}"
+                        <var name="lbc_qs" name_in_code="qs" array_group="moist"  packages="bl_mynn_in;mp_thompson_in;mp_wsm6_in" units="kg kg^{-1} s^{-1}"
                              description="Lateral boundary tendency of snow mixing ratio"/>
 
                         <var name="lbc_qg" name_in_code="qg" array_group="moist"  packages="mp_thompson_in;mp_wsm6_in" units="kg kg^{-1} s^{-1}"
                              description="Lateral boundary tendency of graupel mixing ratio"/>
 
-                        <var name="lbc_nc" name_in_code="nc" array_group="number" packages="mp_thompson_in" units="m^{-3} s^{-1}"
-                             description="Lateral boundary tendency of cloud number concentration"/>
+                        <var name="lbc_nc" name_in_code="nc" array_group="number" packages="bl_mynn_in;mp_thompson_in" units="m^{-3} s^{-1}"
+                             description="Lateral boundary tendency of cloud water number concentration"/>
 			
                         <var name="lbc_nr" name_in_code="nr" array_group="number" packages="mp_thompson_in" units="m^{-3} s^{-1}"
                              description="Lateral boundary tendency of rain number concentration"/>
@@ -1925,10 +1931,10 @@
                         <var name="lbc_ni" name_in_code="ni" array_group="number" packages="bl_mynn_in;mp_thompson_in" units="m^{-3} s^{-1}"
                              description="Lateral boundary tendency of ice number concentration"/>
 
-                        <var name="lbc_nwfa" name_in_code="nwfa" array_group="passive" packages="mp_thompson_in" units="m^{-3} s^{-1}"
+                        <var name="lbc_nwfa" name_in_code="nwfa" array_group="passive" packages="bl_mynn_in;mp_thompson_in" units="m^{-3} s^{-1}"
                              description="Lateral boundary tendency of wfa"/>
 
-                        <var name="lbc_nifa" name_in_code="nifa" array_group="passive" packages="mp_thompson_in" units="m^{-3} s^{-1}"
+                        <var name="lbc_nifa" name_in_code="nifa" array_group="passive" packages="bl_mynn_in;mp_thompson_in" units="m^{-3} s^{-1}"
                              description="Lateral boundary tendency of ifa"/>
                 </var_array>
         </var_struct>
@@ -1987,7 +1993,7 @@
                      possible_values="Positive integers"/>
 
                 <!-- NAMELIST VARIABLES ADDED FOR PHYSICS CONFIGURATION: -->
-                
+
                 <nml_option name="config_frac_seaice" type="logical" default_value="true" in_defaults="false"
                      units="-"
                      description="logical for configuration of fractional sea-ice"
@@ -2103,6 +2109,76 @@
                      description="configuration for planetary boundary layer schemes"
                      possible_values="`suite',`bl_ysu',`bl_mynn',`off'"/>
 
+		<nml_option name="config_mynn_output" type="integer" default_value="0" in_defaults="false"
+                     units="-"
+                     description="extra output for mynn planetary boundary layer scheme"
+                     possible_values="`0: not output',`1: updraft arrays',`2: downdraft arrays'"/>
+
+		<nml_option name="config_tkebudget" type="integer" default_value="0" in_defaults="false"
+                     units="-"
+                     description="tke budget for planetary boundary layer schemes"
+                     possible_values="`0: off',`1: activated'"/>
+
+		<nml_option name="config_mynn_cloudpdf" type="integer" default_value="2" in_defaults="false"
+                     units="-"
+                     description="configuration for cloud pdf in MYNN"
+                     possible_values="`0: Someria-Deardorff',`1: Someria-Deardorf 1st order',`1: Modified Chab-Bechtold'"/>
+
+		<nml_option name="config_mynn_mixlength" type="integer" default_value="1" in_defaults="false"
+                     units="-"
+                     description="configuration for mixing length option in the MYNN"
+                     possible_values="`0: orig',`1: operational',`1: research"/>
+
+		<nml_option name="config_mynn_edmf" type="integer" default_value="1" in_defaults="false"
+                     units="-"
+                     description="configuration for activating the mass-flux component of the MYNN"
+                     possible_values="`0: off',`1: activated'"/>
+
+		<nml_option name="config_mynn_edmf_mom" type="integer" default_value="1" in_defaults="false"
+                     units="-"
+                     description="configuration for transporting momentum in MYNN mass flux component"
+                     possible_values="`0: off',`1: transport momentum'"/>
+
+		<nml_option name="config_mynn_edmf_tke" type="integer" default_value="0" in_defaults="false"
+                     units="-"
+                     description="configuration for transporting TKE in MYNN mass flux component"
+                     possible_values="`0: off',`1: transport TKE'"/>
+
+		<nml_option name="config_mynn_mixscalars" type="integer" default_value="1" in_defaults="false"
+                     units="-"
+                     description="configuration for mixing scalars in MYNN"
+                     possible_values="`0: do not mix scalars',`1: mix scalars'"/>
+
+		<nml_option name="config_mynn_mixqt" type="integer" default_value="0" in_defaults="false"
+                     units="-"
+                     description="configuration for mixing individual species vs total water in MYNN"
+                     possible_values="`0: mix individual species',`1: mix total water (do not use)'"/>
+
+		<nml_option name="config_mynn_cloudmix" type="integer" default_value="1" in_defaults="false"
+                     units="-"
+                     description="configuration for mixing cloud species in MYNN"
+                     possible_values="`0: do not mix cloud species',`1: mix all cloud species'"/>
+		
+		<nml_option name="config_icloud_bl" type="integer" default_value="1" in_defaults="false"
+                     units="-"
+                     description="configuration for MYNN subgrid cloud coupling to radiation"
+                     possible_values="`0: uncoupled',`1: coupled'"/>
+
+		<nml_option name="config_mynn_closure" type="real" default_value="2.6" in_defaults="false"
+                     units="-"
+                     description="configuration for closure level for MYNN-EDMF"
+                     possible_values="`2.5: level 2.5',`2.6: level 2.6',`3.0: level 3.0'"/>
+
+		<nml_option name="config_mynn_tkeadvect" type="logical" default_value="false" in_defaults="false"
+                     units="-"
+                     description="configuration for tke advection"
+                     possible_values="`false: off',`true: activated'"/>
+
+		<nml_option name="config_spp_pbl" type="integer" default_value="0" in_defaults="false"
+                     units="-"
+                     description="configuration for spp boundary layer"
+                     possible_values="`0: off',`1: activated'"/>
+		
                 <nml_option name="config_gwdo_scheme" type="character" default_value="suite" in_defaults="false"
                      units="-"
                      description="configuration of gravity wave drag over orography"
@@ -2368,7 +2444,7 @@
 
                 <var name="delta" type="real" dimensions="nCells Time" units="m"
                      description="entrainment layer depth from PBL scheme"
-                     packages="bl_mynn_in;bl_ysu_in"/>
+                     packages="bl_ysu_in"/>
 
                 <var name="wstar" type="real" dimensions="nCells Time" units="m s^{-1}"
                      description="mixed velocity scale from PBL scheme"
@@ -2422,6 +2498,18 @@
                      description="turbulent kinetic energy from PBL"
                      packages="bl_mynn_in"/>
 
+		<var name="cldfrac_bl" type="real" dimensions="nVertLevels nCells Time" units="fraction"
+                     description="cloud fraction from boundary layer scheme"
+                     packages="bl_mynn_in"/>
+
+                <var name="qc_bl" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1}"
+                     description="subgrid cloud water from boundary layer scheme"
+                     packages="bl_mynn_in"/>
+
+                <var name="qi_bl" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1}"
+                     description="subgrid cloud ice from boundary layer scheme"
+                     packages="bl_mynn_in"/> 
+
                 <var name="dqke" type="real" dimensions="nVertLevels nCells Time" units="m^{2} s^{-2}"
                      description="TKE change"
                      packages="bl_mynn_in"/>
@@ -2442,7 +2530,66 @@
                      description="TKE vertical distribution"
                      packages="bl_mynn_in"/>
 
+		<var name="edmf_a" type="real" dimensions="nVertLevels nCells Time" units="frac"
+                     description="mass flux relative updraft area"
+                     packages="bl_mynn_in"/>
 
+		<var name="edmf_w" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+                     description="mass flux relative updraft area"
+                     packages="bl_mynn_in"/>
+
+		<var name="edmf_thl" type="real" dimensions="nVertLevels nCells Time" units="K"
+                     description="liquid potential temperature in mass flux updrafts"
+                     packages="bl_mynn_in"/>
+
+		<var name="edmf_qt" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1}"
+                     description="total water in mass flux updrafts"
+                     packages="bl_mynn_in"/>
+
+		<var name="edmf_ent" type="real" dimensions="nVertLevels nCells Time" units="m^{-1}"
+                     description="entrainment rate in mass flux updrafts"
+                     packages="bl_mynn_in"/>
+
+		<var name="edmf_qc" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1}"
+                     description="cloud water in mass flux updrafts"
+                     packages="bl_mynn_in"/>
+
+		<var name="sub_thl" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+                     description="temperature tendency from subsidence"
+                     packages="bl_mynn_in"/>
+
+		<var name="sub_sqv" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
+                     description="water vapor tendency from subsidence"
+                     packages="bl_mynn_in"/>
+
+		<var name="det_thl" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+                     description="temperature tendency from detrainment"
+                     packages="bl_mynn_in"/>
+
+                <var name="det_sqv" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
+                     description="water vapor tendency from detrainment"
+                     packages="bl_mynn_in"/>
+
+		<var name="sh3d" type="real" dimensions="nVertLevels nCells Time" units="-"
+                     description="stability function for scalars"
+                     packages="bl_mynn_in"/>
+
+                <var name="sm3d" type="real" dimensions="nVertLevels nCells Time" units="-"
+                     description="stability function for momentum"
+                     packages="bl_mynn_in"/>
+
+                <var name="maxmf" type="real" dimensions="nCells Time" units="m s^{-1}"
+                     description="Maximum mass flux in the each column"
+                     packages="bl_mynn_in"/>
+
+		<var name="maxwidth" type="real" dimensions="nCells Time" units="m"
+                     description="Maximum width of updrafts"
+                     packages="bl_mynn_in"/>
+
+		<var name="ztop_plume" type="real" dimensions="nCells Time" units="m"
+                     description="Height of highest penetratign plume"
+                     packages="bl_mynn_in"/>
+		
                 <!-- ================================================================================================== -->
                 <!-- ... PARAMETERIZATION OF SURFACE LAYER PROCESSES:                                                   -->
                 <!-- ================================================================================================== -->
@@ -2574,10 +2721,6 @@
                 <var name="qcg" type="real" dimensions="nCells Time" units="kg kg^{-1}"
                      description="cloud water mixing ratio at the ground surface"
                      packages="bl_mynn_in;lsm_ruc_in"/>
-
-                <var name="sh3d" type="real" dimensions="nVertLevels nCells Time" units="unitless"
-                     description="stability function for heat"
-                     packages="bl_mynn_in"/>
 
 
                 <!-- DIAGNOSTICS: -->
@@ -3143,6 +3286,18 @@
                      description="tendency of cloud ice number concentration due to pbl processes"
                      packages="bl_mynn_in"/>
 
+		<var name="rncblten" type="real" dimensions="nVertLevels nCells Time" units="nb kg^{-1} s^{-1}"
+                     description="tendency of cloud water number concentration due to pbl processes"
+                     packages="bl_mynn_in"/>
+
+		<var name="rnwfablten" type="real" dimensions="nVertLevels nCells Time" units="nb kg^{-1} s^{-1}"
+                     description="tendency of water friendly aerosol number concentration due to pbl processes"
+                     packages="bl_mynn_in"/>
+
+		<var name="rnifablten" type="real" dimensions="nVertLevels nCells Time" units="nb kg^{-1} s^{-1}"
+                     description="tendency of ice friendly aerosol number concentration due to pbl processes"
+                     packages="bl_mynn_in"/>
+
 	        <!-- MGD should we add packages to the field below? -->
 	        <var name="rublten_Edge" type="real"     dimensions="nVertLevels nEdges Time"/>
 
@@ -3171,7 +3326,6 @@
                 <var name="ozmixm" type="real" dimensions="nMonths nOznLevels nCells" units="mol mol^{-1}"
                      description="monthly-mean climatological ozone defined at fixed pressure levels"/>
         </var_struct>
-
 
         <var_struct name="sfc_input" time_levs="1">
 
@@ -3313,7 +3467,7 @@
 #endif
 
         <var_struct name="tend_iau" time_levs="1" packages="iau">
-			
+
                 <!-- analysis increments; read from iau input -->
                 <var name="u_amb"     name_in_code="u" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-1}"
                      description="Horizontal normal velocity increment"/>

--- a/src/core_atmosphere/physics/mpas_atmphys_control.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_control.F
@@ -99,6 +99,7 @@
                                   config_radt_lw_scheme,    &
                                   config_radt_sw_scheme,    &
                                   config_sfclayer_scheme
+ integer,pointer :: config_icloud_bl
 
 !-----------------------------------------------------------------------------------------------------------------
 !call mpas_log_write('')
@@ -114,7 +115,7 @@
  call mpas_pool_get_config(configs,'config_radt_lw_scheme'   ,config_radt_lw_scheme   )
  call mpas_pool_get_config(configs,'config_radt_sw_scheme'   ,config_radt_sw_scheme   )
  call mpas_pool_get_config(configs,'config_sfclayer_scheme'  ,config_sfclayer_scheme  )
-
+ call mpas_pool_get_config(configs,'config_icloud_bl'        ,config_icloud_bl)
  call mpas_log_write('')
  call mpas_log_write('----- Setting up physics suite '''//trim(config_physics_suite)//''' -----')
 
@@ -256,6 +257,19 @@
     call physics_message(mpas_err_message)
     config_radt_cld_scheme = "cld_incidence"
 
+ endif
+
+ if(     config_pbl_scheme     .eq. 'bl_mynn'          .and. &
+         config_icloud_bl      .gt.  0                 .and. &
+    .not.config_radt_cld_scheme == 'cld_fraction_mynn') then
+    call mpas_log_write('')
+    write(mpas_err_message,'(A,A10)') &
+       '    config_pbl_scheme is set to bl_mynn and config_icloud_bl > 0  '
+    call physics_message(mpas_err_message)
+    write(mpas_err_message,'(A,A10)') &
+       '    switch calculation of cloud fraction to config_radt_cld_scheme = cld_fraction_mynn'
+    call physics_message(mpas_err_message)
+    config_radt_cld_scheme = "cld_fraction_mynn"
  endif
 
 !surface-layer scheme:

--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -200,12 +200,12 @@
     end do
 !$OMP END PARALLEL DO
 
-    !call to cloud scheme:
+    call mpas_log_write( ' call to cloud scheme: ')
     if(l_radtlw .or. l_radtsw) then
-       call allocate_cloudiness
+       call allocate_cloudiness(block%configs)
 !$OMP PARALLEL DO
        do thread=1,nThreads
-          call driver_cloudiness(block%configs,mesh,diag_physics,sfc_input, &
+          call driver_cloudiness(itimestep,block%configs,mesh,diag_physics,sfc_input, &
                                  cellSolveThreadStart(thread),cellSolveThreadEnd(thread))
        end do
 !$OMP END PARALLEL DO
@@ -249,7 +249,7 @@
 
     !deallocate all radiation arrays:
     if(config_radt_sw_scheme.ne.'off' .or. config_radt_lw_scheme.ne.'off') &
-       call deallocate_cloudiness
+       call deallocate_cloudiness(block%configs)
     if(config_radt_sw_scheme.ne.'off') call deallocate_radiation_sw(block%configs)
     if(config_radt_lw_scheme.ne.'off') call deallocate_radiation_lw(block%configs)
 

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_cloudiness.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_cloudiness.F
@@ -58,8 +58,15 @@
 
 
 !=================================================================================================================
- subroutine allocate_cloudiness
+ subroutine allocate_cloudiness(configs)
 !=================================================================================================================
+
+!input arguments:
+ type(mpas_pool_type),intent(in)   :: configs
+!local pointer:
+ character(len=StrKIND),pointer:: radt_cld_scheme
+
+ call mpas_pool_get_config(configs,'config_radt_cld_scheme',radt_cld_scheme)
 
  if(.not.allocated(dx_p)     ) allocate(dx_p(ims:ime,jms:jme)             ) 
  if(.not.allocated(xland_p)  ) allocate(xland_p(ims:ime,jms:jme)          )
@@ -69,11 +76,27 @@
  if(.not.allocated(qirad_p)  ) allocate(qirad_p(ims:ime,kms:kme,jms:jme)  )
  if(.not.allocated(qsrad_p)  ) allocate(qsrad_p(ims:ime,kms:kme,jms:jme)  )
 
+ cld_fraction_select: select case (trim(radt_cld_scheme))
+
+    case("cld_fraction_mynn")
+       if(.not.allocated(qi_bl_p)) allocate(qi_bl_p(ims:ime,kms:kme,jms:jme))
+       if(.not.allocated(qc_bl_p)) allocate(qc_bl_p(ims:ime,kms:kme,jms:jme))
+    case default
+
+ end select cld_fraction_select
+
  end subroutine allocate_cloudiness
 
 !=================================================================================================================
- subroutine deallocate_cloudiness
+ subroutine deallocate_cloudiness(configs)
 !=================================================================================================================
+
+!input arguments:
+ type(mpas_pool_type),intent(in)   :: configs
+!local pointer:
+ character(len=StrKIND),pointer:: radt_cld_scheme
+
+ call mpas_pool_get_config(configs,'config_radt_cld_scheme',radt_cld_scheme)
 
  if(allocated(dx_p)     ) deallocate(dx_p     )
  if(allocated(xland_p)  ) deallocate(xland_p  )
@@ -83,14 +106,26 @@
  if(allocated(qirad_p)  ) deallocate(qirad_p  )
  if(allocated(qsrad_p)  ) deallocate(qsrad_p  )
 
+ cld_fraction_select: select case (trim(radt_cld_scheme))
+
+    case("cld_fraction_mynn")
+
+       if(allocated(qi_bl_p)) deallocate(qi_bl_p)
+       if(allocated(qc_bl_p)) deallocate(qc_bl_p)
+    case default
+
+ end select cld_fraction_select
+
+
  end subroutine deallocate_cloudiness
 
 !=================================================================================================================
- subroutine cloudiness_from_MPAS(configs,mesh,diag_physics,sfc_input,its,ite)
+ subroutine cloudiness_from_MPAS(itimestep,configs,mesh,diag_physics,sfc_input,its,ite)
 !=================================================================================================================
 
 !input arguments:
  integer,intent(in):: its,ite
+ integer,intent(in):: itimestep
 
 !input and inout arguments:
  type(mpas_pool_type),intent(in)   :: configs
@@ -107,6 +142,10 @@
  real(kind=RKIND),dimension(:),pointer:: areaCell,meshDensity
  real(kind=RKIND),dimension(:),pointer:: xland
 
+ real(kind=RKIND),dimension(:,:),pointer:: cldfrac_bl,qi_bl,qc_bl
+
+ character(len=StrKIND),pointer:: radt_cld_scheme
+
 !-----------------------------------------------------------------------------------------------------------------
 
  call mpas_pool_get_config(configs,'config_len_disp',len_disp)
@@ -115,6 +154,7 @@
  call mpas_pool_get_array(mesh,'meshDensity',meshDensity)
 
  call mpas_pool_get_array(sfc_input,'xland',xland)
+ call mpas_pool_get_config(configs,'config_radt_cld_scheme',radt_cld_scheme)
 
  do j = jts,jte
     do i = its,ite
@@ -134,6 +174,49 @@
     enddo
     enddo
  enddo
+
+ cld_fraction_select: select case (trim(radt_cld_scheme))
+ 
+    case("cld_fraction_mynn")
+       call mpas_pool_get_array(diag_physics,'cldfrac_bl',cldfrac_bl)
+       call mpas_pool_get_array(diag_physics,'qi_bl',qi_bl)
+       call mpas_pool_get_array(diag_physics,'qc_bl',qc_bl)
+       if(itimestep > 0) then
+          do j = jts,jte
+          do k = kts,kte
+          do i = its,ite
+             if (cldfrac_bl(k,i) .gt. 0.001) then
+                cldfrac_p(i,k,j) = cldfrac_bl(k,i)
+             endif
+          enddo
+          enddo
+          enddo
+       else
+          do j = jts,jte
+          do k = kts,kte
+          do i = its,ite
+             if	(qcrad_p(i,k,j) .gt. 1e-6 .or. &
+                 qirad_p(i,k,j) .gt. 1e-9 .or. &
+                 qsrad_p(i,k,j) .gt. 1e-8 ) then
+                cldfrac_p(i,k,j) = 1._RKIND
+      	     endif
+          enddo
+          enddo
+          enddo
+       endif
+
+       do j = jts,jte
+       do k = kts,kte
+       do i = its,ite
+          qc_bl_p(i,k,j) = qc_bl(k,i)
+          qi_bl_p(i,k,j) = qi_bl(k,i)
+       enddo
+       enddo
+       enddo
+
+    case default
+ end select cld_fraction_select  
+ 
 
  end subroutine cloudiness_from_MPAS
 
@@ -167,7 +250,7 @@
  end subroutine cloudiness_to_MPAS
 
 !=================================================================================================================
- subroutine driver_cloudiness(configs,mesh,diag_physics,sfc_input,its,ite)
+ subroutine driver_cloudiness(itimestep,configs,mesh,diag_physics,sfc_input,its,ite)
 !=================================================================================================================
 
 !input arguments:
@@ -176,6 +259,7 @@
  type(mpas_pool_type),intent(in)   :: sfc_input
 
  integer,intent(in):: its,ite
+ integer,intent(in):: itimestep
 
 !inout arguments:
  type(mpas_pool_type),intent(inout):: diag_physics
@@ -192,7 +276,7 @@
  call mpas_pool_get_config(configs,'config_radt_cld_scheme',radt_cld_scheme)
 
 !copy MPAS arrays to local arrays:
- call cloudiness_from_MPAS(configs,mesh,diag_physics,sfc_input,its,ite)
+ call cloudiness_from_MPAS(itimestep,configs,mesh,diag_physics,sfc_input,its,ite)
 
  cld_fraction_select: select case (trim(radt_cld_scheme))
     case("cld_incidence")
@@ -216,6 +300,13 @@
            its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte     &
                       )
       call mpas_timer_stop('cal_cldfra3')
+
+    case("cld_fraction_mynn")
+      call mpas_timer_start('cal_mynncld')
+      call cal_mynncld(cldfrac_p , qcrad_p   , qirad_p    , &
+                       qc_bl_p   , qi_bl_p   ,              &
+                       its,  ite , jts , jte , kts , kte  )
+      call mpas_timer_stop('cal_mynncld')
 
     case default
 
@@ -364,6 +455,40 @@
 
  end subroutine calc_cldfraction
 
+!=================================================================================================================
+ subroutine cal_mynncld(cldfrac,qc,qi,qc_bl,qi_bl,its,ite,jts,jte,kts,kte)
+!=================================================================================================================
+
+!input arguments:
+ integer,intent(in):: its,ite,jts,jte,kts,kte
+ real(kind=RKIND),intent(inout),dimension(ims:ime,kms:kme,jms:jme):: qc,qi
+ real(kind=RKIND),intent(in),   dimension(ims:ime,kms:kme,jms:jme):: qc_bl,qi_bl
+ real(kind=RKIND),intent(in),   dimension(ims:ime,kms:kme,jms:jme):: cldfrac
+
+!local variables:
+ integer:: i,j,k
+
+ real(kind=RKIND),parameter:: qc_thresh  = 1.e-06
+ real(kind=RKIND),parameter:: qi_thresh  = 1.e-08
+ real(kind=RKIND),parameter:: cld_thresh = 1.e-03
+
+ do j = jts,jte
+ do k = kts,kte
+ do i = its,ite
+    
+    if (qc(i,k,j) < qc_thresh .AND. cldfrac(i,k,j) > cld_thresh) THEN
+       !call mpas_log_write("Adding in cldfra_bl to qc at $i,$i,$i", intArgs=(/i,j,k/))
+       qc(i,k,j)=qc(i,k,j) + qc_bl(i,k,j)
+    endif
+    if (qi(i,k,j) < qi_thresh .AND. cldfrac(i,k,j) > cld_thresh) THEN
+       !call mpas_log_write("Adding in cldfra_bl to qi at $i,$i,$i", intArgs=(/i,j,k/))
+       qi(i,k,j)=qi(i,k,j) + qi_bl(i,k,j)
+    endif
+ enddo
+ enddo
+ enddo
+
+ end subroutine cal_mynncld
 !=================================================================================================================
  end module mpas_atmphys_driver_cloudiness
 !=================================================================================================================

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
@@ -160,43 +160,43 @@
        if(.not.allocated(sh3d_p)  ) allocate(sh3d_p(ims:ime,kms:kme,jms:jme)  )
        if(.not.allocated(sm3d_p)  ) allocate(sm3d_p(ims:ime,kms:kme,jms:jme)  )
 
-       if (config_tkebudget .gt. 0) then
+       !if (config_tkebudget .gt. 0) then
           if(.not.allocated(dqke_p)  ) allocate(dqke_p(ims:ime,kms:kme,jms:jme)  )
           if(.not.allocated(qbuoy_p) ) allocate(qbuoy_p(ims:ime,kms:kme,jms:jme) )
           if(.not.allocated(qdiss_p) ) allocate(qdiss_p(ims:ime,kms:kme,jms:jme) )
           if(.not.allocated(qshear_p)) allocate(qshear_p(ims:ime,kms:kme,jms:jme))
           if(.not.allocated(qwt_p)   ) allocate(qwt_p(ims:ime,kms:kme,jms:jme)   )
-       else
-          if(.not.allocated(dqke_p)  ) allocate(dqke_p(1,1,1)  )
-          if(.not.allocated(qbuoy_p) ) allocate(qbuoy_p(1,1,1) )
-          if(.not.allocated(qdiss_p) ) allocate(qdiss_p(1,1,1) )
-          if(.not.allocated(qshear_p)) allocate(qshear_p(1,1,1))
-          if(.not.allocated(qwt_p)   ) allocate(qwt_p(1,1,1)   )
-       endif
+       !else
+       !   if(.not.allocated(dqke_p)  ) allocate(dqke_p(1,1,1)  )
+       !   if(.not.allocated(qbuoy_p) ) allocate(qbuoy_p(1,1,1) )
+       !   if(.not.allocated(qdiss_p) ) allocate(qdiss_p(1,1,1) )
+       !   if(.not.allocated(qshear_p)) allocate(qshear_p(1,1,1))
+       !   if(.not.allocated(qwt_p)   ) allocate(qwt_p(1,1,1)   )
+       !endif
 
-       if (config_mynn_output .gt. 0) then
+       !if (config_mynn_output .gt. 0) then
           if(.not.allocated(edmf_a_p)  ) allocate(edmf_a_p(ims:ime,kms:kme,jms:jme)  )
           if(.not.allocated(edmf_w_p)  ) allocate(edmf_w_p(ims:ime,kms:kme,jms:jme)  )
           if(.not.allocated(edmf_thl_p)) allocate(edmf_thl_p(ims:ime,kms:kme,jms:jme))
           if(.not.allocated(edmf_qt_p) ) allocate(edmf_qt_p(ims:ime,kms:kme,jms:jme) )
           if(.not.allocated(edmf_qc_p) ) allocate(edmf_qc_p(ims:ime,kms:kme,jms:jme) )
           if(.not.allocated(edmf_ent_p)) allocate(edmf_ent_p(ims:ime,kms:kme,jms:jme))
-          if(.not.allocated(sub_thl_p) ) allocate(edmf_w_p(ims:ime,kms:kme,jms:jme)  )
-          if(.not.allocated(sub_sqv_p) ) allocate(edmf_thl_p(ims:ime,kms:kme,jms:jme))
-          if(.not.allocated(det_thl_p) ) allocate(edmf_qt_p(ims:ime,kms:kme,jms:jme) )
-          if(.not.allocated(det_sqv_p) ) allocate(edmf_qc_p(ims:ime,kms:kme,jms:jme) )
-       else
-          if(.not.allocated(edmf_a_p)  ) allocate(edmf_a_p(1,1,1)  )
-          if(.not.allocated(edmf_w_p)  ) allocate(edmf_w_p(1,1,1)  )
-          if(.not.allocated(edmf_thl_p)) allocate(edmf_thl_p(1,1,1))
-          if(.not.allocated(edmf_qt_p) ) allocate(edmf_qt_p(1,1,1) )
-          if(.not.allocated(edmf_qc_p) ) allocate(edmf_qc_p(1,1,1) )
-          if(.not.allocated(edmf_ent_p)) allocate(edmf_ent_p(1,1,1))
-          if(.not.allocated(sub_thl_p) ) allocate(sub_thl_p(1,1,1) )
-          if(.not.allocated(sub_sqv_p) ) allocate(sub_sqv_p(1,1,1) )
-          if(.not.allocated(det_thl_p) ) allocate(det_thl_p(1,1,1) )
-          if(.not.allocated(det_sqv_p) ) allocate(det_sqv_p(1,1,1) )
-       endif
+          if(.not.allocated(sub_thl_p) ) allocate(sub_thl_p(ims:ime,kms:kme,jms:jme)  )
+          if(.not.allocated(sub_sqv_p) ) allocate(sub_sqv_p(ims:ime,kms:kme,jms:jme))
+          if(.not.allocated(det_thl_p) ) allocate(det_thl_p(ims:ime,kms:kme,jms:jme) )
+          if(.not.allocated(det_sqv_p) ) allocate(det_sqv_p(ims:ime,kms:kme,jms:jme) )
+       !else
+       !   if(.not.allocated(edmf_a_p)  ) allocate(edmf_a_p(1,1,1)  )
+       !   if(.not.allocated(edmf_w_p)  ) allocate(edmf_w_p(1,1,1)  )
+       !   if(.not.allocated(edmf_thl_p)) allocate(edmf_thl_p(1,1,1))
+       !   if(.not.allocated(edmf_qt_p) ) allocate(edmf_qt_p(1,1,1) )
+       !   if(.not.allocated(edmf_qc_p) ) allocate(edmf_qc_p(1,1,1) )
+       !   if(.not.allocated(edmf_ent_p)) allocate(edmf_ent_p(1,1,1))
+       !   if(.not.allocated(sub_thl_p) ) allocate(sub_thl_p(1,1,1) )
+       !   if(.not.allocated(sub_sqv_p) ) allocate(sub_sqv_p(1,1,1) )
+       !   if(.not.allocated(det_thl_p) ) allocate(det_thl_p(1,1,1) )
+       !   if(.not.allocated(det_sqv_p) ) allocate(det_sqv_p(1,1,1) )
+       !endif
        
        if(.not.allocated(rqsblten_p)  ) allocate(rqsblten_p(ims:ime,kms:kme,jms:jme)  )
        if(.not.allocated(rniblten_p)  ) allocate(rniblten_p(ims:ime,kms:kme,jms:jme)  )
@@ -206,9 +206,9 @@
        if(.not.allocated(rnbcablten_p)) allocate(rnbcablten_p(ims:ime,kms:kme,jms:jme)) 
        if(.not.allocated(nbca_p)      ) allocate(nbca_p(ims:ime,kms:kme,jms:jme)      )
        
-       if(.not.allocated(qc_bl_p)    ) allocate(qc_bl_p(ims:ime,kms:kme,jms:jme)    )
-       if(.not.allocated(qi_bl_p)    ) allocate(qi_bl_p(ims:ime,kms:kme,jms:jme)    )
-       if(.not.allocated(cldfrac_bl_p))allocate(cldfrac_bl_p(ims:ime,kms:kme,jms:jme))
+       if(.not.allocated(qc_bl_p)     ) allocate(qc_bl_p(ims:ime,kms:kme,jms:jme)     )
+       if(.not.allocated(qi_bl_p)     ) allocate(qi_bl_p(ims:ime,kms:kme,jms:jme)     )
+       if(.not.allocated(cldfrac_bl_p)) allocate(cldfrac_bl_p(ims:ime,kms:kme,jms:jme))
 
        !from radiation schemes:
        if(.not.allocated(rthraten_p)) allocate(rthraten_p(ims:ime,kms:kme,jms:jme))
@@ -313,8 +313,25 @@
        if(allocated(qc_bl_p)    ) deallocate(qc_bl_p    )
        if(allocated(qi_bl_p)    ) deallocate(qi_bl_p    )
        if(allocated(cldfrac_bl_p))deallocate(cldfrac_bl_p)
-       if(allocated(rthraten_p) ) deallocate(rthraten_p )
 
+       if(allocated(dqke_p)  ) deallocate(dqke_p      )
+       if(allocated(qbuoy_p) ) deallocate(qbuoy_p     )
+       if(allocated(qdiss_p) ) deallocate(qdiss_p     )
+       if(allocated(qshear_p)) deallocate(qshear_p    )
+       if(allocated(qwt_p)   ) deallocate(qwt_p       )
+
+       if(allocated(edmf_a_p)  ) deallocate(edmf_a_p  )
+       if(allocated(edmf_w_p)  ) deallocate(edmf_w_p  )
+       if(allocated(edmf_thl_p)) deallocate(edmf_thl_p)
+       if(allocated(edmf_qt_p) ) deallocate(edmf_qt_p )
+       if(allocated(edmf_qc_p) ) deallocate(edmf_qc_p )
+       if(allocated(edmf_ent_p)) deallocate(edmf_ent_p)
+       if(allocated(sub_thl_p) ) deallocate(sub_thl_p )
+       if(allocated(sub_sqv_p) ) deallocate(sub_sqv_p )
+       if(allocated(det_thl_p) ) deallocate(det_thl_p )
+       if(allocated(det_sqv_p) ) deallocate(det_sqv_p )
+
+       if(allocated(rthraten_p)) deallocate(rthraten_p)
        if(allocated(pattern_spp_pbl_p)) deallocate(pattern_spp_pbl_p) 
     case default
 
@@ -777,8 +794,8 @@
              edmf_qt(k,i)    = edmf_qt_p(i,k,j)
              edmf_qc(k,i)    = edmf_qc_p(i,k,j)
              edmf_ent(k,i)   = edmf_ent_p(i,k,j)
-             det_thl(k,i)    = sub_thl_p(i,k,j)
-             det_sqv(k,i)    = sub_sqv_p(i,k,j)
+             sub_thl(k,i)    = sub_thl_p(i,k,j)
+             sub_sqv(k,i)    = sub_sqv_p(i,k,j)
              det_thl(k,i)    = det_thl_p(i,k,j)
              det_sqv(k,i)    = det_sqv_p(i,k,j)
           enddo

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
@@ -15,7 +15,7 @@
  use mpas_atmphys_vars
 
 !wrf physics:
- use module_bl_mynn
+ use module_bl_mynn_wrapper
  use module_bl_ysu
 
  implicit none
@@ -87,6 +87,8 @@
 
 !local pointers:
  character(len=StrKIND),pointer:: pbl_scheme
+ integer,pointer :: config_mynn_output
+ integer,pointer :: config_tkebudget
 
 !-----------------------------------------------------------------------------------------------------------------
 
@@ -135,13 +137,19 @@
        if(.not.allocated(rthraten_p)) allocate(rthraten_p(ims:ime,kms:kme,jms:jme))
 
     case("bl_mynn")
-       if(.not.allocated(dx_p)   ) allocate(dx_p(ims:ime,jms:jme)   )
-       if(.not.allocated(ch_p)   ) allocate(ch_p(ims:ime,jms:jme)   )
-       if(.not.allocated(qcg_p)  ) allocate(qcg_p(ims:ime,jms:jme)  )
-       if(.not.allocated(qsfc_p) ) allocate(qsfc_p(ims:ime,jms:jme) )
-       if(.not.allocated(rmol_p) ) allocate(rmol_p(ims:ime,jms:jme) )
-       if(.not.allocated(tsk_p)  ) allocate(tsk_p(ims:ime,jms:jme)  )
-       if(.not.allocated(vdfg_p) ) allocate(vdfg_p(ims:ime,jms:jme) )
+       call mpas_pool_get_config(configs,'config_mynn_output',config_mynn_output)
+       call mpas_pool_get_config(configs,'config_tkebudget',config_tkebudget)
+         
+       if(.not.allocated(dx_p)        ) allocate(dx_p(ims:ime,jms:jme)   )
+       if(.not.allocated(ch_p)        ) allocate(ch_p(ims:ime,jms:jme)   )
+       if(.not.allocated(qcg_p)       ) allocate(qcg_p(ims:ime,jms:jme)  )
+       if(.not.allocated(qsfc_p)      ) allocate(qsfc_p(ims:ime,jms:jme) )
+       if(.not.allocated(rmol_p)      ) allocate(rmol_p(ims:ime,jms:jme) )
+       if(.not.allocated(tsk_p)       ) allocate(tsk_p(ims:ime,jms:jme)  )
+       if(.not.allocated(vdfg_p)      ) allocate(vdfg_p(ims:ime,jms:jme) )
+       if(.not.allocated(maxmf_p)     ) allocate(maxmf_p(ims:ime,jms:jme))
+       if(.not.allocated(maxwidth_p)  ) allocate(maxwidth_p(ims:ime,jms:jme))
+       if(.not.allocated(ztop_plume_p)) allocate(ztop_plume_p(ims:ime,jms:jme))
 
        if(.not.allocated(cov_p)   ) allocate(cov_p(ims:ime,kms:kme,jms:jme)   )
        if(.not.allocated(qke_p)   ) allocate(qke_p(ims:ime,kms:kme,jms:jme)   )
@@ -149,17 +157,64 @@
        if(.not.allocated(tsq_p)   ) allocate(tsq_p(ims:ime,kms:kme,jms:jme)   )
        if(.not.allocated(qkeadv_p)) allocate(qkeadv_p(ims:ime,kms:kme,jms:jme))
        if(.not.allocated(elpbl_p) ) allocate(elpbl_p(ims:ime,kms:kme,jms:jme) )
-       if(.not.allocated(tkepbl_p)) allocate(tkepbl_p(ims:ime,kms:kme,jms:jme))
        if(.not.allocated(sh3d_p)  ) allocate(sh3d_p(ims:ime,kms:kme,jms:jme)  )
+       if(.not.allocated(sm3d_p)  ) allocate(sm3d_p(ims:ime,kms:kme,jms:jme)  )
 
-       if(.not.allocated(dqke_p)  ) allocate(dqke_p(ims:ime,kms:kme,jms:jme)  )
-       if(.not.allocated(qbuoy_p) ) allocate(qbuoy_p(ims:ime,kms:kme,jms:jme) )
-       if(.not.allocated(qdiss_p) ) allocate(qdiss_p(ims:ime,kms:kme,jms:jme) )
-       if(.not.allocated(qshear_p)) allocate(qshear_p(ims:ime,kms:kme,jms:jme))
-       if(.not.allocated(qwt_p)   ) allocate(qwt_p(ims:ime,kms:kme,jms:jme)   )
+       if (config_tkebudget .gt. 0) then
+          if(.not.allocated(dqke_p)  ) allocate(dqke_p(ims:ime,kms:kme,jms:jme)  )
+          if(.not.allocated(qbuoy_p) ) allocate(qbuoy_p(ims:ime,kms:kme,jms:jme) )
+          if(.not.allocated(qdiss_p) ) allocate(qdiss_p(ims:ime,kms:kme,jms:jme) )
+          if(.not.allocated(qshear_p)) allocate(qshear_p(ims:ime,kms:kme,jms:jme))
+          if(.not.allocated(qwt_p)   ) allocate(qwt_p(ims:ime,kms:kme,jms:jme)   )
+       else
+          if(.not.allocated(dqke_p)  ) allocate(dqke_p(1,1,1)  )
+          if(.not.allocated(qbuoy_p) ) allocate(qbuoy_p(1,1,1) )
+          if(.not.allocated(qdiss_p) ) allocate(qdiss_p(1,1,1) )
+          if(.not.allocated(qshear_p)) allocate(qshear_p(1,1,1))
+          if(.not.allocated(qwt_p)   ) allocate(qwt_p(1,1,1)   )
+       endif
 
-       if(.not.allocated(rniblten_p)) allocate(rniblten_p(ims:ime,kms:kme,jms:jme))
+       if (config_mynn_output .gt. 0) then
+          if(.not.allocated(edmf_a_p)  ) allocate(edmf_a_p(ims:ime,kms:kme,jms:jme)  )
+          if(.not.allocated(edmf_w_p)  ) allocate(edmf_w_p(ims:ime,kms:kme,jms:jme)  )
+          if(.not.allocated(edmf_thl_p)) allocate(edmf_thl_p(ims:ime,kms:kme,jms:jme))
+          if(.not.allocated(edmf_qt_p) ) allocate(edmf_qt_p(ims:ime,kms:kme,jms:jme) )
+          if(.not.allocated(edmf_qc_p) ) allocate(edmf_qc_p(ims:ime,kms:kme,jms:jme) )
+          if(.not.allocated(edmf_ent_p)) allocate(edmf_ent_p(ims:ime,kms:kme,jms:jme))
+          if(.not.allocated(sub_thl_p) ) allocate(edmf_w_p(ims:ime,kms:kme,jms:jme)  )
+          if(.not.allocated(sub_sqv_p) ) allocate(edmf_thl_p(ims:ime,kms:kme,jms:jme))
+          if(.not.allocated(det_thl_p) ) allocate(edmf_qt_p(ims:ime,kms:kme,jms:jme) )
+          if(.not.allocated(det_sqv_p) ) allocate(edmf_qc_p(ims:ime,kms:kme,jms:jme) )
+       else
+          if(.not.allocated(edmf_a_p)  ) allocate(edmf_a_p(1,1,1)  )
+          if(.not.allocated(edmf_w_p)  ) allocate(edmf_w_p(1,1,1)  )
+          if(.not.allocated(edmf_thl_p)) allocate(edmf_thl_p(1,1,1))
+          if(.not.allocated(edmf_qt_p) ) allocate(edmf_qt_p(1,1,1) )
+          if(.not.allocated(edmf_qc_p) ) allocate(edmf_qc_p(1,1,1) )
+          if(.not.allocated(edmf_ent_p)) allocate(edmf_ent_p(1,1,1))
+          if(.not.allocated(sub_thl_p) ) allocate(sub_thl_p(1,1,1) )
+          if(.not.allocated(sub_sqv_p) ) allocate(sub_sqv_p(1,1,1) )
+          if(.not.allocated(det_thl_p) ) allocate(det_thl_p(1,1,1) )
+          if(.not.allocated(det_sqv_p) ) allocate(det_sqv_p(1,1,1) )
+       endif
+       
+       if(.not.allocated(rqsblten_p)  ) allocate(rqsblten_p(ims:ime,kms:kme,jms:jme)  )
+       if(.not.allocated(rniblten_p)  ) allocate(rniblten_p(ims:ime,kms:kme,jms:jme)  )
+       if(.not.allocated(rncblten_p)  ) allocate(rncblten_p(ims:ime,kms:kme,jms:jme)  )
+       if(.not.allocated(rnwfablten_p)) allocate(rnwfablten_p(ims:ime,kms:kme,jms:jme))
+       if(.not.allocated(rnifablten_p)) allocate(rnifablten_p(ims:ime,kms:kme,jms:jme))
+       if(.not.allocated(rnbcablten_p)) allocate(rnbcablten_p(ims:ime,kms:kme,jms:jme)) 
+       if(.not.allocated(nbca_p)      ) allocate(nbca_p(ims:ime,kms:kme,jms:jme)      )
+       
+       if(.not.allocated(qc_bl_p)    ) allocate(qc_bl_p(ims:ime,kms:kme,jms:jme)    )
+       if(.not.allocated(qi_bl_p)    ) allocate(qi_bl_p(ims:ime,kms:kme,jms:jme)    )
+       if(.not.allocated(cldfrac_bl_p))allocate(cldfrac_bl_p(ims:ime,kms:kme,jms:jme))
 
+       !from radiation schemes:
+       if(.not.allocated(rthraten_p)) allocate(rthraten_p(ims:ime,kms:kme,jms:jme))
+
+       !spp:
+       if(.not.allocated(pattern_spp_pbl_p)) allocate(pattern_spp_pbl_p(ims:ime,kms:kme,jms:jme))
     case default
 
  end select pbl_select
@@ -222,13 +277,16 @@
        if(allocated(rthraten_p)) deallocate(rthraten_p)
 
     case("bl_mynn")
-       if(allocated(dx_p)   ) deallocate(dx_p   )
-       if(allocated(ch_p)   ) deallocate(ch_p   )
-       if(allocated(qcg_p)  ) deallocate(qcg_p  )
-       if(allocated(qsfc_p) ) deallocate(qsfc_p )
-       if(allocated(rmol_p) ) deallocate(rmol_p )
-       if(allocated(tsk_p)  ) deallocate(tsk_p  )
-       if(allocated(vdfg_p) ) deallocate(vdfg_p )
+       if(allocated(dx_p)        ) deallocate(dx_p   )
+       if(allocated(ch_p)        ) deallocate(ch_p   )
+       if(allocated(qcg_p)       ) deallocate(qcg_p  )
+       if(allocated(qsfc_p)      ) deallocate(qsfc_p )
+       if(allocated(rmol_p)      ) deallocate(rmol_p )
+       if(allocated(tsk_p)       ) deallocate(tsk_p  )
+       if(allocated(vdfg_p)      ) deallocate(vdfg_p )
+       if(allocated(maxmf_p)     ) deallocate(maxmf_p)
+       if(allocated(maxwidth_p)  ) deallocate(maxwidth_p)
+       if(allocated(ztop_plume_p)) deallocate(ztop_plume_p)
 
        if(allocated(cov_p)   ) deallocate(cov_p   )
        if(allocated(qke_p)   ) deallocate(qke_p   )
@@ -236,16 +294,28 @@
        if(allocated(tsq_p)   ) deallocate(tsq_p   )
        if(allocated(qkeadv_p)) deallocate(qkeadv_p)
        if(allocated(elpbl_p) ) deallocate(elpbl_p )
-       if(allocated(tkepbl_p)) deallocate(tkepbl_p)
        if(allocated(sh3d_p)  ) deallocate(sh3d_p  )
+       if(allocated(sm3d_p)  ) deallocate(sm3d_p  )
        if(allocated(dqke_p)  ) deallocate(dqke_p  )
        if(allocated(qbuoy_p) ) deallocate(qbuoy_p )
        if(allocated(qdiss_p) ) deallocate(qdiss_p )
        if(allocated(qshear_p)) deallocate(qshear_p)
        if(allocated(qwt_p)   ) deallocate(qwt_p   )
 
-       if(allocated(rniblten_p)) deallocate(rniblten_p)
+       if(allocated(rqsblten_p)  ) deallocate(rqsblten_p  )
+       if(allocated(rniblten_p)  ) deallocate(rniblten_p  )
+       if(allocated(rncblten_p)  ) deallocate(rncblten_p  )
+       if(allocated(rnwfablten_p)) deallocate(rnwfablten_p)
+       if(allocated(rnifablten_p)) deallocate(rnifablten_p)
+       if(allocated(rnbcablten_p)) deallocate(rnbcablten_p)
+       if(allocated(nbca_p)      ) deallocate(nbca_p      )
+       
+       if(allocated(qc_bl_p)    ) deallocate(qc_bl_p    )
+       if(allocated(qi_bl_p)    ) deallocate(qi_bl_p    )
+       if(allocated(cldfrac_bl_p))deallocate(cldfrac_bl_p)
+       if(allocated(rthraten_p) ) deallocate(rthraten_p )
 
+       if(allocated(pattern_spp_pbl_p)) deallocate(pattern_spp_pbl_p) 
     case default
 
  end select pbl_select
@@ -270,7 +340,19 @@
 
 !local pointers:
  character(len=StrKIND),pointer:: pbl_scheme
-
+ integer,pointer:: config_tkebudget
+ integer,pointer:: config_mynn_mixlength
+ integer,pointer:: config_mynn_cloudpdf
+ integer,pointer:: config_mynn_edmf
+ integer,pointer:: config_mynn_edmf_mom
+ integer,pointer:: config_mynn_edmf_tke
+ integer,pointer:: config_mynn_mixscalars
+ integer,pointer:: config_mynn_mixqt
+ integer,pointer:: config_mynn_output
+ integer,pointer:: config_icloud_bl
+ real,   pointer:: config_mynn_closure
+ logical,pointer:: config_mynn_tkeadvect
+      
  real(kind=RKIND),dimension(:),pointer:: hfx,hpbl,qfx,ust,wspd,xland,znt
  real(kind=RKIND),dimension(:),pointer:: delta,wstar
 
@@ -283,8 +365,14 @@
  real(kind=RKIND),pointer:: len_disp
  real(kind=RKIND),dimension(:),pointer  :: meshDensity
  real(kind=RKIND),dimension(:),pointer  :: ch,qsfc,qcg,rmol,skintemp
- real(kind=RKIND),dimension(:,:),pointer:: cov,qke,qsq,tsq,sh3d,tke_pbl,qke_adv,el_pbl
-
+ real(kind=RKIND),dimension(:,:),pointer:: cov,qsq,tsq,sh3d,sm3d
+ real(kind=RKIND),dimension(:,:),pointer:: qke,qke_adv,el_pbl
+ real(kind=RKIND),dimension(:,:),pointer:: cldfrac_bl,qi_bl,qc_bl
+ real(kind=RKIND),dimension(:,:),pointer:: dqke,qdiss,qshear,qbuoy,qwt
+ real(kind=RKIND),dimension(:,:),pointer:: edmf_a,edmf_w,edmf_thl
+ real(kind=RKIND),dimension(:,:),pointer:: edmf_qt,edmf_qc,edmf_ent
+ real(kind=RKIND),dimension(:,:),pointer:: sub_thl,sub_sqv,det_thl,det_sqv
+      
 !-----------------------------------------------------------------------------------------------------------------
 
  call mpas_pool_get_config(configs,'config_pbl_scheme',pbl_scheme)
@@ -295,9 +383,8 @@
  call mpas_pool_get_array(diag_physics,'ust'   ,ust   )
  call mpas_pool_get_array(diag_physics,'wspd'  ,wspd  )
  call mpas_pool_get_array(diag_physics,'znt'   ,znt   )
- call mpas_pool_get_array(diag_physics,'delta' ,delta )
  call mpas_pool_get_array(diag_physics,'wstar' ,wstar )
-
+ call mpas_pool_get_array(sfc_input,'skintemp' ,skintemp)
  call mpas_pool_get_array(sfc_input   ,'xland' ,xland )
 
  do j = jts,jte
@@ -309,9 +396,9 @@
     ust_p(i,j)    = ust(i)
     wspd_p(i,j)   = wspd(i)
     xland_p(i,j)  = xland(i)
+    tsk_p(i,j)    = skintemp(i)
     kpbl_p(i,j)   = 1
     znt_p(i,j)    = znt(i)
-    delta_p(i,j)  = delta(i)
     wstar_p(i,j)  = wstar(i)
     !... ocean currents are set to zero:
     uoce_p(i,j)  = 0._RKIND
@@ -329,7 +416,8 @@
        call mpas_pool_get_array(diag_physics,'fh'    ,fh    )
        call mpas_pool_get_array(diag_physics,'u10'   ,u10   )
        call mpas_pool_get_array(diag_physics,'v10'   ,v10   )
-
+       call mpas_pool_get_array(diag_physics,'delta' ,delta )
+       
        call mpas_pool_get_array(tend_physics,'rthratenlw',rthratenlw)
        call mpas_pool_get_array(tend_physics,'rthratensw',rthratensw)
 
@@ -344,6 +432,7 @@
           psih_p(i,j)   = fh(i)
           u10_p(i,j)    = u10(i)
           v10_p(i,j)    = v10(i)
+          delta_p(i,j)  = delta(i)
           !initialization for YSU PBL scheme:
           ctopo_p(i,j)  = 1._RKIND
           ctopo2_p(i,j) = 1._RKIND
@@ -360,7 +449,20 @@
        enddo
 
     case("bl_mynn")
-       call mpas_pool_get_config(configs,'config_len_disp',len_disp)
+       call mpas_pool_get_config(configs,'config_len_disp'       ,len_disp)
+       call mpas_pool_get_config(configs,'config_mynn_output'    ,config_mynn_output)
+       call mpas_pool_get_config(configs,'config_tkebudget'      ,config_tkebudget)
+       call mpas_pool_get_config(configs,'config_mynn_cloudpdf'  ,config_mynn_cloudpdf)
+       call mpas_pool_get_config(configs,'config_mynn_mixlength' ,config_mynn_mixlength)
+       call mpas_pool_get_config(configs,'config_mynn_edmf'      ,config_mynn_edmf)
+       call mpas_pool_get_config(configs,'config_mynn_edmf_mom'  ,config_mynn_edmf_mom)
+       call mpas_pool_get_config(configs,'config_mynn_edmf_tke'  ,config_mynn_edmf_tke)
+       call mpas_pool_get_config(configs,'config_mynn_mixscalars',config_mynn_mixscalars)
+       call mpas_pool_get_config(configs,'config_mynn_mixqt'     ,config_mynn_mixqt)
+       call mpas_pool_get_config(configs,'config_mynn_closure'   ,config_mynn_closure)
+       call mpas_pool_get_config(configs,'config_mynn_tkeadvect' ,config_mynn_tkeadvect)
+       call mpas_pool_get_config(configs,'config_icloud_bl'      ,config_icloud_bl) 
+       
        call mpas_pool_get_array(mesh,'meshDensity',meshDensity)
 
        call mpas_pool_get_array(sfc_input   ,'skintemp',skintemp)
@@ -375,8 +477,32 @@
        call mpas_pool_get_array(diag_physics,'qke_adv',qke_adv  )
        call mpas_pool_get_array(diag_physics,'qsq'    ,qsq      )
        call mpas_pool_get_array(diag_physics,'tsq'    ,tsq      )
-       call mpas_pool_get_array(diag_physics,'tke_pbl',tke_pbl  )
        call mpas_pool_get_array(diag_physics,'sh3d'   ,sh3d     )
+       call mpas_pool_get_array(diag_physics,'sm3d'   ,sm3d     )
+       call mpas_pool_get_array(diag_physics,'cldfrac_bl',cldfrac_bl)
+       call mpas_pool_get_array(diag_physics,'qc_bl'  ,qc_bl    )
+       call mpas_pool_get_array(diag_physics,'qi_bl'  ,qi_bl    )
+       
+       if (config_tkebudget .gt. 0) then
+          call mpas_pool_get_array(diag_physics,'dqke'  ,dqke   )
+          call mpas_pool_get_array(diag_physics,'qdiss' ,qdiss  )
+          call mpas_pool_get_array(diag_physics,'qwt'   ,qwt    )
+          call mpas_pool_get_array(diag_physics,'qbuoy' ,qbuoy  )
+          call mpas_pool_get_array(diag_physics,'qshear',qshear )
+       endif
+
+       if (config_mynn_output .gt. 0) then
+          call mpas_pool_get_array(diag_physics,'edmf_a'  ,edmf_a  )
+          call mpas_pool_get_array(diag_physics,'edmf_w'  ,edmf_w  )
+          call mpas_pool_get_array(diag_physics,'edmf_thl',edmf_thl)
+          call mpas_pool_get_array(diag_physics,'edmf_qt' ,edmf_qt )
+          call mpas_pool_get_array(diag_physics,'edmf_qc' ,edmf_qc )
+          call mpas_pool_get_array(diag_physics,'edmf_ent',edmf_ent)
+          call mpas_pool_get_array(diag_physics,'sub_thl' ,sub_thl )
+          call mpas_pool_get_array(diag_physics,'sub_sqv' ,sub_sqv )
+          call mpas_pool_get_array(diag_physics,'det_thl' ,det_thl )
+          call mpas_pool_get_array(diag_physics,'det_sqv' ,det_sqv )
+       endif
 
        do j = jts,jte
        do i = its,ite
@@ -394,26 +520,48 @@
        do j = jts,jte
        do k = kts,kte
        do i = its,ite
-          elpbl_p(i,k,j)    = el_pbl(k,i)
-          cov_p(i,k,j)      = cov(k,i)
-          qke_p(i,k,j)      = qke(k,i)
-          qsq_p(i,k,j)      = qsq(k,i)
-          tsq_p(i,k,j)      = tsq(k,i)
-          tkepbl_p(i,k,j)   = tke_pbl(k,i)
-          qkeadv_p(i,k,j)   = qke_adv(k,i)
-          sh3d_p(i,k,j)     = sh3d(k,i)
-          rniblten_p(i,k,j) = 0._RKIND
+          elpbl_p(i,k,j)      = el_pbl(k,i)
+          cov_p(i,k,j)        = cov(k,i)
+          qke_p(i,k,j)        = qke(k,i)
+          qsq_p(i,k,j)        = qsq(k,i)
+          tsq_p(i,k,j)        = tsq(k,i)
+          qkeadv_p(i,k,j)     = qke_adv(k,i)
+          sh3d_p(i,k,j)       = sh3d(k,i)
+          cldfrac_bl_p(i,k,j) = cldfrac_bl(k,i)
+          qi_bl_p(i,k,j)      = qi_bl(k,i)
+          qc_bl_p(i,k,j)      = qc_bl(k,i)
 
-          !... outputs:
-          dqke_p(i,k,j)   = 0._RKIND
-          qbuoy_p(i,k,j)  = 0._RKIND
-          qdiss_p(i,k,j)  = 0._RKIND
-          qshear_p(i,k,j) = 0._RKIND
-          qwt_p(i,k,j)    = 0._RKIND
+          rqsblten_p(i,k,j)   = 0._RKIND
+          rniblten_p(i,k,j)   = 0._RKIND
+          rncblten_p(i,k,j)   = 0.0_RKIND
+          rnwfablten_p(i,k,j) = 0.0_RKIND
+          rnifablten_p(i,k,j) = 0.0_RKIND
+          rnbcablten_p(i,k,j) = 0.0_RKIND
+          nbca_p(i,k,j)       = 0.0_RKIND
+          
+          pattern_spp_pbl_p(i,k,j)=0.0_RKIND
        enddo
        enddo
        enddo
 
+       !... outputs:
+       dqke_p        = 0._RKIND
+       qbuoy_p       = 0._RKIND
+       qdiss_p       = 0._RKIND
+       qshear_p      = 0._RKIND
+       qwt_p         = 0._RKIND
+
+       edmf_a_p      = 0._RKIND
+       edmf_w_p      = 0._RKIND
+       edmf_thl_p    = 0._RKIND
+       edmf_qt_p     = 0._RKIND
+       edmf_qc_p     = 0._RKIND
+       edmf_ent_p    = 0._RKIND
+       sub_thl_p     = 0._RKIND
+       sub_sqv_p     = 0._RKIND
+       det_thl_p     = 0._RKIND
+       det_sqv_p     = 0._RKIND
+       
     case default
 
  end select pbl_select
@@ -455,32 +603,41 @@
 
 !local pointers:
  character(len=StrKIND),pointer:: pbl_scheme
+ integer,pointer::config_tkebudget
+ integer,pointer::config_mynn_output
 
  integer,dimension(:),pointer:: kpbl
 
  real(kind=RKIND),dimension(:),pointer  :: hpbl
  real(kind=RKIND),dimension(:,:),pointer:: kzh,kzm,kzq
- real(kind=RKIND),dimension(:,:),pointer:: rublten,rvblten,rthblten,rqvblten,rqcblten,rqiblten, &
-                                           rniblten
+ real(kind=RKIND),dimension(:,:),pointer:: rublten,rvblten,rthblten
+ real(kind=RKIND),dimension(:,:),pointer:: rqvblten,rqcblten,rqiblten
+ real(kind=RKIND),dimension(:,:),pointer:: rniblten,rncblten
+ real(kind=RKIND),dimension(:,:),pointer:: rnwfablten,rnifablten
 
 !local pointers for YSU scheme:
  real(kind=RKIND),dimension(:,:),pointer:: exch_h
 
 !local pointers for MYNN scheme:
  real(kind=RKIND),dimension(:),pointer  :: delta,wstar
- real(kind=RKIND),dimension(:,:),pointer:: cov,qke,qsq,tsq,sh3d,tke_pbl,qke_adv,el_pbl,dqke,qbuoy, &
-                                           qdiss,qshear,qwt
-
+ real(kind=RKIND),dimension(:,:),pointer:: cov,qke,qsq,tsq,sh3d,sm3d
+ real(kind=RKIND),dimension(:,:),pointer:: qke_adv,el_pbl
+ real(kind=RKIND),dimension(:,:),pointer:: cldfrac_bl,qi_bl,qc_bl
+ real(kind=RKIND),dimension(:,:),pointer:: dqke,qdiss,qshear,qbuoy,qwt
+ real(kind=RKIND),dimension(:,:),pointer:: edmf_a,edmf_w,edmf_thl
+ real(kind=RKIND),dimension(:,:),pointer:: edmf_qt,edmf_qc,edmf_ent
+ real(kind=RKIND),dimension(:,:),pointer:: sub_thl,sub_sqv,det_thl,det_sqv
 !-----------------------------------------------------------------------------------------------------------------
 
- call mpas_pool_get_config(configs,'config_pbl_scheme',pbl_scheme)
+ call mpas_pool_get_config(configs,'config_pbl_scheme'  ,pbl_scheme)
+ call mpas_pool_get_config(configs,'config_tkebudget'   ,config_tkebudget)
+ call mpas_pool_get_config(configs,'config_mynn_output' ,config_mynn_output)
 
  call mpas_pool_get_array(diag_physics,'kpbl' ,kpbl )
  call mpas_pool_get_array(diag_physics,'hpbl' ,hpbl )
  call mpas_pool_get_array(diag_physics,'kzh'  ,kzh  )
  call mpas_pool_get_array(diag_physics,'kzm'  ,kzm  )
  call mpas_pool_get_array(diag_physics,'kzq'  ,kzq  )
- call mpas_pool_get_array(diag_physics,'delta',delta)
  call mpas_pool_get_array(diag_physics,'wstar',wstar)
 
  call mpas_pool_get_array(tend_physics,'rublten' ,rublten )
@@ -494,7 +651,6 @@
  do i = its,ite
     hpbl(i)  = hpbl_p(i,j)
     kpbl(i)  = kpbl_p(i,j)
-    delta(i) = delta_p(i,j)
     wstar(i) = wstar_p(i,j)
  enddo
  enddo
@@ -520,7 +676,8 @@
 
     case("bl_ysu")
        call mpas_pool_get_array(diag_physics,'exch_h',exch_h)
-
+       call mpas_pool_get_array(diag_physics,'delta',delta)
+       
        do j = jts,jte
        do k = kts,kte
        do i = its,ite
@@ -529,22 +686,48 @@
        enddo
        enddo
 
+       do j = jts,jte
+       do i = its,ite
+          delta(i) = delta_p(i,j)
+       enddo
+       enddo
+       
     case("bl_mynn")
-       call mpas_pool_get_array(diag_physics,'el_pbl'  ,el_pbl  )
-       call mpas_pool_get_array(diag_physics,'cov'     ,cov     )
-       call mpas_pool_get_array(diag_physics,'qke'     ,qke     )
-       call mpas_pool_get_array(diag_physics,'qke_adv' ,qke_adv )
-       call mpas_pool_get_array(diag_physics,'qsq'     ,qsq     )
-       call mpas_pool_get_array(diag_physics,'tsq'     ,tsq     )
-       call mpas_pool_get_array(diag_physics,'tke_pbl' ,tke_pbl )
-       call mpas_pool_get_array(diag_physics,'sh3d'    ,sh3d    )
-       call mpas_pool_get_array(diag_physics,'dqke'    ,dqke    )
-       call mpas_pool_get_array(diag_physics,'qbuoy'   ,qbuoy   )
-       call mpas_pool_get_array(diag_physics,'qdiss'   ,qdiss   )
-       call mpas_pool_get_array(diag_physics,'qshear'  ,qshear  )
-       call mpas_pool_get_array(diag_physics,'qwt'     ,qwt     )
-       call mpas_pool_get_array(tend_physics,'rniblten',rniblten)
-
+       call mpas_pool_get_array(diag_physics,'el_pbl'  , el_pbl   )
+       call mpas_pool_get_array(diag_physics,'cov'     , cov      )
+       call mpas_pool_get_array(diag_physics,'qke'     , qke      )
+       call mpas_pool_get_array(diag_physics,'qke_adv' , qke_adv  )
+       call mpas_pool_get_array(diag_physics,'qsq'     , qsq      )
+       call mpas_pool_get_array(diag_physics,'tsq'     , tsq      )
+       call mpas_pool_get_array(diag_physics,'sh3d'    , sh3d     )
+       call mpas_pool_get_array(diag_physics,'sm3d'    , sm3d     )
+       if (config_tkebudget .gt. 0) then
+          call mpas_pool_get_array(diag_physics,'dqke'    , dqke     )
+          call mpas_pool_get_array(diag_physics,'qbuoy'   , qbuoy    )
+          call mpas_pool_get_array(diag_physics,'qdiss'   , qdiss    )
+          call mpas_pool_get_array(diag_physics,'qshear'  , qshear   )
+          call mpas_pool_get_array(diag_physics,'qwt'     , qwt      )
+       endif
+       if (config_mynn_output .gt. 0) then
+          call mpas_pool_get_array(diag_physics,'edmf_a'   , edmf_a   )
+          call mpas_pool_get_array(diag_physics,'edmf_w'   , edmf_w   )
+          call mpas_pool_get_array(diag_physics,'edmf_thl' , edmf_thl )
+          call mpas_pool_get_array(diag_physics,'edmf_qt'  , edmf_qt  )
+          call mpas_pool_get_array(diag_physics,'edmf_qc'  , edmf_qc  )
+          call mpas_pool_get_array(diag_physics,'edmf_ent' , edmf_ent )
+          call mpas_pool_get_array(diag_physics,'sub_thl'  , sub_thl  )
+          call mpas_pool_get_array(diag_physics,'sub_sqv'  , sub_sqv  )
+          call mpas_pool_get_array(diag_physics,'det_thl'  , det_thl  )
+          call mpas_pool_get_array(diag_physics,'det_sqv'  , det_sqv  )
+       endif
+       call mpas_pool_get_array(diag_physics,'cldfrac_bl',cldfrac_bl)
+       call mpas_pool_get_array(diag_physics,'qc_bl'    ,qc_bl    )
+       call mpas_pool_get_array(diag_physics,'qi_bl'    ,qi_bl    )
+       call mpas_pool_get_array(tend_physics,'rniblten', rniblten )
+       call mpas_pool_get_array(tend_physics,'rncblten', rncblten )
+       call mpas_pool_get_array(tend_physics,'rnwfablten', rnwfablten )
+       call mpas_pool_get_array(tend_physics,'rnifablten', rnifablten )
+       
        do j = jts,jte
        do k = kts,kte
        do i = its,ite
@@ -554,20 +737,55 @@
           qsq(k,i)      = qsq_p(i,k,j)
           tsq(k,i)      = tsq_p(i,k,j)
           sh3d(k,i)     = sh3d_p(i,k,j)
-          tke_pbl(k,i)  = tkepbl_p(i,k,j)
+          sm3d(k,i)     = sm3d_p(i,k,j)
           qke_adv(k,i)  = qkeadv_p(i,k,j)
-          !... outputs:
-          dqke(k,i)     = dqke_p(i,k,j)
-          qbuoy(k,i)    = qbuoy_p(i,k,j)
-          qdiss(k,i)    = qdiss_p(i,k,j)
-          qshear(k,i)   = qshear_p(i,k,j)
-          qwt(k,i)      = qwt_p(i,k,j)
 
+          cldfrac_bl(k,i)= cldfrac_bl_p(i,k,j)
+          qc_bl(k,i)    = qc_bl_p(i,k,j)
+          qi_bl(k,i)    = qi_bl_p(i,k,j)
+
+          rncblten(k,i) = rncblten_p(i,k,j)
           rniblten(k,i) = rniblten_p(i,k,j)
+          rnwfablten(k,i) = rnwfablten_p(i,k,j)
+          rnifablten(k,i) = rnifablten_p(i,k,j)
        enddo
        enddo
        enddo
 
+       !optional output
+       if (config_tkebudget .gt. 0) then
+          do j = jts,jte
+          do k = kts,kte
+          do i = its,ite
+             dqke(k,i)     = dqke_p(i,k,j)
+             qbuoy(k,i)    = qbuoy_p(i,k,j)
+             qdiss(k,i)    = qdiss_p(i,k,j)
+             qshear(k,i)   = qshear_p(i,k,j)
+             qwt(k,i)      = qwt_p(i,k,j)
+          enddo
+          enddo
+          enddo
+       endif
+
+       if (config_mynn_output .gt. 0) then
+          do j = jts,jte
+          do k = kts,kte
+          do i = its,ite
+             edmf_a(k,i)     = edmf_a_p(i,k,j)
+             edmf_w(k,i)     = edmf_w_p(i,k,j)
+             edmf_thl(k,i)   = edmf_thl_p(i,k,j)
+             edmf_qt(k,i)    = edmf_qt_p(i,k,j)
+             edmf_qc(k,i)    = edmf_qc_p(i,k,j)
+             edmf_ent(k,i)   = edmf_ent_p(i,k,j)
+             det_thl(k,i)    = sub_thl_p(i,k,j)
+             det_sqv(k,i)    = sub_sqv_p(i,k,j)
+             det_thl(k,i)    = det_thl_p(i,k,j)
+             det_sqv(k,i)    = det_sqv_p(i,k,j)
+          enddo
+          enddo
+          enddo
+       endif
+      
     case default
 
  end select pbl_select
@@ -593,7 +811,22 @@
 !local pointers:
  logical,pointer:: config_do_restart
  character(len=StrKIND),pointer:: pbl_scheme
-
+ integer,pointer:: config_icloud_bl
+ integer,pointer:: config_tkebudget
+ integer,pointer:: config_mynn_mixlength
+ integer,pointer:: config_mynn_cloudpdf
+ integer,pointer:: config_mynn_edmf
+ integer,pointer:: config_mynn_edmf_mom
+ integer,pointer:: config_mynn_edmf_tke
+ integer,pointer:: config_mynn_mixscalars
+ integer,pointer:: config_mynn_mixqt
+ integer,pointer:: config_mynn_cloudmix
+ integer,pointer:: config_mynn_output
+ integer,pointer:: config_spp_pbl
+ real   ,pointer:: config_mynn_closure
+ logical,pointer:: config_mynn_tkeadvect
+ logical,pointer:: config_do_DAcycling
+      
 !local variables:
  integer:: initflag
  integer:: i,k,j
@@ -601,7 +834,7 @@
 !CCPP-compliant flags:
  character(len=StrKIND):: errmsg
  integer:: errflg
-
+ integer, pointer :: indexToCellID(:)
 !-----------------------------------------------------------------------------------------------------------------
 !call mpas_log_write('')
 !call mpas_log_write('--- enter subroutine driver_pbl:')
@@ -610,9 +843,24 @@
  errmsg = ' '
  errflg = 0
 
- call mpas_pool_get_config(configs,'config_do_restart',config_do_restart)
- call mpas_pool_get_config(configs,'config_pbl_scheme',pbl_scheme       )
-
+ call mpas_pool_get_config(configs,'config_do_restart'     ,config_do_restart     )
+ call mpas_pool_get_config(configs,'config_do_DAcycling'   ,config_do_DAcycling   )
+ call mpas_pool_get_config(configs,'config_pbl_scheme'     ,pbl_scheme            )
+ call mpas_pool_get_config(configs,'config_icloud_bl'      ,config_icloud_bl      )
+ call mpas_pool_get_config(configs,'config_mynn_output'    ,config_mynn_output    )
+ call mpas_pool_get_config(configs,'config_mynn_cloudpdf'  ,config_mynn_cloudpdf  )
+ call mpas_pool_get_config(configs,'config_mynn_mixlength' ,config_mynn_mixlength )
+ call mpas_pool_get_config(configs,'config_mynn_edmf'      ,config_mynn_edmf      )
+ call mpas_pool_get_config(configs,'config_mynn_edmf_mom'  ,config_mynn_edmf_mom  )
+ call mpas_pool_get_config(configs,'config_mynn_edmf_tke'  ,config_mynn_edmf_tke  )
+ call mpas_pool_get_config(configs,'config_mynn_mixscalars',config_mynn_mixscalars)
+ call mpas_pool_get_config(configs,'config_mynn_mixqt'     ,config_mynn_mixqt     )
+ call mpas_pool_get_config(configs,'config_mynn_cloudmix'  ,config_mynn_cloudmix  ) 
+ call mpas_pool_get_config(configs,'config_mynn_closure'   ,config_mynn_closure   )
+ call mpas_pool_get_config(configs,'config_mynn_tkeadvect' ,config_mynn_tkeadvect )
+ call mpas_pool_get_config(configs,'config_tkebudget'      ,config_tkebudget )
+ call mpas_pool_get_config(configs,'config_spp_pbl'        ,config_spp_pbl )
+ call mpas_pool_get_array(mesh,'indexToCellID',indexToCellID)
 !copy MPAS arrays to local arrays:
  call pbl_from_MPAS(configs,mesh,sfc_input,diag_physics,tend_physics,its,ite)
 
@@ -651,37 +899,77 @@
        call mpas_timer_stop('bl_ysu')
 
     case("bl_mynn")
-       call mpas_timer_start('MYNN_pbl')
-       call  mynn_bl_driver ( &
-                 p        = pres_hyd_p  , exner    = pi_p        , ps       = psfc_p     , &
-                 th       = th_p        , dz       = dz_p        , u        = u_p        , &
-                 v        = v_p         , qv       = qv_p        , qc       = qc_p       , &
-                 qi       = qi_p        , qni      = ni_p        , rho      = rho_p      , &
-                 du       = rublten_p   , dv       = rvblten_p   , dth      = rthblten_p , &
-                 dqv      = rqvblten_p  , dqc      = rqcblten_p  , dqi      = rqiblten_p , &
-                 dqni     = rniblten_p  , flag_qc  = f_qc        , flag_qnc = f_qnc      , &
-                 flag_qi  = f_qi        , flag_qni = f_qni       , kpbl     = kpbl_p     , &
-                 pblh     = hpbl_p      , xland    = xland_p     , ts       = tsk_p      , &
-                 hfx      = hfx_p       , qfx      = qfx_p       , ch       = ch_p       , &
-                 sh3d     = sh3d_p      , tsq      = tsq_p       , qsq      = qsq_p      , &
-                 cov      = cov_p       , el_pbl   = elpbl_p     , qsfc     = qsfc_p     , &
-                 qcg      = qcg_p       , ust      = ust_p       , rmol     = rmol_p     , &
-                 wspd     = wspd_p      , wstar    = wstar_p     , delta    = delta_p    , &
-                 delt     = dt_pbl      , k_h      = kzh_p       , k_m      = kzm_p      , &
-                 k_q      = kzq_p       , uoce     = uoce_p      , voce     = voce_p     , &
-                 qke      = qke_p       , qke_adv  = qkeadv_p    , vdfg     = vdfg_p     , &
-                 tke_pbl  = tkepbl_p    , dqke     = dqke_p      , qwt      = qwt_p      , &
-                 qshear   = qshear_p    , qbuoy    = qbuoy_p     , qdiss    = qdiss_p    , &
-                 initflag          = initflag          ,                                   &
-                 grav_settling     = grav_settling     ,                                   &
-                 bl_mynn_cloudpdf  = bl_mynn_cloudpdf  ,                                   &
-                 bl_mynn_tkeadvect = bl_mynn_tkeadvect ,                                   &
-                 bl_mynn_tkebudget = bl_mynn_tkebudget ,                                   &
-                 ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde   , &
-                 ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme   , &
-                 its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte     &
-                            )
-       call mpas_timer_stop('MYNN_pbl')
+       call mpas_timer_start('bl_mynnedmf')
+       call mynnedmf_wrapper_run ( &
+                 !3d input/output
+                 p        = pres_hyd_p    , exner    = pi_p          , t3d      = t_p          , &
+                 th       = th_p          , dz       = dz_p          , rho      = rho_p        , &
+                 u        = u_p           , v        = v_p           , w        = w_p          , &
+                 qv       = qv_p          , qc       = qc_p          , qi       = qi_p         , &
+                 qs       = qs_p          , qni      = ni_p          , qnc      = nc_p         , &
+                 qnwfa    = nwfa_p        , qnifa    = nifa_p        , qnbca    = nbca_p       , &
+                 qc_bl    = qc_bl_p       , qi_bl    = qi_bl_p       , cldfra_bl= cldfrac_bl_p , &
+                 pattern_spp_pbl= pattern_spp_pbl_p,                                             &
+                 !tendency arrays
+                 rublten  = rublten_p     , rvblten  = rvblten_p     , rthblten = rthblten_p   , &
+                 rqvblten = rqvblten_p    , rqcblten = rqcblten_p    , rqiblten = rqiblten_p   , &
+                 rqsblten = rqsblten_p    , rqncblten = rncblten_p   , rqniblten = rniblten_p  , &
+                 rqnwfablten=rnwfablten_p , rqnifablten=rnifablten_p , rqnbcablten=rnbcablten_p, &
+                 rthraten = rthraten_p    ,                                                      &
+                 !moist flags
+                 flag_qc  = f_qc          , flag_qnc = f_qnc         , flag_qs  = f_qs         , &
+                 flag_qi  = f_qi          , flag_qni = f_qni         , flag_qnwfa=f_nwfa       , &
+                 flag_qnifa=f_nifa        , flag_qnbca=.false.       ,                           &
+                 !2d arrays
+                 kpbl     = kpbl_p        , pblh     = hpbl_p        , xland    = xland_p      , &
+                 hfx      = hfx_p         , qfx      = qfx_p         , ch       = ch_p         , &
+                 qsfc     = qsfc_p        , ust      = ust_p         , rmol     = rmol_p       , &
+                 wspd     = wspd_p        , dxc      = dx_p          , delt     = dt_pbl       , &
+                 uoce     = uoce_p        , voce     = voce_p        , ts       = tsk_p        , &
+                 ps       = psfc_p        , znt      = znt_p         , maxmf    = maxmf_p      , &
+                 maxwidth = maxwidth_p    , ztop_plume=ztop_plume_p  ,                           &
+                 !turbulence arrays
+                 qke      = qke_p         , qke_adv  = qkeadv_p      , el_pbl   = elpbl_p      , &
+                 sh3d     = sh3d_p        , sm3d     = sm3d_p        , cov      = cov_p        , &
+                 tsq      = tsq_p         , qsq      = qsq_p         , kh       = kzh_p        , &
+                 km       = kzm_p         ,                                                      &
+                 !tke budget arrays
+                 dqke     = dqke_p        , qwt      = qwt_p         ,                           &
+                 qshear   = qshear_p      , qbuoy    = qbuoy_p       , qdiss    = qdiss_p      , &
+                 !optional output
+      	      	 edmf_a   = edmf_a_p      , edmf_w   = edmf_w_p      , edmf_thl = edmf_thl_p   , &
+                 edmf_qc  = edmf_qc_p     , edmf_qt  = edmf_qt_p     , edmf_ent = edmf_ent_p   , &
+                 sub_thl  = sub_thl_p     , sub_sqv  = sub_sqv_p     , det_thl  = det_thl_p    , &
+                 det_sqv  = det_sqv_p     ,                                                      &
+#if (WRF_CHEM == 1)
+                 !smoke/chem---not yet added
+                 mix_chem = mix_chem      , chem3d   = chem_p        , vd3d     = vd_p         , &
+                 nchem    = nchem         , kdvel    = kdvel         , ndvel    = ndvel        , &
+                 num_vert_mix=numvertmix  , frp_mean = frp_mean_p    , emis_ant_no=emis_ant_no_p,&
+                 enh_mix  = enh_mix       ,                                                      &
+#endif
+                 !configuration parameters
+                 initflag                 = initflag                 ,                           &
+                 restart                  = config_do_restart        ,                           &
+                 cycling                  = config_do_DAcycling      ,                           &
+                 bl_mynn_cloudpdf         = config_mynn_cloudpdf     ,                           &
+                 bl_mynn_tkeadvect        = config_mynn_tkeadvect    ,                           &
+                 tke_budget               = config_tkebudget         ,                           &
+                 bl_mynn_output           = config_mynn_output       ,                           &
+                 bl_mynn_mixlength        = config_mynn_mixlength    ,                           &
+                 bl_mynn_edmf             = config_mynn_edmf         ,                           &
+                 bl_mynn_edmf_mom         = config_mynn_edmf_mom     ,                           &
+                 bl_mynn_edmf_tke         = config_mynn_edmf_tke     ,                           &
+                 bl_mynn_mixscalars       = config_mynn_mixscalars   ,                           &
+                 bl_mynn_mixqt            = config_mynn_mixqt        ,                           &
+                 bl_mynn_cloudmix         = config_mynn_cloudmix     ,                           &
+                 bl_mynn_closure          = config_mynn_closure      ,                           &
+                 icloud_bl                = config_icloud_bl         ,                           &
+                 spp_pbl                  = config_spp_pbl           ,                           &
+                 ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde         , &
+                 ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme         , &
+                 its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte         ) 
+       call mpas_timer_stop('bl_mynnedmf')
 
     case default
 

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_sfclayer.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_sfclayer.F
@@ -9,6 +9,7 @@
  module mpas_atmphys_driver_sfclayer
  use mpas_kind_types
  use mpas_pool_routines
+ use mpas_dmpar
  use mpas_timer, only : mpas_timer_start, mpas_timer_stop
 
  use mpas_atmphys_constants
@@ -219,12 +220,6 @@
           if(.not.allocated(ch_sea)) allocate(ch_sea(ims:ime,jms:jme))
        endif
 
-       if(.not.allocated(cov_p)     ) allocate(cov_p(ims:ime,kms:kme,jms:jme)     )
-       if(.not.allocated(qsq_p)     ) allocate(qsq_p(ims:ime,kms:kme,jms:jme)     )
-       if(.not.allocated(tsq_p)     ) allocate(tsq_p(ims:ime,kms:kme,jms:jme)     )
-       if(.not.allocated(sh3d_p)    ) allocate(sh3d_p(ims:ime,kms:kme,jms:jme)    )
-       if(.not.allocated(elpbl_p)   ) allocate(elpbl_p(ims:ime,kms:kme,jms:jme)   )
-
     case default
 
  end select sfclayer_select
@@ -347,12 +342,6 @@
           if(allocated(ch_sea)) deallocate(ch_sea)
        endif
 
-       if(allocated(cov_p)     ) deallocate(cov_p     )
-       if(allocated(qsq_p)     ) deallocate(qsq_p     )
-       if(allocated(tsq_p)     ) deallocate(tsq_p     )
-       if(allocated(sh3d_p)    ) deallocate(sh3d_p    )
-       if(allocated(elpbl_p)   ) deallocate(elpbl_p   )
-
     case default
 
  end select sfclayer_select
@@ -391,7 +380,6 @@
 
 !local pointers specific to mynn:
  real(kind=RKIND),dimension(:),pointer:: ch,qcg,snowh
- real(kind=RKIND),dimension(:,:),pointer:: cov,el_pbl,qsq,sh3d,tsq
 
 !-----------------------------------------------------------------------------------------------------------------
 
@@ -581,11 +569,6 @@
        !input variables:
        call mpas_pool_get_array(diag_physics,'qcg'   ,qcg   )
        call mpas_pool_get_array(sfc_input   ,'snowh' ,snowh )
-       call mpas_pool_get_array(diag_physics,'cov'   ,cov   )
-       call mpas_pool_get_array(diag_physics,'el_pbl',el_pbl)
-       call mpas_pool_get_array(diag_physics,'qsq'   ,qsq   )
-       call mpas_pool_get_array(diag_physics,'sh3d'  ,sh3d  )
-       call mpas_pool_get_array(diag_physics,'tsq'   ,tsq   )
        !inout variables:
        call mpas_pool_get_array(diag_physics,'ch',ch        )
 
@@ -599,19 +582,6 @@
           if(config_frac_seaice) then
              ch_sea(i,j) = ch(i)
           endif
-       enddo
-       enddo
-
-       do j = jts,jte
-       do k = kts,kte
-       do i = its,ite
-          !input variables:
-          cov_p(i,k,j)      = cov(k,i)
-          qsq_p(i,k,j)      = qsq(k,i)
-          tsq_p(i,k,j)      = tsq(k,i)
-          sh3d_p(i,k,j)     = sh3d(k,i)
-          elpbl_p(i,k,j)    = el_pbl(k,i)
-       enddo
        enddo
        enddo
 
@@ -652,7 +622,6 @@
 
 !local pointers specific to mynn:
  real(kind=RKIND),dimension(:),pointer:: ch,qcg
- real(kind=RKIND),dimension(:,:),pointer:: cov,el_pbl,qsq,sh3d,tsq
 
 !-----------------------------------------------------------------------------------------------------------------
 
@@ -1049,11 +1018,12 @@
        call mpas_timer_stop('sf_monin_obukhov_rev')
 
     case("sf_mynn")
-       call mpas_timer_start('MYNN_sfclay')
+       call mpas_timer_start('sf_mynn')
+       call mpas_log_write('--- enter subroutine sfclay_mynn:')
        call sfclay_mynn( &
-                   p3d      = pres_hyd_p , pi3d     = pi_p       , psfcpa    = psfc_p     , &
+                   p3d      = pres_hyd_p , psfcpa    = psfc_p     , &
                    th3d     = th_p       , t3d      = t_p        , u3d       = u_p        , &
-                   v3d      = v_p        , qv3d     = qv_p       , qc3d      = qc_p       , &
+                   v3d      = v_p        , qv3d     = qv_p       ,  &
                    rho3d    = rho_p      , dz8w     = dz_p       , cp        = cp         , &
                    g        = gravity    , rovcp    = rcp        , R         = R_d        , &
                    xlv      = xlv        , chs      = chs_p      , chs2      = chs2_p     , &
@@ -1069,13 +1039,11 @@
                    gz1oz0   = gz1oz0_p   , wspd     = wspd_p     , br        = br_p       , &
                    isfflx   = isfflx     , dx       = dx         , svp1      = svp1       , &
                    svp2     = svp2       , svp3     = svp3       , svpt0     = svpt0      , &
-                   ep1      = ep_1       , ep2      = ep_2       , karman    = karman     , &
-                   dxCell   = dx_p       , ustm     = ustm_p     , ck        = ck_p       , &
+                   karman   = karman     , ep1      = ep_1       , ep2       = ep_2       , &
+                   dx2d     = dx_p       , ustm     = ustm_p     , ck        = ck_p       , &
                    cka      = cka_p      , cd       = cd_p       , cda       = cda_p      , &
                    isftcflx = isftcflx   , iz0tlnd  = iz0tlnd    , itimestep = initflag   , &
-                   ch       = ch_p       , cov      = cov_p      , tsq       = tsq_p      , &
-                   qsq      = qsq_p      , sh3d     = sh3d_p     , el_pbl    = elpbl_p    , &
-                   qcg      = qcg_p      , bl_mynn_cloudpdf = bl_mynn_cloudpdf            , &
+                   ch       = ch_p       ,  spp_pbl = 0          , qcg       = qcg_p      , &
                    ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde  , &
                    ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme  , &
                    its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte    &
@@ -1083,9 +1051,9 @@
 
        if(config_frac_seaice) then
           call sfclay_mynn( &
-                      p3d      = pres_hyd_p , pi3d     = pi_p       , psfcpa    = psfc_p     , &
+                      p3d      = pres_hyd_p , psfcpa    = psfc_p     , &
                       th3d     = th_p       , t3d      = t_p        , u3d       = u_p        , &
-                      v3d      = v_p        , qv3d     = qv_p       , qc3d      = qc_p       , &
+                      v3d      = v_p        , qv3d     = qv_p       , &
                       rho3d    = rho_p      , dz8w     = dz_p       , cp        = cp         , &
                       g        = gravity    , rovcp    = rcp        , R         = R_d        , &
                       xlv      = xlv        , chs      = chs_sea    , chs2      = chs2_sea   , &
@@ -1102,18 +1070,16 @@
                       isfflx   = isfflx     , dx       = dx         , svp1      = svp1       , &
                       svp2     = svp2       , svp3     = svp3       , svpt0     = svpt0      , &
                       ep1      = ep_1       , ep2      = ep_2       , karman    = karman     , &
-                      dxCell   = dx_p       , ustm     = ustm_sea   , ck        = ck_sea     , &
+                      dx2d     = dx_p       , ustm     = ustm_sea   , ck        = ck_sea     , &
                       cka      = cka_sea    , cd       = cd_sea     , cda       = cda_sea    , &
                       isftcflx = isftcflx   , iz0tlnd  = iz0tlnd    , itimestep = initflag   , &
-                      ch       = ch_sea     , cov      = cov_p      , tsq       = tsq_p      , &
-                      qsq      = qsq_p      , sh3d     = sh3d_p     , el_pbl    = elpbl_p    , &
-                      qcg      = qcg_p      , bl_mynn_cloudpdf = bl_mynn_cloudpdf            , &
+                      ch       = ch_sea     , spp_pbl  = 0          , qcg       = qcg_p      ,  &
                       ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde  , &
                       ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme  , &
                       its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte    &
                           )
        endif
-       call mpas_timer_stop('MYNN_sfclay')
+       call mpas_timer_stop('sf_mynn')
 
     case default
 

--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -117,7 +117,9 @@
  pbl_select: select case (trim(pbl_scheme))
     case("bl_mynn")
        if(.not.allocated(ni_p)) allocate(ni_p(ims:ime,kms:kme,jms:jme))
-
+       if(.not.allocated(nc_p)) allocate(nc_p(ims:ime,kms:kme,jms:jme))
+       if(.not.allocated(nwfa_p)) allocate(nwfa_p(ims:ime,kms:kme,jms:jme))
+       if(.not.allocated(nifa_p)) allocate(nifa_p(ims:ime,kms:kme,jms:jme))
     case default
 
  end select pbl_select
@@ -181,7 +183,9 @@
  pbl_select: select case (trim(pbl_scheme))
     case("bl_mynn")
        if(allocated(ni_p)) deallocate(ni_p)
-
+       if(allocated(nc_p)) deallocate(nc_p)
+       if(allocated(nwfa_p)) deallocate(nwfa_p)
+       if(allocated(nifa_p)) deallocate(nifa_p)
     case default
 
  end select pbl_select
@@ -216,7 +220,7 @@
  character(len=StrKIND),pointer:: pbl_scheme
 
  integer,pointer:: index_qv,index_qc,index_qr,index_qi,index_qs,index_qg
- integer,pointer:: index_ni
+ integer,pointer:: index_ni,index_nc,index_nwfa,index_nifa
 
  real(kind=RKIND),dimension(:),pointer    :: latCell,lonCell
  real(kind=RKIND),dimension(:),pointer    :: fzm,fzp,rdzw
@@ -225,7 +229,7 @@
  real(kind=RKIND),dimension(:,:),pointer  :: zz,exner,pressure_b,rtheta_p,rtheta_b
  real(kind=RKIND),dimension(:,:),pointer  :: rho_zz,theta_m,pressure_p,u,v,w
  real(kind=RKIND),dimension(:,:),pointer  :: qv,qc,qr,qi,qs,qg
- real(kind=RKIND),dimension(:,:),pointer  :: ni
+ real(kind=RKIND),dimension(:,:),pointer  :: ni,nc,nwfa,nifa
  real(kind=RKIND),dimension(:,:,:),pointer:: scalars
 
 !local variables:
@@ -322,11 +326,20 @@
     case("bl_mynn")
        call mpas_pool_get_dimension(state,'index_ni',index_ni)
        ni => scalars(index_ni,:,:)
-
+       call mpas_pool_get_dimension(state,'index_nc',index_nc)
+       nc => scalars(index_nc,:,:)
+       call mpas_pool_get_dimension(state,'index_nwfa',index_nwfa)
+       nwfa => scalars(index_nwfa,:,:)
+       call mpas_pool_get_dimension(state,'index_nifa',index_nifa)
+       nifa => scalars(index_nifa,:,:)
+       
        do j = jts,jte
        do k = kts,kte
        do i = its,ite
           ni_p(i,k,j) = max(0.,ni(k,i))
+          nc_p(i,k,j) = max(0.,nc(k,i))
+	  nwfa_p(i,k,j) = max(0.,nwfa(k,i))
+	  nifa_p(i,k,j) = max(0.,nifa(k,i))
        enddo
        enddo
        enddo

--- a/src/core_atmosphere/physics/mpas_atmphys_todynamics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_todynamics.F
@@ -97,7 +97,7 @@
 
  integer:: i,iCell,k,n
  integer,pointer:: index_qv, index_qc, index_qr, index_qi, index_qs, index_qg
- integer,pointer:: index_ni
+ integer,pointer:: index_ni,index_nc,index_nwfa,index_nifa
  integer,pointer:: nCells,nCellsSolve,nEdges,nEdgesSolve
 
  real(kind=RKIND),dimension(:,:),pointer:: mass          ! time level 2 rho_zz
@@ -106,7 +106,8 @@
  real(kind=RKIND),dimension(:,:,:),pointer:: scalars
  real(kind=RKIND),dimension(:,:),pointer:: rthblten,rqvblten,rqcblten, &
                                            rqiblten,rublten,rvblten
- real(kind=RKIND),dimension(:,:),pointer:: rniblten
+ real(kind=RKIND),dimension(:,:),pointer:: rniblten,rncblten,    &
+                                           rnwfablten,rnifablten
  real(kind=RKIND),dimension(:,:),pointer:: rthcuten,rqvcuten,rqccuten, &
                                            rqrcuten,rqicuten,rqscuten, &
                                            rucuten,rvcuten
@@ -148,7 +149,10 @@
  call mpas_pool_get_dimension(state, 'index_qs', index_qs)
  call mpas_pool_get_dimension(state, 'index_qg', index_qg)
  call mpas_pool_get_dimension(state, 'index_ni', index_ni)
-
+ call mpas_pool_get_dimension(state, 'index_ni', index_nc)
+ call mpas_pool_get_dimension(state, 'index_ni', index_nwfa)
+ call mpas_pool_get_dimension(state, 'index_ni', index_nifa)
+      
  call mpas_pool_get_array(tend_physics, 'rublten', rublten)
  call mpas_pool_get_array(tend_physics, 'rvblten', rvblten)
  call mpas_pool_get_array(tend_physics, 'rublten_Edge', rublten_Edge)
@@ -157,6 +161,9 @@
  call mpas_pool_get_array(tend_physics, 'rqcblten', rqcblten)
  call mpas_pool_get_array(tend_physics, 'rqiblten', rqiblten)
  call mpas_pool_get_array(tend_physics, 'rniblten', rniblten)
+ call mpas_pool_get_array(tend_physics, 'rncblten', rncblten)
+ call mpas_pool_get_array(tend_physics, 'rnwfablten', rnwfablten)
+ call mpas_pool_get_array(tend_physics, 'rnifablten', rnifablten)
 
  call mpas_pool_get_array(tend_physics, 'rucuten', rucuten)
  call mpas_pool_get_array(tend_physics, 'rvcuten', rvcuten)
@@ -205,6 +212,9 @@
  if (.not. associated(rqvblten)) allocate(rqvblten(0,0))
  if (.not. associated(rqcblten)) allocate(rqcblten(0,0))
  if (.not. associated(rqiblten)) allocate(rqiblten(0,0))
+ if (.not. associated(rncblten)) allocate(rncblten(0,0))
+ if (.not. associated(rnwfablten)) allocate(rnwfablten(0,0))
+ if (.not. associated(rnifablten)) allocate(rnifablten(0,0))
  if (.not. associated(rthcuten)) allocate(rthcuten(0,0))
  if (.not. associated(rqvcuten)) allocate(rqvcuten(0,0))
  if (.not. associated(rqccuten)) allocate(rqccuten(0,0))
@@ -213,11 +223,13 @@
  call physics_get_tend_work(block, mesh, nCells, nEdges, nCellsSolve, nEdgesSolve, &
                            rk_step, dynamics_substep, &
                            config_pbl_scheme, config_convection_scheme, config_radt_lw_scheme, config_radt_sw_scheme, &
-                           index_qv, index_qc, index_qr, index_qi, index_qs, index_ni, &
+                           index_qv, index_qc, index_qr, index_qi, index_qs, &
+                           index_ni, index_nc, index_nwfa, index_nifa, &
                            rublten, rvblten, mass_edge, rublten_Edge, &
                            tend_ru_physics, &
                            rucuten, rvcuten, rucuten_Edge, &
                            tend_th, tend_scalars, mass, rthblten, rqvblten, rqcblten, rqiblten, rniblten, &
+			   rncblten, rnwfablten, rnifablten, &
                            rthcuten, rqvcuten, rqccuten, rqrcuten, rqicuten, rqscuten, &
                            rthratenlw, rthratensw, &
                            tend_u_phys, &
@@ -242,6 +254,9 @@
  if (size(rqvblten) == 0) deallocate(rqvblten)
  if (size(rqcblten) == 0) deallocate(rqcblten)
  if (size(rqiblten) == 0) deallocate(rqiblten)
+ if (size(rncblten) == 0) deallocate(rncblten)
+ if (size(rnwfablten) == 0) deallocate(rnwfablten)
+ if (size(rnifablten) == 0) deallocate(rnifablten)
  if (size(rthcuten) == 0) deallocate(rthcuten)
  if (size(rqvcuten) == 0) deallocate(rqvcuten)
  if (size(rqccuten) == 0) deallocate(rqccuten)
@@ -272,9 +287,11 @@
                                  rk_step, dynamics_substep, &
                                  config_pbl_scheme, config_convection_scheme, config_radt_lw_scheme, config_radt_sw_scheme, &
                                  index_qv, index_qc, index_qr, index_qi, index_qs, index_ni, &
+                                 index_nc, index_nwfa, index_nifa, &
                                  rublten, rvblten, mass_edge, rublten_Edge, tend_u, &
                                  rucuten, rvcuten, rucuten_Edge, &
                                  tend_th, tend_scalars, mass, rthblten, rqvblten, rqcblten, rqiblten, rniblten, &
+				 rncblten, rnwfablten, rnifablten, &
                                  rthcuten, rqvcuten, rqccuten, rqrcuten, rqicuten, rqscuten, &
                                  rthratenlw, rthratensw, &
                                  tend_u_phys, &
@@ -295,7 +312,8 @@
     character(len=StrKIND), intent(in) :: config_convection_scheme
     character(len=StrKIND), intent(in) :: config_radt_lw_scheme
     character(len=StrKIND), intent(in) :: config_radt_sw_scheme
-    integer, intent(in) :: index_qv, index_qc, index_qr, index_qi, index_qs, index_ni
+    integer, intent(in) :: index_qv, index_qc, index_qr, index_qi, index_qs, &
+                           index_ni, index_nc, index_nwfa, index_nifa
     real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: rublten
     real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: rvblten
     real (kind=RKIND), dimension(nVertLevels,nEdges+1), intent(in) :: mass_edge
@@ -312,6 +330,9 @@
     real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: rqcblten
     real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: rqiblten
     real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: rniblten
+    real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: rncblten
+    real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: rnwfablten
+    real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: rnifablten
     real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: rthcuten
     real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: rqvcuten
     real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: rqccuten
@@ -362,6 +383,9 @@
              do i = 1, nCellsSolve
              do k = 1, nVertLevels
                 tend_scalars(index_ni,k,i) = tend_scalars(index_ni,k,i) + rniblten(k,i)*mass(k,i)
+                tend_scalars(index_nc,k,i) = tend_scalars(index_nc,k,i) + rncblten(k,i)*mass(k,i)
+		tend_scalars(index_nwfa,k,i) = tend_scalars(index_nwfa,k,i) + rnwfablten(k,i)*mass(k,i)
+		tend_scalars(index_nifa,k,i) = tend_scalars(index_nifa,k,i) + rnifablten(k,i)*mass(k,i)
              enddo
              enddo
    

--- a/src/core_atmosphere/physics/mpas_atmphys_vars.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_vars.F
@@ -198,7 +198,8 @@
     ni_p,             &!
     nr_p,             &!
     nwfa_p,           &!
-    nifa_p             !
+    nifa_p,           &!
+    nbca_p
 
 !... arrays located at w (vertical velocity) points, or at interface between layers:
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
@@ -250,7 +251,10 @@
 
  logical,parameter:: &
     f_qnc = .true.,   &!
-    f_qni = .true.     !
+    f_qni = .true.,   &!
+    f_nwfa = .true.,  &
+    f_nifa = .true.,  &
+    f_nbca = .true.
 
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     f_ice,            &!fraction of cloud ice (used in WRF only).
@@ -396,31 +400,70 @@
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     kzh_p,            &!
     kzm_p,            &!
-    kzq_p              !
+    kzq_p,            &!
+    exch_h_p,         &!exchange coefficient for heat                                                    [K s-1]
+    exch_m_p           !exchange coefficient for momentum                                                [K s-1]
 
 !... MYNN PBL scheme (module_bl_mynn.F):
- integer,parameter:: grav_settling = 0
-
- logical,parameter:: bl_mynn_tkeadvect = .false.!
- integer,parameter:: bl_mynn_tkebudget = 0      !
- integer,parameter:: bl_mynn_cloudpdf  = 0      !
-
- real(kind=RKIND),dimension(:,:),allocatable:: &
-    vdfg_p             !
+ logical,parameter:: bl_mynn_tkeadvect  = .false.!
+ integer,parameter:: tkebudget          = 0      !
+ integer,parameter:: bl_mynn_cloudpdf   = 2      !
+ integer,parameter:: bl_mynn_cloudmix   = 1      !
+ integer,parameter:: bl_mynn_mixlength  = 1
+ integer,parameter:: bl_mynn_edmf       = 1      !
+ integer,parameter:: bl_mynn_edmf_mom   = 1      !
+ integer,parameter:: bl_mynn_edmf_tke   = 0      !
+ integer,parameter:: bl_mynn_output     = 0      !
+ integer,parameter:: bl_mynn_mixscalars = 1      !
+ integer,parameter:: bl_mynn_mixqt      = 0
+ logical,parameter:: flag_qnwfa         = .false.
+ logical,parameter:: flag_qnifa         = .false.
+ logical,parameter:: flag_qnbca         = .false.
+ real,parameter   :: bl_mynn_closure    = 2.6
+ integer,parameter:: spp_pbl            = 0
+ 
+real(kind=RKIND),dimension(:,:),allocatable:: &
+    vdfg_p,             &
+    maxmf_p,            & !
+    maxwidth_p,         &
+    ztop_plume_p
 
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
-    dqke_p,           &!
-    qbuoy_p,          &!
-    qdiss_p,          &!
-    qke_p,            &!
-    qkeadv_p,         &!
-    qshear_p,         &!
-    qwt_p,            &!
-    tkepbl_p           !
+    dqke_p,            &!
+    qbuoy_p,           &!
+    qdiss_p,           &!
+    qshear_p,          &!
+    qwt_p,             &!
+    qke_p,             &!
+    qkeadv_p,          &!
+    elpbl_p,           &
+    sm3d_p,            &!stability function for momentum
+    sh3d_p,            &!stability function for heat
+    qc_bl_p,           &!sgs clouds
+    qi_bl_p,           &!sgs clouds
+    cldfrac_bl_p,      &!sgs_clouds
+    edmf_a_p,          &!optional output
+    edmf_w_p,          &
+    edmf_thl_p,        &
+    edmf_qt_p, 	       &
+    edmf_qc_p,         &
+    edmf_ent_p,        &
+    sub_thl_p,         &
+    sub_sqv_p, 	       &
+    det_thl_p,         &
+    det_sqv_p
+    
+ real(kind=RKIND),dimension(:,:,:),allocatable:: &
+    rniblten_p,        &!
+    rncblten_p,        &! Qnc tendency due to PBL parameterization                                    [# kg-1 s-1]
+    rqsblten_p,        &
+    rnwfablten_p,      &
+    rnifablten_p,      &
+    rnbcablten_p
 
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
-    rniblten_p         !
-
+    pattern_spp_pbl_p
+      
 !=================================================================================================================
 !... variables and arrays related to parameterization of gravity wave drag over orography:
 !=================================================================================================================
@@ -525,9 +568,7 @@
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     cov_p,            &!liquid water-liquid water potential temperature covariance                       [K kg/kg]
     qsq_p,            &!liquid water variance                                                          [(kg/kg)^2]
-    tsq_p,            &!liquid water potential temperature variance                                          [K^2]
-    sh3d_p,           &!stability function for heat                                                            [-]
-    elpbl_p            !length scale from PBL                                                                  [m]
+    tsq_p              !liquid water potential temperature variance                                          [K^2]
 
 !=================================================================================================================
 !... variables and arrays related to parameterization of seaice:

--- a/src/core_atmosphere/physics/physics_wrf/Makefile
+++ b/src/core_atmosphere/physics/physics_wrf/Makefile
@@ -9,7 +9,9 @@ OBJS = \
 	libmassv.o                     \
 	module_bep_bem_helper.o        \
 	module_bl_gwdo.o               \
+	module_bl_mynn_common.o        \
 	module_bl_mynn.o               \
+	module_bl_mynn_wrapper.o       \
 	module_bl_ysu.o                \
 	module_cam_error_function.o    \
 	module_cam_shr_kind_mod.o      \
@@ -47,8 +49,16 @@ physics_wrf: $(OBJS)
 	ar -ru ./../libphys.a $(OBJS)
 
 # DEPENDENCIES:
+module_bl_mynn_common.o: \
+	../mpas_atmphys_constants.o
+
 module_bl_mynn.o: \
-	module_cam_error_function.o
+	module_cam_error_function.o \
+	module_bl_mynn_common.o	
+
+module_bl_mynn_wrapper.o: \
+        module_bl_mynn.o \
+	module_bl_mynn_common.o
 
 module_cam_support.o: \
 	module_cam_shr_kind_mod.o
@@ -72,10 +82,6 @@ module_sf_bep_bem.o: \
 	module_bep_bem_helper.o \
 	module_sf_bem.o \
 	module_sf_urban.o
-
-module_sf_mynn.o: \
-	module_bl_mynn.o \
-	module_sf_sfclay.o
 
 module_sf_noahdrv.o: \
 	module_sf_bem.o \

--- a/src/core_atmosphere/physics/physics_wrf/module_bl_mynn.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_bl_mynn.F
@@ -1,186 +1,54 @@
-!==================================================================================================
-! copied for implementation in MPAS from WRF version 3.6.1.
-
-! modifications made to sourcecode:
-! * used preprocessing option to replace module_model_constants with mpas_atmphys_constants.
-! * used preprocessing option to not compile subroutine mynn_bl_init_driver.
-!   Laura D. Fowler (laura@ucar.edu) / 2014-09-25.
-
-!==================================================================================================
-
-! translated from NN f77 to F90 and put into WRF by Mariusz Pagowski
-! NOAA/GSD & CIRA/CSU, Feb 2008
-! changes to original code:
-! 1. code is 1d (in z)
-! 2. no advection of TKE, covariances and variances 
-! 3. Cranck-Nicholson replaced with the implicit scheme
-! 4. removed terrain dependent grid since input in WRF in actual
-!    distances in z[m]
-! 5. cosmetic changes to adhere to WRF standard (remove common blocks, 
-!            intent etc)
-!-------------------------------------------------------------------
-!Modifications implemented by Joseph Olson NOAA/GSD/AMB - CU/CIRES
-!(approved by Mikio Nakanishi or under consideration):
-! 1. Addition of BouLac mixing length in the free atmosphere.
-! 2. Changed the turbulent mixing length to be integrated from the
-!    surface to the top of the BL + a transition layer depth.
-! 3. v3.4.1: Option to use Kitamura/Canuto modification which removes 
-!    the critical Richardson number and negative TKE (default).
-! 4. v3.4.1: Hybrid PBL height diagnostic, which blends a theta-v-based
-!    definition in neutral/convective BL and a TKE-based definition
-!    in stable conditions.
-! 5. v3.4.1: TKE budget output option (bl_mynn_tkebudget)
-! 6. v3.5.0: TKE advection option (bl_mynn_tkeadvect)
-! 7. v3.5.1: Fog deposition related changes.
-!
-! For changes 1 and 3, see "JOE's mods" below:
-!-------------------------------------------------------------------
-
-MODULE module_bl_mynn
-
-#if defined(mpas)
- use mpas_atmphys_constants, only: &
-          karman,        &
-          g => gravity,  &
-          p1000mb => P0, &
-          cp,            &
-          r_d => R_d,    &
-          rcp,           &
-          xlv,           &
-          xlf,           &
-          svp1,          &
-          svp2,          &
-          svp3,          &
-          svpt0,         &
-          ep_1,          &
-          ep_2
- use error_function, only: erf
-
- implicit none
- private
- public:: tv0,mym_condensation,mynn_bl_driver
-#else
-  USE module_model_constants, only: &
-       &karman, g, p1000mb, &
-       &cp, r_d, rcp, xlv, xlf,&
-       &svp1, svp2, svp3, svpt0, ep_1, ep_2
-  USE module_state_description, only: param_first_scalar, &
-       &p_qc, p_qr, p_qi, p_qs, p_qg, p_qnc, p_qni
-!-------------------------------------------------------------------
-  IMPLICIT NONE
-!-------------------------------------------------------------------
-#endif
-
-! The parameters below depend on stability functions of module_sf_mynn.
-  REAL, PARAMETER :: cphm_st=5.0, cphm_unst=16.0, &
-                     cphh_st=5.0, cphh_unst=16.0
-
-  REAL, PARAMETER :: xlvcp=xlv/cp, xlscp=(xlv+xlf)/cp, ev=xlv, rd=r_d, &
-       &rk=cp/rd, svp11=svp1*1.e3, p608=ep_1, ep_3=1.-ep_2
-
-  REAL, PARAMETER :: tref=300.0    ! reference temperature (K)
-  REAL, PARAMETER :: tv0=p608*tref, tv1=(1.+p608)*tref, gtr=g/tref
-
-! Closure constants
-  REAL, PARAMETER :: &
-       &vk  = karman, &
-       &pr  =  0.74, &
-       &g1  =  0.229, &  ! NN2009 = 0.235
-       &b1  = 24.0, &
-       &b2  = 15.0, &    ! CKmod     NN2009
-       &c2  =  0.729, &  ! 0.729, & !0.75, &
-       &c3  =  0.340, &  ! 0.340, & !0.352, &
-       &c4  =  0.0, &
-       &c5  =  0.2, &
-       &a1  = b1*( 1.0-3.0*g1 )/6.0, &
-!       &c1  = g1 -1.0/( 3.0*a1*b1**(1.0/3.0) ), &
-       &c1  = g1 -1.0/( 3.0*a1*2.88449914061481660), &
-       &a2  = a1*( g1-c1 )/( g1*pr ), &
-       &g2  = b2/b1*( 1.0-c3 ) +2.0*a1/b1*( 3.0-2.0*c2 )
-
-  REAL, PARAMETER :: &
-       &cc2 =  1.0-c2, &
-       &cc3 =  1.0-c3, &
-       &e1c =  3.0*a2*b2*cc3, &
-       &e2c =  9.0*a1*a2*cc2, &
-       &e3c =  9.0*a2*a2*cc2*( 1.0-c5 ), &
-       &e4c = 12.0*a1*a2*cc2, &
-       &e5c =  6.0*a1*a1
-
-! Constants for length scale (alps & cns) and TKE diffusion (Sqfac)
-! Original (Nakanishi and Niino 2009) (for CKmod=0.):
-!  REAL, PARAMETER :: qmin=0.0, zmax=1.0, cns=2.7, & 
-!           &alp1=0.23, alp2=1.0, alp3=5.0, alp4=100.0, &
-!           &alp5=0.40, Sqfac=3.0
-! Modified for Rapid Refresh/HRRR (and for CKmod=1.):
-  REAL, PARAMETER :: qmin=0.0, zmax=1.0, cns=2.1, &
-            &alp1=0.23, alp2=0.65, alp3=3.0, alp4=20.0, &
-            &alp5=1.0, Sqfac=2.0
-
-! Constants for gravitational settling
-!  REAL, PARAMETER :: gno=1.e6/(1.e8)**(2./3.), gpw=5./3., qcgmin=1.e-8
-  REAL, PARAMETER :: gno=1.0  !original value seems too agressive: 4.64158883361278196
-  REAL, PARAMETER :: gpw=5./3., qcgmin=1.e-8, qkemin=1.e-12
-!  REAL, PARAMETER :: pblh_ref=1500.
-
-! Constants for cloud PDF (mym_condensation)
-  REAL, PARAMETER :: rr2=0.7071068, rrp=0.3989423
-
-!JOE's mods
-  !Use Canuto/Kitamura mod (remove Ric and negative TKE) (1:yes, 0:no)
-  !For more info, see Canuto et al. (2008 JAS) and Kitamura (Journal of the 
-  !Meteorological Society of Japan, Vol. 88, No. 5, pp. 857-864, 2010).
-  !Note that this change required further modification of other parameters
-  !above (c2, c3, alp2, and Sqfac). If you want to remove this option, set these
-  !parameters back to NN2009 values (see commented out lines next to the
-  !parameters above). This only removes the negative TKE problem
-  !but does not necessarily improve performance - neutral impact.
-  REAL, PARAMETER :: CKmod=1.
-
-  !Use BouLac mixing length in free atmosphere (1:yes, 0:no)
-  !This helps remove excessively large mixing in unstable layers aloft.
-  REAL, PARAMETER :: BLmod=1.
-
-  !Mix couds (water & ice): (0: no, 1: yes)                                                                
-! REAL, PARAMETER :: Cloudmix=0.
-  REAL, PARAMETER :: Cloudmix=1.
-!JOE-end
-
-  INTEGER :: mynn_level=2
-
-  INTEGER, PARAMETER :: kdebug=27
-
-CONTAINS
-
+!>\file module_bl_mynn.F90
+!! This file contains the entity of MYNN-EDMF PBL scheme.
 ! **********************************************************************
 ! *   An improved Mellor-Yamada turbulence closure model               *
 ! *                                                                    *
-! *                                   Aug/2005  M. Nakanishi (N.D.A)   *
-! *                        Modified:  Dec/2005  M. Nakanishi (N.D.A)   *
-! *                                             naka@nda.ac.jp         *
+! *      Original author: M. Nakanishi (N.D.A), naka@nda.ac.jp         *
+! *      Translated into F90 and implemented in WRF-ARW by:            *
+! *                       Mariusz Pagowski (NOAA-GSL)                  *
+! *      Subsequently developed by:                                    *
+! *                 Joseph Olson, Jaymes Kenyon (NOAA/GSL),            *
+! *                 Wayne Angevine (NOAA/CSL), Kay Suselj (NASA/JPL),  *
+! *                 Franciano Puhales (UFSM), Laura Fowler (NCAR),     *
+! *                 Elynn Wu (UCSD), and Jordan Schnell (NOAA/GSL)     *
 ! *                                                                    *
 ! *   Contents:                                                        *
+! *                                                                    *
+! *   mynn_bl_driver - main subroutine which calls all other routines  *
+! *   --------------                                                   *
 ! *     1. mym_initialize  (to be called once initially)               *
 ! *        gives the closure constants and initializes the turbulent   *
 ! *        quantities.                                                 *
-! *    (2) mym_level2      (called in the other subroutines)           *
-! *        calculates the stability functions at Level 2.              *
-! *    (3) mym_length      (called in the other subroutines)           *
-! *        calculates the master length scale.                         *
-! *     4. mym_turbulence                                              *
-! *        calculates the vertical diffusivity coefficients and the    *
-! *        production terms for the turbulent quantities.              *
-! *     5. mym_predict                                                 *
-! *        predicts the turbulent quantities at the next step.         *
-! *     6. mym_condensation                                            *
+! *     2. get_pblh                                                    *
+! *        Calculates the boundary layer height                        *
+! *     3. scale_aware                                                 *
+! *        Calculates scale-adaptive tapering functions                *
+! *     4. mym_condensation                                            *
 ! *        determines the liquid water content and the cloud fraction  *
 ! *        diagnostically.                                             *
+! *     5. dmp_mf                                                      *
+! *        Calls the (nonlocal) mass-flux component                    *
+! *     6. ddmp_mf                                                     *
+! *        Calls the downdraft mass-flux component                     *
+! *    (-) mym_level2      (called in the other subroutines)           *
+! *        calculates the stability functions at Level 2.              *
+! *    (-) mym_length      (called in the other subroutines)           *
+! *        calculates the master length scale.                         *
+! *     7. mym_turbulence                                              *
+! *        calculates the vertical diffusivity coefficients and the    *
+! *        production terms for the turbulent quantities.              *
+! *     8. mym_predict                                                 *
+! *        predicts the turbulent quantities at the next step.         *
 ! *                                                                    *
 ! *             call mym_initialize                                    *
 ! *                  |                                                 *
 ! *                  |<----------------+                               *
 ! *                  |                 |                               *
+! *             call get_pblh          |                               *
+! *             call scale_aware       |                               *
 ! *             call mym_condensation  |                               *
+! *             call dmp_mf            |                               *
+! *             call ddmp_mf           |                               *
 ! *             call mym_turbulence    |                               *
 ! *             call mym_predict       |                               *
 ! *                  |                 |                               *
@@ -190,27 +58,30 @@ CONTAINS
 ! *                                                                    *
 ! *   Variables worthy of special mention:                             *
 ! *     tref   : Reference temperature                                 *
-! *     thl     : Liquid water potential temperature               *
+! *     thl    : Liquid water potential temperature                    *
 ! *     qw     : Total water (water vapor+liquid water) content        *
 ! *     ql     : Liquid water content                                  *
 ! *     vt, vq : Functions for computing the buoyancy flux             *
+! *     qke    : 2 * TKE                                               *
+! *     el     : mixing length                                         *
 ! *                                                                    *
 ! *     If the water contents are unnecessary, e.g., in the case of    *
-! *     ocean models, thl is the potential temperature and qw, ql, vt   *
+! *     ocean models, thl is the potential temperature and qw, ql, vt  *
 ! *     and vq are all zero.                                           *
 ! *                                                                    *
 ! *   Grid arrangement:                                                *
 ! *             k+1 +---------+                                        *
 ! *                 |         |     i = 1 - nx                         *
-! *             (k) |    *    |     j = 1 - ny                         *
-! *                 |         |     k = 1 - nz                         *
+! *             (k) |    *    |     k = 1 - nz                         *
+! *                 |         |                                        *
 ! *              k  +---------+                                        *
 ! *                 i   (i)  i+1                                       *
 ! *                                                                    *
 ! *     All the predicted variables are defined at the center (*) of   *
-! *     the grid boxes. The diffusivity coefficients are, however,     *
+! *     the grid boxes. The diffusivity coefficients and two of their  *
+! *     components (el and stability functions sh & sm) are, however,  *
 ! *     defined on the walls of the grid boxes.                        *
-! *     # Upper boundary values are given at k=nz.                   *
+! *     # Upper boundary values are given at k=nz.                     *
 ! *                                                                    *
 ! *   References:                                                      *
 ! *     1. Nakanishi, M., 2001:                                        *
@@ -218,120 +89,1262 @@ CONTAINS
 ! *     2. Nakanishi, M. and H. Niino, 2004:                           *
 ! *        Boundary-Layer Meteor., 112, 1-31.                          *
 ! *     3. Nakanishi, M. and H. Niino, 2006:                           *
-! *        Boundary-Layer Meteor., (in press).                         *
+! *        Boundary-Layer Meteor., 119, 397-407.                       *
 ! *     4. Nakanishi, M. and H. Niino, 2009:                           *
 ! *        Jour. Meteor. Soc. Japan, 87, 895-912.                      *
+! *     5. Olson J. and coauthors, 2019: A description of the          *
+! *        MYNN-EDMF scheme and coupling to other components in        *
+! *        WRF-ARW. NOAA Tech. Memo. OAR GSD, 61, 37 pp.,              *
+! *        https://doi.org/10.25923/n9wm-be49.                         * 
+! *     6. Puhales, Franciano S. and coauthors, 2020: Turbulent        *
+! *        Kinetic Energy Budget for MYNN-EDMF PBL Scheme in WRF model.*
+! *        Universidade Federal de Santa Maria Technical Note. 9 pp.   *
 ! **********************************************************************
+! ==================================================================
+! Notes on original implementation into WRF-ARW
+! changes to original code:
+! 1. code is 1D (in z)
+! 2. option to advect TKE, but not the covariances and variances
+! 3. Cranck-Nicholson replaced with the implicit scheme
+! 4. removed terrain-dependent grid since input in WRF in actual
+!    distances in z[m]
+! 5. cosmetic changes to adhere to WRF standard (remove common blocks,
+!            intent etc)
+!-------------------------------------------------------------------
+! Further modifications post-implementation
 !
+! 1. Addition of BouLac mixing length in the free atmosphere.
+! 2. Changed the turbulent mixing length to be integrated from the
+!    surface to the top of the BL + a transition layer depth.
+! v3.4.1:    Option to use Kitamura/Canuto modification which removes 
+!            the critical Richardson number and negative TKE (default).
+!            Hybrid PBL height diagnostic, which blends a theta-v-based
+!            definition in neutral/convective BL and a TKE-based definition
+!            in stable conditions.
+!            TKE budget output option
+! v3.5.0:    TKE advection option (bl_mynn_tkeadvect)
+! v3.5.1:    Fog deposition related changes.
+! v3.6.0:    Removed fog deposition from the calculation of tendencies
+!            Added mixing of qc, qi, qni
+!            Added output for wstar, delta, TKE_PBL, & KPBL for correct 
+!                   coupling to shcu schemes  
+! v3.8.0:    Added subgrid scale cloud output for coupling to radiation
+!            schemes (activated by setting icloud_bl =1 in phys namelist).
+!            Added WRF_DEBUG prints (at level 3000)
+!            Added Tripoli and Cotton (1981) correction.
+!            Added namelist option bl_mynn_cloudmix to test effect of mixing
+!                cloud species (default = 1: on). 
+!            Added mass-flux option (bl_mynn_edmf, = 1 for DMP mass-flux, 0: off).
+!                Related options: 
+!                 bl_mynn_edmf_mom = 1 : activate momentum transport in MF scheme
+!                 bl_mynn_edmf_tke = 1 : activate TKE transport in MF scheme
+!            Added mixing length option (bl_mynn_mixlength, see notes below)
+!            Added more sophisticated saturation checks, following Thompson scheme
+!            Added new cloud PDF option (bl_mynn_cloudpdf = 2) from Chaboureau
+!                and Bechtold (2002, JAS, with mods) 
+!            Added capability to mix chemical species when env variable
+!                WRF_CHEM = 1, thanks to Wayne Angevine.
+!            Added scale-aware mixing length, following Junshi Ito's work
+!                Ito et al. (2015, BLM).
+! v3.9.0    Improvement to the mass-flux scheme (dynamic number of plumes,
+!                better plume/cloud depth, significant speed up, better cloud
+!                fraction). 
+!            Added Stochastic Parameter Perturbation (SPP) implementation.
+!            Many miscellaneous tweaks to the mixing lengths and stratus
+!                component of the subgrid clouds.
+! v.4.0      Removed or added alternatives to WRF-specific functions/modules
+!                for the sake of portability to other models.
+!                the sake of portability to other models.
+!            Further refinement of mass-flux scheme from SCM experiments with
+!                Wayne Angevine: switch to linear entrainment and back to
+!                Simpson and Wiggert-type w-equation.
+!            Addition of TKE production due to radiation cooling at top of 
+!                clouds (proto-version); not activated by default.
+!            Some code rewrites to move if-thens out of loops in an attempt to
+!                improve computational efficiency.
+!            New tridiagonal solver, which is supposedly 14% faster and more
+!                conservative. Impact seems very small.
+!            Many miscellaneous tweaks to the mixing lengths and stratus
+!                component of the subgrid-scale (SGS) clouds.
+! v4.1       Big improvements in downward SW radiation due to revision of subgrid clouds
+!                - better cloud fraction and subgrid scale mixing ratios.
+!                - may experience a small cool bias during the daytime now that high 
+!                  SW-down bias is greatly reduced...
+!            Some tweaks to increase the turbulent mixing during the daytime for
+!                bl_mynn_mixlength option 2 to alleviate cool bias (very small impact).
+!            Improved ensemble spread from changes to SPP in MYNN
+!                - now perturbing eddy diffusivity and eddy viscosity directly
+!                - now perturbing background rh (in SGS cloud calc only)
+!                - now perturbing entrainment rates in mass-flux scheme
+!            Added IF checks (within IFDEFS) to protect mixchem code from being used
+!                when HRRR smoke is used (no impact on regular non-wrf chem use)
+!            Important bug fix for wrf chem when transporting chemical species in MF scheme
+!            Removed 2nd mass-flux scheme (no only bl_mynn_edmf = 1, no option 2)
+!            Removed unused stochastic code for mass-flux scheme
+!            Changed mass-flux scheme to be integrated on interface levels instead of
+!                mass levels - impact is small
+!            Added option to mix 2nd moments in MYNN as opposed to the scalar_pblmix option.
+!                - activated with bl_mynn_mixscalars = 1; this sets scalar_pblmix = 0
+!                - added tridagonal solver used in scalar_pblmix option to duplicate tendencies
+!                - this alone changes the interface call considerably from v4.0.
+!            Slight revision to TKE production due to radiation cooling at top of clouds
+!            Added the non-Guassian buoyancy flux function of Bechtold and Siebesma (1998, JAS).
+!                - improves TKE in SGS clouds
+!            Added heating due to dissipation of TKE (small impact, maybe + 0.1 C daytime PBL temp)
+!            Misc changes made for FV3/MPAS compatibility
+! v4.2       A series of small tweaks to help reduce a cold bias in the PBL:
+!                - slight increase in diffusion in convective conditions
+!                - relaxed criteria for mass-flux activation/strength
+!                - added capability to cycle TKE for continuity in hourly updating HRRR
+!                - added effects of compensational environmental subsidence in mass-flux scheme,
+!                  which resulted in tweaks to detrainment rates.
+!            Bug fix for diagnostic-decay of SGS clouds - noticed by Greg Thompson. This has
+!                a very small, but primarily  positive, impact on SW-down biases.
+!            Tweak to calculation of KPBL - urged by Laura Fowler - to make more intuitive.
+!            Tweak to temperature range of blending for saturation check (water to ice). This
+!                slightly reduces excessive SGS clouds in polar region. No impact warm clouds. 
+!            Added namelist option bl_mynn_output (0 or 1) to suppress or activate the
+!                allocation and output of 10 3D variables. Most people will want this
+!                set to 0 (default) to save memory and disk space.
+!            Added new array qi_bl as opposed to using qc_bl for both SGS qc and qi. This
+!                gives us more control of the magnitudes which can be confounded by using
+!                a single array. As a results, many subroutines needed to be modified,
+!                especially mym_condensation.
+!            Added the blending of the stratus component of the SGS clouds to the mass-flux
+!                clouds to account for situations where stratus and cumulus may exist in the
+!                grid cell.
+!            Misc small-impact bugfixes:
+!                1) dz was incorrectly indexed in mym_condensation
+!                2) configurations with icloud_bl = 0 were using uninitialized arrays
+! v4.5 / CCPP
+!            This version includes many modifications that proved valuable in the global
+!            framework and removes some key lingering bugs in the mixing of chemical species.
+!            TKE Budget output fixed (Puhales, 2020-12)
+!            New option for stability function: (Puhales, 2020-12)
+!                bl_mynn_stfunc = 0 (original, Kansas-type function, Paulson, 1970 )
+!                bl_mynn_stfunc = 1 (expanded range, same as used for Jimenez et al (MWR)
+!                see the Technical Note for this implementation (small impact).
+!            Improved conservation of momentum and higher-order moments.
+!            Important bug fixes for mixing of chemical species.
+!            Addition of pressure-gradient effects on updraft momentum transport.
+!            Addition of bl_mynn_closure option = 2.5, 2.6, or 3.0
+!            Addition of higher-order moments for sigma when using 
+!                bl_mynn_cloudpdf = 2 (Chab-Becht).
+!            Removed WRF_CHEM dependencies.
+!            Many miscellaneous tweaks.
+! v4.6 / CCPP
+!            Some code optimization. Removed many conditions from loops. Redesigned the mass-
+!                flux scheme to use 8 plumes instead of a variable n plumes. This results in
+!                the removal of the output variable "nudprafts" and adds maxwidth and ztop_plume.
+!            Revision option bl_mynn_cloudpdf = 2, which now ensures cloud fractions for all
+!                optically relevant mixing ratios (tip from Greg Thompson). Also, added flexibility
+!                for tuning near-surface cloud fractions to remove excess fog/low ceilings.
+!            Now outputs all SGS cloud mixing ratios as grid-mean values, not in-cloud. This 
+!                results in a change in the pre-radiation code to no longer multiply mixing ratios
+!                by cloud fractions.
+!            Bug fix for the momentum transport.
+!            Lots of code cleanup: removal of test code, comments, changing text case, etc.
+!            Many misc tuning/tweaks.
+!
+! Many of these changes are now documented in references listed above.
+!====================================================================
+
+MODULE module_bl_mynn
+
+ use module_bl_mynn_common,only:                        &
+       cp        , cpv       , cliq       , cice      , &
+       p608      , ep_2      , ep_3       , gtr       , &
+       grav      , g_inv     , karman     , p1000mb   , &
+       rcp       , r_d       , r_v        , rk        , &
+       rvovrd    , svp1      , svp2       , svp3      , &
+       xlf       , xlv       , xls        , xlscp     , &
+       xlvcp     , tv0       , tv1        , tref      , &
+       zero      , half      , one        , two       , &
+       onethird  , twothirds , tkmin      , t0c       , &
+       tice      , kind_phys
+
+
+ IMPLICIT NONE
+
+!===================================================================
+! From here on, these are MYNN-specific parameters:
+! The parameters below depend on stability functions of module_sf_mynn.
+ real(kind_phys), parameter :: cphm_st=5.0, cphm_unst=16.0, &
+                               cphh_st=5.0, cphh_unst=16.0
+
+! Closure constants
+ real(kind_phys), parameter ::  &
+      &pr  =  0.74,             &
+      &g1  =  0.235,            &  ! NN2009 = 0.235
+      &b1  = 24.0,              &
+      &b2  = 15.0,              &  ! CKmod     NN2009
+      &c2  =  0.729,            &  ! 0.729, & !0.75, &
+      &c3  =  0.340,            &  ! 0.340, & !0.352, &
+      &c4  =  0.0,              &
+      &c5  =  0.2,              &
+      &a1  = b1*( 1.0-3.0*g1 )/6.0, &
+!      &c1  = g1 -1.0/( 3.0*a1*b1**(1.0/3.0) ), &
+      &c1  = g1 -1.0/( 3.0*a1*2.88449914061481660), &
+      &a2  = a1*( g1-c1 )/( g1*pr ), &
+      &g2  = b2/b1*( 1.0-c3 ) +2.0*a1/b1*( 3.0-2.0*c2 )
+
+ real(kind_phys), parameter ::  &
+      &cc2 =  1.0-c2,           &
+      &cc3 =  1.0-c3,           &
+      &e1c =  3.0*a2*b2*cc3,    &
+      &e2c =  9.0*a1*a2*cc2,    &
+      &e3c =  9.0*a2*a2*cc2*( 1.0-c5 ), &
+      &e4c = 12.0*a1*a2*cc2,    &
+      &e5c =  6.0*a1*a1
+
+! Constants for min tke in elt integration (qmin), max z/L in els (zmax), 
+! and factor for eddy viscosity for TKE (Kq = Sqfac*Km):
+ real(kind_phys), parameter :: qmin=0.0, zmax=1.0, Sqfac=3.0
+! Note that the following mixing-length constants are now specified in mym_length
+!     &cns=3.5, alp1=0.23, alp2=0.3, alp3=3.0, alp4=10.0, alp5=0.2
+
+ real(kind_phys), parameter :: qkemin=1.e-3
+ real(kind_phys), parameter :: tliq = 269. !all hydrometeors are liquid when T > tliq
+
+! Constants for cloud PDF (mym_condensation)
+ real(kind_phys), parameter :: rr2=0.7071068, rrp=0.3989423
+
+!>Use Canuto/Kitamura mod (remove Ric and negative TKE) (1:yes, 0:no)
+!!For more info, see Canuto et al. (2008 JAS) and Kitamura (Journal of the 
+!!Meteorological Society of Japan, Vol. 88, No. 5, pp. 857-864, 2010).
+!!Note that this change required further modification of other parameters
+!!above (c2, c3). If you want to remove this option, set c2 and c3 constants 
+!!(above) back to NN2009 values (see commented out lines next to the
+!!parameters above). This only removes the negative TKE problem
+!!but does not necessarily improve performance - neutral impact.
+ real(kind_phys), parameter :: CKmod=1.
+
+!For calculating the b-f freq and Ri, either use the buoyancy flux functions
+!(true) or use the direct calc of thlv with resolved and sgs clouds (false).  
+ logical, parameter :: use_buoy=.true.
+
+!>Use Ito et al. (2015, BLM) scale-aware (0: no, 1: yes). Note that this also has impacts
+!!on the cloud PDF and mass-flux scheme, using LES-derived similarity function.
+ real(kind_phys), parameter :: scaleaware=1.
+
+!>Of the following the options, use one OR the other, not both.
+!>Adding top-down diffusion driven by cloud-top radiative cooling
+ integer, parameter :: bl_mynn_topdown = 0
+!>Option to activate downdrafts, from Elynn Wu (0: deactive, 1: active)
+ integer, parameter :: bl_mynn_edmf_dd = 0
+
+!>Option to activate heating due to dissipation of TKE (to activate, set to 1.0)
+ integer, parameter :: dheat_opt = 1
+
+!Option to activate environmental subsidence in mass-flux scheme
+ logical, parameter :: env_subs = .false.
+
+!Option to switch flux-profile relationship for surface (from Puhales et al. 2020)
+!0: use original Dyer-Hicks, 1: use Cheng-Brustaert and Blended COARE
+ integer, parameter :: bl_mynn_stfunc = 1
+
+!option to print out more stuff for debugging purposes
+ logical, parameter :: debug_code = .false.
+ integer, parameter :: idbg = 20 !specific i-point to write out
+
+!Used in WRF-ARW module_physics_init.F
+ integer :: mynn_level
+
+
+CONTAINS
+
+! ==================================================================
+!>\ingroup gsd_mynn_edmf
+!! This subroutine is the GSD MYNN-EDNF PBL driver routine,which
+!! encompassed the majority of the subroutines that comprise the 
+!! procedures that ultimately solve for tendencies of 
+!! \f$U, V, \theta, q_v, q_c, and q_i\f$.
+!!\section gen_mynn_bl_driver GSD mynn_bl_driver General Algorithm
+!> @{
+  SUBROUTINE mynn_bl_driver(i,j,        &
+       &initflag,restart,cycling,       &
+       &delt,dz1,dx,znt,                &
+       &u1,v1,w1,th1,sqv1,sqc1,sqi1,    &
+       &sqs1,qnc1,qni1,                 &
+       &qnwfa1,qnifa1,qnbca1,ozone1,    &
+       &p1,ex1,rho1,tk1,                &
+       &xland,ts,qsfc,ps,               &
+       &ust,ch,hfx,qfx,rmol,wspd,       &
+       &uoce,voce,                      & !ocean current
+       &qke1,qke_adv1,                  &
+       &sh1,sm1,                        &
+       &nchem,kdvel,ndvel,              & !smoke/chem variables
+       &chem,vdep,                      &
+       &frp,emis_ant_no,                &
+       &mix_chem,enh_mix,               & !note: these arrays/flags are still under development
+       &rrfs_sd,smoke_dbg,              & !end smoke/chem variables
+       &tsq1,qsq1,cov1,                 &
+       &du1,dv1,dth1,                   &
+       &dqv1,dqc1,dqi1,                 &
+       &dqnc1,dqni1,dqs1,               &
+       &dqnwfa1,dqnifa1,                &
+       &dqnbca1,dozone1,                &
+       &kh1,km1,                        &
+       &pblh,kpbl,                      & 
+       &el1,                            &
+       &dqke1,qwt1,qshear1,             &
+       &qbuoy1,qdiss1,                  &
+       &qc_bl1,qi_bl1,cldfra_bl1,       &
+       &bl_mynn_tkeadvect,              &
+       &tke_budget,                     &
+       &bl_mynn_cloudpdf,               &
+       &bl_mynn_mixlength,              &
+       &icloud_bl,                      &
+       &closure,                        &
+       &bl_mynn_edmf,                   &
+       &bl_mynn_edmf_mom,               &
+       &bl_mynn_edmf_tke,               &
+       &bl_mynn_mixscalars,             &
+       &bl_mynn_output,                 &
+       &bl_mynn_cloudmix,bl_mynn_mixqt, &
+       &edmf_a1,edmf_w1,edmf_qt1,       &
+       &edmf_thl1,edmf_ent1,edmf_qc1,   &
+       &sub_thl1,sub_sqv1,              &
+       &det_thl1,det_sqv1,              &
+       &maxwidth,maxmf,ztop_plume,      &
+       &spp_pbl,pattern_spp_pbl1,       &
+       &rthraten1,                      &
+       &FLAG_QC,FLAG_QI,FLAG_QNC,       &
+       &FLAG_QNI,FLAG_QS,               &
+       &FLAG_QNWFA,FLAG_QNIFA,          &
+       &FLAG_QNBCA,FLAG_OZONE,          &
+       &IDS,IDE,JDS,JDE,KDS,KDE,        &
+       &IMS,IME,JMS,JME,KMS,KME,        &
+       &ITS,ITE,JTS,JTE,KTS,KTE         )
+    
+!-------------------------------------------------------------------
+
+ integer, intent(in) :: initflag
+ logical, intent(in) :: restart,cycling
+ integer, intent(in) :: tke_budget
+ integer, intent(in) :: bl_mynn_cloudpdf
+ integer, intent(in) :: bl_mynn_mixlength
+ integer, intent(in) :: bl_mynn_edmf
+ logical, intent(in) :: bl_mynn_tkeadvect
+ integer, intent(in) :: bl_mynn_edmf_mom
+ integer, intent(in) :: bl_mynn_edmf_tke
+ integer, intent(in) :: bl_mynn_mixscalars
+ integer, intent(in) :: bl_mynn_output
+ integer, intent(in) :: bl_mynn_cloudmix
+ integer, intent(in) :: bl_mynn_mixqt
+ integer, intent(in) :: icloud_bl
+ real(kind_phys), intent(in) :: closure
+
+ logical, intent(in) :: FLAG_QI,FLAG_QNI,FLAG_QC,FLAG_QNC,&
+                        FLAG_QNWFA,FLAG_QNIFA,FLAG_QNBCA, &
+                        FLAG_OZONE,FLAG_QS
+
+ logical, intent(in) :: mix_chem,enh_mix,rrfs_sd,smoke_dbg
+
+ integer, intent(in) ::                                   &
+                      & IDS,IDE,JDS,JDE,KDS,KDE           &
+                      &,IMS,IME,JMS,JME,KMS,KME           &
+                      &,ITS,ITE,JTS,JTE,KTS,KTE
+
+#ifdef HARDCODE_VERTICAL
+# define kts 1
+# define kte HARDCODE_VERTICAL
+#endif
+
+! initflag > 0  for TRUE
+! else        for FALSE
+!       closure       : <= 2.5;  Level 2.5
+!                  2.5< and <3;  Level 2.6
+!                        =   3;  Level 3
+
+! SGT: Changed this to use assumed shape arrays (dimension(:,:,:)) with no "optional" arguments
+!      to prevent a crash on Cheyenne. Do not change it back without testing if the code runs
+!      on Cheyenne with the GNU compiler.
+
+!scalar variables
+    real(kind_phys), intent(in)    :: delt
+    real(kind_phys), intent(in)    :: dx
+    real(kind_phys), intent(in)    :: ust,ch,qsfc,ps,wspd,xland
+    real(kind_phys), intent(in)    :: ts,znt,hfx,qfx,uoce,voce
+    real(kind_phys), intent(inout) :: pblh,rmol
+    real(kind_phys), intent(out)   :: maxmf,maxwidth,ztop_plume
+    integer,         intent(in)    :: i,j
+    integer,         intent(inout) :: kpbl
+    !local
+    real(kind_phys) :: psig_bl,psig_shcu
+    integer :: imd,jmd
+    integer :: k,kproblem
+
+!column variables (all end with a "1")
+    real(kind_phys), dimension(kts:kte), intent(in)      ::            &
+         &dz1,u1,v1,w1,th1,p1,ex1,rho1,tk1,rthraten1
+    !real(kind_phys), dimension(kts:kte+1), intent(in)    ::  w1
+    real(kind_phys), dimension(kts:kte), intent(inout)   ::            &
+         &sqv1,sqc1,sqi1,sqs1,qni1,qnc1,qnwfa1,qnifa1,qnbca1,ozone1,   &
+         &qke1,tsq1,qsq1,cov1,qke_adv1,                                &
+         &sh1,sm1,el1,                                                 & !interface, but kte+1 not included
+         &du1,dv1,dth1,dqv1,dqc1,dqi1,dqs1,                            &
+         &dqni1,dqnc1,dqnwfa1,dqnifa1,dqnbca1,dozone1,                 &
+         &qc_bl1,qi_bl1,cldfra_bl1,edmf_a1,edmf_w1,                    &
+         &edmf_qt1,edmf_thl1,edmf_ent1,edmf_qc1,                       &
+         &sub_thl1,sub_sqv1,det_thl1,det_sqv1
+    real(kind_phys), dimension(kts:kte), intent(inout)   ::            &
+         &qwt1,qshear1,qbuoy1,qdiss1,dqke1
+
+    real(kind_phys), dimension(kts:kte), intent(out)     ::            & !interface
+         &kh1,km1
+    !local
+    real(kind_phys), dimension(kts:kte)                  ::            &
+         &qc_bl1_old,qi_bl1_old,cldfra_bl1_old,dummy1,dummy2,          &
+         &diss_heat1,                                                  &
+         &thl1,thv1,thlv1,qv1,qc1,qi1,qs1,sqw1,                        &
+         &dfm1, dfh1, dfq1, tcd1, qcd1,                                &
+         &pdk1, pdt1, pdq1, pdc1,                                      &
+         &vt1, vq1, sgm1, kzero1
+
+! smoke/chemical arrays
+    integer, intent(in) ::   nchem, kdvel, ndvel
+    real(kind_phys), dimension(kts:kte,nchem), intent(inout) :: chem
+    real(kind_phys), dimension(ndvel), intent(in)    :: vdep
+    real(kind_phys),                   intent(in)    :: frp,emis_ant_no
+    real(kind_phys), dimension(kts:kte+1,nchem)      :: s_awchem1
+    integer :: ic
+
+!local vars
+    !mass-flux variables
+    real(kind_phys), dimension(kts:kte) ::                  &
+         &dth1mf,dqv1mf,dqc1mf,du1mf,dv1mf
+    real(kind_phys), dimension(kts:kte) ::                  &
+         &edmf_a_dd1,edmf_w_dd1,edmf_qt_dd1,edmf_thl_dd1,   &
+         &edmf_ent_dd1,edmf_qc_dd1
+    real(kind_phys), dimension(kts:kte) ::                  &
+         &sub_u1,sub_v1,det_sqc1,det_u1,det_v1
+    real(kind_phys), dimension(kts:kte+1) ::                & !interface
+         &s_aw1,s_awthl1,s_awqt1,                           &
+         &s_awqv1,s_awqc1,s_awu1,s_awv1,s_awqke1,           &
+         &s_awqnc1,s_awqni1,s_awqnwfa1,s_awqnifa1,          &
+         &s_awqnbca1
+    real(kind_phys), dimension(kts:kte+1) ::                & !interface
+         &sd_aw1,sd_awthl1,sd_awqt1,                        &
+         &sd_awqv1,sd_awqc1,sd_awu1,sd_awv1,sd_awqke1,      &
+         &sd_awqi1,sd_awqnc1,sd_awqni1,                     &
+         &sd_awqnwfa1,sd_awqnifa1
+    real(kind_phys), dimension(kts:kte+1) :: zw1              !interface
+    real(kind_phys) :: cpm,sqcg,flt,fltv,flq,flqv,flqc,     &
+         &pmz,phh,exnerg,zet,phi_m,                         &
+         &afk,abk,ts_decay, qc_bl2, qi_bl2,                 &
+         &th_sfc,wsp
+    integer:: ktop_plume
+
+    !top-down diffusion
+    real(kind_phys) :: maxKHtopdown
+    real(kind_phys), dimension(kts:kte) :: KHtopdown
+    !mass flux tke production
+    real(kind_phys), dimension(kts:kte) :: TKEprod_dn,TKEprod_up
+      
+    logical :: INITIALIZE_QKE,problem
+
+    ! Stochastic fields 
+    integer,  intent(in)                            :: spp_pbl
+    real(kind_phys), dimension(kts:kte), intent(in)  :: pattern_spp_pbl1
+!    real(kind_phys), dimension(kts:kte)          :: rstoch_col1
+
+    ! Substepping TKE
+    integer :: nsub
+    real(kind_phys) :: delt2
+
+
+    if (debug_code) then !check incoming values
+       problem = .false.
+       do k=kts,kte
+          wsp  = sqrt(u1(k)**2 + v1(k)**2)
+          if (abs(hfx) > 1200. .or. abs(qfx) > 0.001 .or.         &
+              wsp > 200. .or. tk1(k) > 380. .or. tk1(k) < 160. .or. &
+              sqv1(k)< 0.0 .or. sqc1(k)< 0.0 ) then
+             kproblem = k
+             problem = .true.
+             print*,"Incoming problem at: i=",i," k=1"
+             print*," QFX=",qfx," HFX=",hfx
+             print*," wsp=",wsp," T=",tk1(k)
+             print*," qv=",sqv1(k)," qc=",sqc1(k)
+             print*," u*=",ust," wspd=",wspd
+             print*," xland=",xland," ts=",ts
+             print*," z/L=",half*dz1(1)*rmol," ps=",ps
+             print*," znt=",znt," dx=",dx
+          endif
+       enddo
+       if (problem) then
+          print*,"===tk:",tk1(max(kproblem-3,1):min(kproblem+3,kte))
+          print*,"===qv:",sqv1(max(kproblem-3,1):min(kproblem+3,kte))
+          print*,"===qc:",sqc1(max(kproblem-3,1):min(kproblem+3,kte))
+          print*,"===qi:",sqi1(max(kproblem-3,1):min(kproblem+3,kte))
+          print*,"====u:",u1(max(kproblem-3,1):min(kproblem+3,kte))
+          print*,"====v:",v1(max(kproblem-3,1):min(kproblem+3,kte))
+       endif
+    endif
+
+!***  Begin debugging
+    IMD=(IMS+IME)/2
+    JMD=(JMS+JME)/2
+!***  End debugging
+
+    edmf_a1(kts:kte)   =0.
+    edmf_w1(kts:kte)   =0.
+    edmf_qt1(kts:kte)  =0.
+    edmf_thl1(kts:kte) =0.
+    edmf_ent1(kts:kte) =0.
+    edmf_qc1(kts:kte)  =0.
+    sub_thl1(kts:kte)  =0.
+    sub_sqv1(kts:kte)  =0.
+    det_thl1(kts:kte)  =0.
+    det_sqv1(kts:kte)  =0.
+    edmf_a_dd1(kts:kte)=0.
+    edmf_w_dd1(kts:kte)=0.
+    ktop_plume     =0  !int
+    ztop_plume     =0.
+    maxwidth       =0.
+    maxmf          =0.
+    maxKHtopdown   =0.
+    kzero1(kts:kte)=0.
+
+    ! DH* CHECK HOW MUCH OF THIS INIT IF-BLOCK IS ACTUALLY NEEDED FOR RESTARTS
+!> - Within the MYNN-EDMF, there is a dependecy check for the first time step,
+!! If true, a three-dimensional initialization loop is entered. Within this loop,
+!! several arrays are initialized and k-oriented (vertical) subroutines are called 
+!! at every i and j point, corresponding to the x- and y- directions, respectively.  
+    IF (initflag > 0 .and. .not.restart) THEN
+
+       !Test to see if we want to initialize qke
+       IF ( (restart .or. cycling)) THEN
+          IF (MAXVAL(qke1(:)) < 0.0002) THEN
+             INITIALIZE_QKE = .TRUE.
+             !print*,"QKE is too small, must initialize"
+          ELSE
+             INITIALIZE_QKE = .FALSE.
+             !print*,"Using background QKE, will not initialize"
+          ENDIF
+       ELSE ! not cycling or restarting:
+          INITIALIZE_QKE = .TRUE.
+          !print*,"not restart nor cycling, must initialize QKE"
+       ENDIF
+ 
+       if (.not.restart .or. .not.cycling) THEN
+         sh1(kts:kte)=0.
+         sm1(kts:kte)=0.
+         el1(kts:kte)=0.
+         tsq1(kts:kte)=0.
+         qsq1(kts:kte)=0.
+         cov1(kts:kte)=0.
+         cldfra_bl1(kts:kte)=0.
+         qc_bl1(kts:kte)=0.
+         qi_bl1(kts:kte)=0.0
+         qke1(kts:kte)=0.
+       end if
+       dqc1(kts:kte)=0.0
+       dqi1(kts:kte)=0.0
+       dqni1(kts:kte)=0.0
+       dqnc1(kts:kte)=0.0
+       dqnwfa1(kts:kte)=0.0
+       dqnifa1(kts:kte)=0.0
+       dqnbca1(kts:kte)=0.0
+       dozone1(kts:kte)=0.0
+       qc_bl1_old(kts:kte)=0.0
+       cldfra_bl1_old(kts:kte)=0.0
+       edmf_a1(kts:kte)=0.0
+       edmf_w1(kts:kte)=0.0
+       edmf_qc1(kts:kte)=0.0
+       edmf_a_dd1(kts:kte)=0.0
+       edmf_w_dd1(kts:kte)=0.0
+       edmf_qc_dd1(kts:kte)=0.0
+       sgm1(kts:kte)=0.0
+       vt1(kts:kte)=0.0
+       vq1(kts:kte)=0.0
+       km1=0.
+       kh1=0.
+
+       if (tke_budget .eq. 1) then
+          qwt1   =0.
+          qshear1=0.
+          qbuoy1 =0.
+          qdiss1 =0.
+          dqke1  =0.
+       endif
+
+       do k=kts,kte
+          thv1(k)=th1(k)*(1.+p608*sqv1(k))
+          !keep snow out for now - increases ceiling bias
+          sqw1(k)=sqv1(k)+sqc1(k)+sqi1(k)!+sqs1(k)
+          thl1(k)=th1(k) - xlvcp/ex1(k)*sqc1(k) &
+               &         - xlscp/ex1(k)*(sqi1(k))!+sqs1(k))
+          !Use form from Tripoli and Cotton (1981) with their
+          !suggested min temperature to improve accuracy.
+          !thl1(k)=th1(k)*(1.- xlvcp/MAX(tk1(k),TKmin)*sqc1(k) &
+          !    &             - xlscp/MAX(tk1(k),TKmin)*sqi1(k))
+          thlv1(k)=thl1(k)*(1.+p608*sqv1(k))
+          IF (k==kts) THEN
+             zw1(k)=0.
+          ELSE
+             zw1(k)=zw1(k-1)+dz1(k-1)
+          ENDIF
+          IF (INITIALIZE_QKE) THEN
+             !Initialize tke for initial PBLH calc only - using 
+             !simple PBLH form of Koracin and Berkowicz (1988, BLM)
+             !to linearly taper off tke towards top of PBL.
+             qke1(k)=5.*ust * MAX((ust*700. - zw1(k))/(MAX(ust,0.01)*700.), 0.01)
+          ENDIF
+!          if (spp_pbl==1) then
+!              rstoch_col1(k)=pattern_spp_pbl1(k)
+!          else
+!              rstoch_col1(k)=0.0
+!          endif
+       enddo
+       zw1(kte+1)=zw1(kte)+dz1(kte)
+
+!>  - Call get_pblh() to calculate hybrid (\f$\theta_{v}-TKE\f$) PBL height.
+       CALL GET_PBLH(KTS,KTE,PBLH,thv1,qke1,zw1,dz1,xland,KPBL)
+             
+!>  - Call scale_aware() to calculate similarity functions for scale-adaptive control
+!! (\f$P_{\sigma-PBL}\f$ and \f$P_{\sigma-shcu}\f$).
+       IF (scaleaware > 0.) THEN
+          CALL SCALE_AWARE(dx,PBLH,Psig_bl,Psig_shcu)
+       ELSE
+          Psig_bl   =1.0
+          Psig_shcu =1.0
+       ENDIF
+
+       ! DH* CHECK IF WE CAN DO WITHOUT CALLING THIS ROUTINE FOR RESTARTS
+!>  - Call mym_initialize() to initializes the mixing length, TKE, \f$\theta^{'2}\f$,
+!! \f$q^{'2}\f$, and \f$\theta^{'}q^{'}\f$. These variables are calculated after 
+!! obtaining prerequisite variables by calling the following subroutines from 
+!! within mym_initialize(): mym_level2() and mym_length().
+       CALL mym_initialize (                & 
+            &kts,kte,xland,                 &
+            &dz1, dx, zw1,                  &
+            &u1, v1, thl1, sqv1,            &
+            &PBLH, th1, thv1, thlv1,        &
+            &sh1, sm1,                      &
+            &ust, rmol,                     &
+            &el1, qke1, tsq1, qsq1, cov1,   &
+            &Psig_bl, cldfra_bl1,           &
+            &bl_mynn_mixlength,             &
+            &edmf_w1,edmf_a1,               &
+            &edmf_w_dd1,edmf_a_dd1,         &
+            &INITIALIZE_QKE,                &
+            &spp_pbl,pattern_spp_pbl1       )
+
+       IF (.not.restart) THEN
+          !initialize qke_adv array if using advection
+          IF (bl_mynn_tkeadvect) THEN
+             DO k=KTS,KTE
+                qke_adv1(k)=qke1(k)
+             ENDDO
+          ENDIF
+       ENDIF
+
+!***  Begin debugging
+!             IF(I==IMD .AND. J==JMD)THEN
+!               PRINT*,"MYNN DRIVER INIT: k=",1," sh=",sh1(k)
+!               PRINT*," sqw=",sqw1(k)," thl=",thl1(k)," k_m=",km1(k)
+!               PRINT*," xland=",xland," rmol=",rmol," ust=",ust
+!               PRINT*," qke=",qke1(k)," el=",el1(k)," tsq=",tsq1(k)
+!               PRINT*," PBLH=",PBLH," u=",u1(k)," v=",v1(k)
+!             ENDIF
+!***  End debugging
+
+    ENDIF ! end initflag
+
+!> - After initializing all required variables, the regular procedures 
+!! performed at every time step are ready for execution.
+    !ACF- copy qke_adv array into qke if using advection
+    IF (bl_mynn_tkeadvect) THEN
+       qke1=qke_adv1
+    ENDIF
+
+    !Initialize some arrays
+    if (tke_budget .eq. 1) then
+       dqke1(:)=qke1(:)
+    endif
+    if (icloud_bl > 0) then
+       cldfra_bl1_old(kts:kte)=cldfra_bl1(kts:kte)
+       qc_bl1_old(kts:kte)    =qc_bl1(kts:kte)
+       qi_bl1_old(kts:kte)    =qi_bl1(kts:kte)
+    else
+       cldfra_bl1    =0.0
+       qc_bl1        =0.0
+       qi_bl1        =0.0
+       cldfra_bl1_old=0.0
+       qc_bl1_old    =0.0
+       qi_bl1_old    =0.0
+    endif
+    dqc1(kts:kte)    =0.0
+    dqi1(kts:kte)    =0.0
+    dqs1(kts:kte)    =0.0
+    dqni1(kts:kte)   =0.0
+    dqnc1(kts:kte)   =0.0
+    dqnwfa1(kts:kte) =0.0
+    dqnifa1(kts:kte) =0.0
+    dqnbca1(kts:kte) =0.0
+    dozone1(kts:kte) =0.0
+!    if (spp_pbl==1) then
+!       rstoch_col1(kts:kte)=pattern_spp_pbl1(kts:kte)
+!    else
+!       rstoch_col1(kts:kte)=0.0
+!    endif
+    !edmf
+    edmf_a1    =0.0
+    edmf_w1    =0.0
+    edmf_qc1   =0.0
+    s_aw1      =0.0
+    s_awthl1   =0.0
+    s_awqt1    =0.0
+    s_awqv1    =0.0
+    s_awqc1    =0.0
+    s_awu1     =0.0
+    s_awv1     =0.0
+    s_awqke1   =0.0
+    s_awqnc1   =0.0
+    s_awqni1   =0.0
+    s_awqnwfa1 =0.0
+    s_awqnifa1 =0.0
+    s_awqnbca1 =0.0
+    s_awchem1(kts:kte+1,1:nchem)   = 0.0
+    !edmf-downdraft
+    edmf_a_dd1 =0.0
+    edmf_w_dd1 =0.0
+    edmf_qc_dd1=0.0
+    sd_aw1     =0.0
+    sd_awthl1  =0.0
+    sd_awqt1   =0.0
+    sd_awqv1   =0.0
+    sd_awqc1   =0.0
+    sd_awqi1   =0.0
+    sd_awqnc1  =0.0
+    sd_awqni1  =0.0
+    sd_awqnwfa1=0.0
+    sd_awqnifa1=0.0
+    sd_awu1    =0.0
+    sd_awv1    =0.0
+    sd_awqke1  =0.0
+    sub_thl1   =0.0
+    sub_sqv1   =0.0
+    sub_u1     =0.0
+    sub_v1     =0.0
+    det_thl1   =0.0
+    det_sqv1   =0.0
+    det_sqc1   =0.0
+    det_u1     =0.0
+    det_v1     =0.0
+
+    do k = kts,kte
+       if (k==kts) then
+           zw1(k)=0.
+       else
+           zw1(k)=zw1(k-1)+dz1(k-1)
+       endif
+       !keep snow out for now - increases ceiling bias
+       sqw1(k)= sqv1(k)+sqc1(k)+sqi1(k)!+sqs1(k)
+       thl1(k)= th1(k) - xlvcp/ex1(k)*sqc1(k) &
+             &         - xlscp/ex1(k)*(sqi1(k))!+sqs1(k))
+       !Use form from Tripoli and Cotton (1981) with their
+       !suggested min temperature to improve accuracy.
+       !thl1(k)=th1(i,k)*(1.- xlvcp/MAX(tk1(k),TKmin)*sqc1(k) &
+       !    &               - xlscp/MAX(tk1(k),TKmin)*sqi1(k))
+       thv1(k)=th1(k)*(1.+p608*sqv1(k))
+    enddo ! end k
+    zw1(kte+1)=zw1(kte)+dz1(kte)
+
+!>  - Call get_pblh() to calculate the hybrid \f$\theta_{v}-TKE\f$
+!! PBL height diagnostic.
+    CALL GET_PBLH(KTS,KTE,PBLH,thv1,qke1,zw1,dz1,xland,KPBL)
+
+!>  - Call scale_aware() to calculate the similarity functions,
+!! \f$P_{\sigma-PBL}\f$ and \f$P_{\sigma-shcu}\f$, to control 
+!! the scale-adaptive behaviour for the local and nonlocal 
+!! components, respectively.
+    if (scaleaware > 0.) then
+       call SCALE_AWARE(dx,PBLH,Psig_bl,Psig_shcu)
+    else
+       Psig_bl=1.0
+       Psig_shcu=1.0
+    endif
+
+    sqcg= 0.0   !ill-defined variable; qcg has been removed
+    cpm=cp*(1.+0.84*qv1(kts))
+    exnerg=(ps/p1000mb)**rcp
+
+    !-----------------------------------------------------
+    !ORIGINAL CODE
+    !flt = hfx(i)/( rho(i,kts)*cpm ) &
+    ! +xlvcp*ch(i)*(sqc(kts)/exner(i,kts) -sqcg/exnerg)
+    !flq = qfx(i)/  rho(i,kts)       &
+    !    -ch(i)*(sqc(kts)   -sqcg )
+    !-----------------------------------------------------
+    flqv = qfx/rho1(kts)
+    flqc = 0.0 !currently no sea-spray fluxes, fog settling handled elsewhere
+    th_sfc = ts/ex1(kts)
+
+    ! TURBULENT FLUX FOR TKE BOUNDARY CONDITIONS
+    flq =flqv+flqc                   !! LATENT
+    flt =hfx/(rho1(kts)*cpm )-xlvcp*flqc/ex1(kts)  !! Temperature flux
+    fltv=flt + flqv*p608*th_sfc      !! Virtual temperature flux
+
+    ! Update 1/L using updated sfc heat flux and friction velocity
+    rmol = -karman*gtr*fltv/max(ust**3,1.0e-6)
+    zet = half*dz1(kts)*rmol
+    zet = MAX(zet, -20.)
+    zet = MIN(zet,  20.)
+    !if(i.eq.idbg)print*,"updated z/L=",zet
+    if (bl_mynn_stfunc == 0) then
+       !Original Kansas-type stability functions
+       if ( zet >= 0.0 ) then
+          pmz = 1.0 + (cphm_st-1.0) * zet
+          phh = 1.0 +  cphh_st      * zet
+       else
+          pmz = 1.0/    (1.0-cphm_unst*zet)**0.25 - zet
+          phh = 1.0/SQRT(1.0-cphh_unst*zet)
+       end if
+    else
+       !Updated stability functions (Puhales, 2020)
+       phi_m = phim(zet)
+       pmz   = phi_m - zet
+       phh   = phih(zet)
+    end if
+
+!>  - Call mym_condensation() to calculate the nonconvective component
+!! of the subgrid cloud fraction and mixing ratio as well as the functions
+!! used to calculate the buoyancy flux. Different cloud PDFs can be
+!! selected by use of the namelist parameter \p bl_mynn_cloudpdf.
+
+    call mym_condensation (kts,kte,                   &
+         &dx,dz1,zw1,xland,                           &
+         &thl1,sqw1,sqv1,sqc1,sqi1,sqs1,              &
+         &p1,ex1,tsq1,qsq1,cov1,                      &
+         &sh1,el1,bl_mynn_cloudpdf,                   &
+         &qc_bl1,qi_bl1,cldfra_bl1,                   &
+         &pblh,hfx,                                   &
+         &vt1, vq1, th1, sgm1,                        &
+         &spp_pbl, pattern_spp_pbl1                   )
+
+!>  - Add TKE source driven by cloud top cooling
+!!  Calculate the buoyancy production of TKE from cloud-top cooling when
+!! \p bl_mynn_topdown =1.
+    if (bl_mynn_topdown.eq.1) then
+       call topdown_cloudrad(kts,kte,dz1,zw1,fltv,     &
+            &xland,kpbl,PBLH,                          &
+            &sqc1,sqi1,sqw1,thl1,th1,ex1,p1,rho1,thv1, &
+            &cldfra_bl1,rthraten1,                     &
+            &maxKHtopdown,KHtopdown,TKEprod_dn         )
+    else
+       maxKHtopdown       = 0.0
+       KHtopdown(kts:kte) = 0.0
+       TKEprod_dn(kts:kte)= 0.0
+    endif
+
+    if (bl_mynn_edmf > 0) then
+       !PRINT*,"Calling DMP Mass-Flux"
+       call DMP_mf(                                   &
+            &kts,kte,delt,zw1,dz1,p1,rho1,            &
+            &bl_mynn_edmf_mom,                        &
+            &bl_mynn_edmf_tke,                        &
+            &bl_mynn_mixscalars,                      &
+            &u1,v1,w1,th1,thl1,thv1,tk1,              &
+            &sqw1,sqv1,sqc1,qke1,                     &
+            &qnc1,qni1,qnwfa1,qnifa1,qnbca1,          &
+            &ex1,vt1,vq1,sgm1,                        &
+            &ust,flt,fltv,flq,flqv,                   &
+            &pblh,kpbl,dx,                            &
+            &xland,th_sfc,                            &
+            ! now outputs - tendencies
+            ! &,dth1mf,dqv1mf,dqc1mf,du1mf,dv1mf         &
+            ! outputs - updraft properties
+            &edmf_a1,edmf_w1,edmf_qt1,                &
+            &edmf_thl1,edmf_ent1,edmf_qc1,            &
+            ! for the solver
+            &s_aw1,s_awthl1,s_awqt1,                  &
+            &s_awqv1,s_awqc1,                         &
+            &s_awu1,s_awv1,s_awqke1,                  &
+            &s_awqnc1,s_awqni1,                       &
+            &s_awqnwfa1,s_awqnifa1,s_awqnbca1,        &
+            &sub_thl1,sub_sqv1,                       &
+            &sub_u1,sub_v1,                           &
+            &det_thl1,det_sqv1,det_sqc1,              &
+            &det_u1,det_v1,                           &
+            ! chem/smoke mixing
+            &nchem,chem,s_awchem1,                    &
+            &mix_chem,                                &
+            &qc_bl1,cldfra_bl1,                       &
+            &qc_bl1_old,cldfra_bl1_old,               &
+            &FLAG_QC,FLAG_QI,                         &
+            &FLAG_QNC,FLAG_QNI,                       &
+            &FLAG_QNWFA,FLAG_QNIFA,FLAG_QNBCA,        &
+            &Psig_shcu,                               &
+            &maxwidth,ktop_plume,                     &
+            &maxmf,ztop_plume,                        &
+            &spp_pbl,pattern_spp_pbl1,                &
+            &TKEprod_up,el1                           )
+    else
+       TKEprod_up(kts:kte)= 0.0
+    endif
+
+    if (bl_mynn_edmf_dd == 1) then
+       call ddmp_mf(kts,kte,delt,dx,zw1,dz1,p1,       &
+            &u1,v1,th1,thl1,thv1,tk1,                 &
+            &sqw1,sqv1,sqc1,sqi1,qnc1,qni1,           &
+            &qnwfa1,qnifa1,                           &
+            &qke1,rho1,ex1,                           &
+            &qc_bl1,qi_bl1,cldfra_bl1,                &
+            &ust,flt,flq,fltv,                        &
+            &pblh,kpbl,                               &
+            &edmf_a_dd1,edmf_w_dd1,edmf_qt_dd1,       &
+            &edmf_thl_dd1,edmf_ent_dd1,               &
+            &edmf_qc_dd1,                             &
+            &sd_aw1,sd_awthl1,sd_awqt1,               &
+            &sd_awqv1,sd_awqc1,sd_awqi1,              &
+            &sd_awqnc1,sd_awqni1,                     &
+            &sd_awqnwfa1,sd_awqnifa1,                 &
+            &sd_awu1,sd_awv1,                         &
+            &sd_awqke1,                               &
+            &tkeprod_dn,el1,                          &
+            &rthraten1                                )
+    endif
+
+    !Capability to substep the eddy-diffusivity portion
+    !do nsub = 1,2
+    delt2 = delt !*0.5    !only works if topdown=0
+
+    !thlv with updated subgrid clouds
+    do k=kts,kte
+       thlv1(k)=(th1(k) - xlvcp/ex1(k)*max(qc_bl1(k),sqc1(k))         &
+                &       - xlscp/ex1(k)*max(qi_bl1(k),sqi1(k)+sqs1(k))) &
+                &       * (1.+p608*sqv1(k))
+    enddo
+
+    call mym_turbulence(                                 &
+            &kts,kte,xland,closure,                      &
+            &dz1, dx, zw1,                               &
+            &u1, v1, thl1, thv1, thlv1,                  &
+            &sqc1, sqw1,                                 &
+            &qke1, tsq1, qsq1, cov1,                     &
+            &vt1, vq1,                                   &
+            &rmol, flt, fltv, flq,                       &
+            &pblh, th1,                                  &
+            &sh1,sm1,el1,                                &
+            &Dfm1,Dfh1,Dfq1,                             &
+            &Tcd1,Qcd1,Pdk1,                             &
+            &Pdt1,Pdq1,Pdc1,                             &
+            &qWT1,qSHEAR1,qBUOY1,qDISS1,                 &
+            &tke_budget,                                 &
+            &Psig_bl,Psig_shcu,                          &
+            &cldfra_bl1,bl_mynn_mixlength,               &
+            &edmf_w1,edmf_a1,                            &
+            &edmf_w_dd1,edmf_a_dd1,                      &
+            &TKEprod_dn,TKEprod_up,                      &
+            &spp_pbl,pattern_spp_pbl1                    )
+
+!>  - Call mym_predict() to solve TKE and 
+!! \f$\theta^{'2}, q^{'2}, and \theta^{'}q^{'}\f$
+!! for the following time step.
+    call mym_predict(kts,kte,closure,                    &
+            &delt2, dz1,                                 &
+            &ust, flt, flq, pmz, phh,                    &
+            &el1, dfq1, rho1, pdk1, pdt1, pdq1, pdc1,    &
+            &qke1, tsq1, qsq1, cov1,                     &
+            &s_aw1, s_awqke1, bl_mynn_edmf_tke,          &
+            &qWT1, qDISS1, tke_budget                    )
+
+    if (dheat_opt > 0) then
+       do k=kts,kte-1
+          ! Set max dissipative heating rate to 7.2 K per hour
+          diss_heat1(k) = MIN(MAX(1.0*(qke1(k)**1.5)/(b1*MAX(half*(el1(k)+el1(k+1)),1.))/cp, 0.0),0.002)
+          ! Limit heating above 100 mb:
+          diss_heat1(k) = diss_heat1(k) * exp(-10000./MAX(p1(k),1.)) 
+       enddo
+       diss_heat1(kte) = 0.
+    else
+       diss_heat1(1:kte) = 0.
+    endif
+
+!>  - Call mynn_tendencies() to solve for tendencies of 
+!! \f$U, V, \theta, q_{v}, q_{c}, and q_{i}\f$.
+    call mynn_tendencies(kts,kte,i,                      &
+            &delt, dz1, rho1,                            &
+            &u1, v1, th1, tk1, qv1,                      &
+            &qc1, qi1, kzero1, qnc1, qni1,               & !kzero replaces qs1 - not mixing snow
+            &ps, p1, ex1, thl1,                          &
+            &sqv1, sqc1, sqi1, kzero1, sqw1,             & !kzero replaces sqs - not mixing snow
+            &qnwfa1, qnifa1, qnbca1, ozone1,             &
+            &ust,flt,flq,flqv,flqc,                      &
+            &wspd,uoce,voce,                             &
+            &tsq1, qsq1, cov1,                           &
+            &tcd1, qcd1,                                 &
+            &dfm1, dfh1, dfq1,                           &
+            &Du1, Dv1, Dth1, Dqv1,                       &
+            &Dqc1, Dqi1, Dqs1, Dqnc1, Dqni1,             &
+            &Dqnwfa1, Dqnifa1, Dqnbca1,                  &
+            &Dozone1,                                    &
+            &diss_heat1,                                 &
+            ! mass flux components
+            &s_aw1,s_awthl1,s_awqt1,                     &
+            &s_awqv1,s_awqc1,s_awu1,s_awv1,              &
+            &s_awqnc1,s_awqni1,                          &
+            &s_awqnwfa1,s_awqnifa1,s_awqnbca1,           &
+            &sd_aw1,sd_awthl1,sd_awqt1,                  &
+            &sd_awqv1,sd_awqc1,sd_awqi1,                 &
+            &sd_awqnc1,sd_awqni1,                        &
+            &sd_awqnwfa1,sd_awqnifa1,                    &
+            &sd_awu1,sd_awv1,                            &
+            &sub_thl1,sub_sqv1,                          &
+            &sub_u1,sub_v1,                              &
+            &det_thl1,det_sqv1,det_sqc1,                 &
+            &det_u1,det_v1,                              &
+            &FLAG_QC,FLAG_QI,FLAG_QNC,                   &
+            &FLAG_QNI,FLAG_QS,                           &
+            &FLAG_QNWFA,FLAG_QNIFA,                      &
+            &FLAG_QNBCA,FLAG_OZONE,                      &
+            &cldfra_bl1,                                 &
+            &bl_mynn_cloudmix,                           &
+            &bl_mynn_mixqt,                              &
+            &bl_mynn_edmf,                               &
+            &bl_mynn_edmf_mom,                           &
+            &bl_mynn_mixscalars                          )
+
+    if ( mix_chem ) then
+       if ( rrfs_sd ) then 
+          call mynn_mix_chem(kts,kte,i,                  &
+               &delt, dz1, pblh,                         &
+               &nchem, kdvel, ndvel,                     &
+               &chem, vdep,                              &
+               &rho1, flt,                               &
+               &tcd1, qcd1,                              &
+               &dfh1,                                    &
+               &s_aw1,s_awchem1,                         &
+               &emis_ant_no,                             &
+               &frp, rrfs_sd,                            &
+               &enh_mix, smoke_dbg                       )
+       else
+          call mynn_mix_chem(kts,kte,i,                  &
+               &delt, dz1, pblh,                         &
+               &nchem, kdvel, ndvel,                     &
+               &chem, vdep,                              &
+               &rho1, flt,                               &
+               &tcd1, qcd1,                              &
+               &dfh1,                                    &
+               &s_aw1,s_awchem1,                         &
+               &zero,                                    &
+               &zero, rrfs_sd,                           &
+               &enh_mix, smoke_dbg                       )
+       endif
+       do ic = 1,nchem
+          do k = kts,kte
+             chem(k,ic) = max(1.e-12, chem(k,ic))
+          enddo
+       enddo
+    endif
+ 
+    call retrieve_exchange_coeffs(kts,kte,               &
+         &dfm1, dfh1, dz1, km1, kh1                      )
+
+    !update the TKE budget
+    if (tke_budget .eq. 1) then
+       !! TKE budget is now given in m**2/s**-3 (Puhales, 2020)
+       !! Lower boundary condtions (using similarity relationships such as the prognostic equation for Qke)
+       k=kts
+       qSHEAR1(k)   = 4.*(ust**3*phi_m/(karman*dz1(k)))-qSHEAR1(k+1) !! staggered
+       qBUOY1(k)    = 4.*(-ust**3*zet/(karman*dz1(k)))-qBUOY1(k+1) !! staggered
+       !! unstaggering SHEAR and BUOY and trasfering all TKE budget to 3D array               
+       do k = kts,kte-1
+          dummy1(k) = half*(qSHEAR1(k)+qSHEAR1(k+1)) !!! unstaggering in z
+          dummy2(k) = half*(qBUOY1(k)+qBUOY1(k+1)) !!! unstaggering in z
+          dqke1(k)  = half*(qke1(k)-dqke1(k))/delt
+       enddo
+       qSHEAR1      = dummy1
+       qBUOY1       = dummy2
+       !! Upper boundary conditions               
+       k=kte
+       qSHEAR1(k)   = 0.
+       qBUOY1(k)    = 0.
+       qWT1(k)      = 0.
+       qDISS1(k)    = 0.
+       dqke1(k)     = 0.
+    endif
+
+    !update updraft/downdraft properties
+    if (bl_mynn_output > 0) then !research mode == 1 or 2
+       !if mode 2, then overwrite updrafts with downdrafts
+       if (bl_mynn_output == 2 .and. bl_mynn_edmf_dd == 1) then
+          edmf_a1(kts:kte)   =edmf_a_dd1(kts:kte)
+          edmf_w1(kts:kte)   =edmf_w_dd1(kts:kte)
+          edmf_qt1(kts:kte)  =edmf_qt_dd1(kts:kte)
+          edmf_thl1(kts:kte) =edmf_thl_dd1(kts:kte)
+          edmf_ent1(kts:kte) =edmf_ent_dd1(kts:kte)
+          edmf_qc1(kts:kte)  =edmf_qc_dd1(kts:kte)
+       endif
+    endif
+
+    !***  Begin debug prints
+    if ( debug_code .and. (i .eq. idbg)) THEN
+       if ( ABS(QFX)>.001)print*,&
+          "SUSPICIOUS VALUES AT: i=",i," QFX=",QFX
+       if ( ABS(HFX)>1100.)print*,&
+          "SUSPICIOUS VALUES AT: i=",i," HFX=",HFX
+       do k = kts,kte
+          IF ( sh1(k) < 0. .OR. sh1(k)> 200.)print*,&
+             "SUSPICIOUS VALUES AT: i,k=",i,k," sh=",sh1(k)
+          IF ( ABS(vt1(k)) > 2.0 )print*,&
+             "SUSPICIOUS VALUES AT: i,k=",i,k," vt=",vt1(k)
+          IF ( ABS(vq1(k)) > 7000.)print*,&
+             "SUSPICIOUS VALUES AT: i,k=",i,k," vq=",vq1(k)
+          IF ( qke1(k) < -1. .OR. qke1(k)> 200.)print*,&
+             "SUSPICIOUS VALUES AT: i,k=",i,k," qke=",qke1(k)
+          IF ( el1(k) < 0. .OR. el1(k)> 1500.)print*,&
+             "SUSPICIOUS VALUES AT: i,k=",i,k," el1=",el1(k)
+          IF ( km1(k) < 0. .OR. km1(k)> 2000.)print*,&
+             "SUSPICIOUS VALUES AT: i,k=",i,k," km=",km1(k)
+          IF (icloud_bl > 0) then
+             IF (cldfra_bl1(k) < 0.0 .OR. cldfra_bl1(k)> 1.)THEN
+                PRINT*,"SUSPICIOUS VALUES: CLDFRA_BL=",cldfra_bl1(k),&
+                                             " qc_bl=",qc_bl1(k)
+             endif
+          endif
+       enddo !end-k
+    endif
+
+!ACF copy qke into qke_adv if using advection
+    IF (bl_mynn_tkeadvect) THEN
+       qke_adv1=qke1
+    ENDIF
+!ACF-end
+
+#ifdef HARDCODE_VERTICAL
+# undef kts
+# undef kte
+#endif
+
+  END SUBROUTINE mynn_bl_driver
+!> @}
+
+!=======================================================================
 !     SUBROUTINE  mym_initialize:
 !
 !     Input variables:
 !       iniflag         : <>0; turbulent quantities will be initialized
 !                         = 0; turbulent quantities have been already
 !                              given, i.e., they will not be initialized
-!       mx, my          : Maximum numbers of grid boxes
-!                         in the x and y directions, respectively
-!       nx, ny, nz      : Numbers of the actual grid boxes
-!                         in the x, y and z directions, respectively
+!       nx, nz          : Dimension sizes of the
+!                         x and z directions, respectively
 !       tref            : Reference temperature                      (K)
-!       dz(nz)        : Vertical grid spacings                     (m)
+!       dz(nz)          : Vertical grid spacings                     (m)
 !                         # dz(nz)=dz(nz-1)
 !       zw(nz+1)        : Heights of the walls of the grid boxes     (m)
 !                         # zw(1)=0.0 and zw(k)=zw(k-1)+dz(k-1)
-!       h(mx,ny)        : G^(1/2) in the terrain-following coordinate
-!                         # h=1-zg/zt, where zg is the height of the
-!                           terrain and zt the top of the model domain
-!       pi0(mx,my,nz) : Exner function at zw*h+zg             (J/kg K)
+!       exner(nx,nz)    : Exner function at zw*h+zg             (J/kg K)
 !                         defined by c_p*( p_basic/1000hPa )^kappa
 !                         This is usually computed by integrating
 !                         d(pi0)/dz = -h*g/tref.
-!       rmo(mx,ny)      : Inverse of the Obukhov length         (m^(-1))
-!       flt, flq(mx,ny) : Turbulent fluxes of sensible and latent heat,
-!                         respectively, e.g., flt=-u_*Theta_* (K m/s)
-!! flt - liquid water potential temperature surface flux
-!! flq - total water flux surface flux
-!       ust(mx,ny)      : Friction velocity                        (m/s)
-!       pmz(mx,ny)      : phi_m-zeta at z1*h+z0, where z1 (=0.5*dz(1))
+!       rmol(nx)        : Inverse of the Obukhov length         (m^(-1))
+!       flt, flq(nx)    : Turbulent fluxes of potential temperature and
+!                         total water, respectively:
+!                                    flt=-u_*Theta_*             (K m/s)
+!                                    flq=-u_*qw_*            (kg/kg m/s)
+!       ust(nx)         : Friction velocity                        (m/s)
+!       pmz(nx)         : phi_m-zeta at z1*h+z0, where z1 (=0.5*dz(1))
 !                         is the first grid point above the surafce, z0
 !                         the roughness length and zeta=(z1*h+z0)*rmo
-!       phh(mx,ny)      : phi_h at z1*h+z0
-!       u, v(mx,my,nz): Components of the horizontal wind        (m/s)
-!       thl(mx,my,nz)  : Liquid water potential temperature
+!       phh(nx)         : phi_h at z1*h+z0
+!       u, v(nx,nz)     : Components of the horizontal wind        (m/s)
+!       thl(nx,nz)      : Liquid water potential temperature
 !                                                                    (K)
-!       qw(mx,my,nz)  : Total water content Q_w                (kg/kg)
+!       qw(nx,nz)       : Total water content Q_w                (kg/kg)
 !
 !     Output variables:
-!       ql(mx,my,nz)  : Liquid water content                   (kg/kg)
-!       v?(mx,my,nz)  : Functions for computing the buoyancy flux
-!       qke(mx,my,nz) : Twice the turbulent kinetic energy q^2
+!       ql(nx,nz)       : Liquid water content                   (kg/kg)
+!       vt, vq(nx,nz)   : Functions for computing the buoyancy flux
+!       qke(nx,nz)      : Twice the turbulent kinetic energy q^2
 !                                                              (m^2/s^2)
-!       tsq(mx,my,nz) : Variance of Theta_l                      (K^2)
-!       qsq(mx,my,nz) : Variance of Q_w
-!       cov(mx,my,nz) : Covariance of Theta_l and Q_w              (K)
-!       el(mx,my,nz)  : Master length scale L                      (m)
+!       tsq(nx,nz)      : Variance of Theta_l                      (K^2)
+!       qsq(nx,nz)      : Variance of Q_w
+!       cov(nx,nz)      : Covariance of Theta_l and Q_w              (K)
+!       el(nx,nz)       : Master length scale L                      (m)
 !                         defined on the walls of the grid boxes
-!       bsh             : no longer used
-!       via common      : Closure constants
 !
 !     Work arrays:        see subroutine mym_level2
-!       pd?(mx,my,nz) : Half of the production terms at Level 2
+!       pd?(nx,nz,ny) : Half of the production terms at Level 2
 !                         defined on the walls of the grid boxes
-!       qkw(mx,my,nz) : q on the walls of the grid boxes         (m/s)
+!       qkw(nx,nz,ny) : q on the walls of the grid boxes         (m/s)
 !
 !     # As to dtl, ...gh, see subroutine mym_turbulence.
 !
 !-------------------------------------------------------------------
-  SUBROUTINE  mym_initialize ( kts,kte,&
-       &            dz, zw,  &
-       &            u, v, thl, qw, &
-!       &            ust, rmo, pmz, phh, flt, flq,&
-!JOE-BouLac/PBLH mod
-       &        zi,theta,&
-       &        sh,&
-!JOE-end
-       &            ust, rmo, el,&
-       &            Qke, Tsq, Qsq, Cov)
+
+!>\ingroup gsd_mynn_edmf
+!! This subroutine initializes the mixing length, TKE, \f$\theta^{'2}\f$,
+!! \f$q^{'2}\f$, and \f$\theta^{'}q^{'}\f$.
+!!\section gen_mym_ini GSD MYNN-EDMF mym_initialize General Algorithm 
+!> @{
+  SUBROUTINE  mym_initialize (                                & 
+       &            kts,kte,xland,                            &
+       &            dz, dx, zw,                               &
+       &            u, v, thl, qw,                            &
+!       &            ust, rmo, pmz, phh, flt, flq,             &
+       &            zi, theta, thv, thlv, sh, sm,             &
+       &            ust, rmol, el,                            &
+       &            Qke, Tsq, Qsq, Cov, Psig_bl, cldfra_bl1,  &
+       &            bl_mynn_mixlength,                        &
+       &            edmf_w1,edmf_a1,                          &
+       &            edmf_w_dd1,edmf_a_dd1,                    &
+       &            INITIALIZE_QKE,                           &
+       &            spp_pbl,pattern_spp_pbl1                  )
 !
 !-------------------------------------------------------------------
-    
-    INTEGER, INTENT(IN)   :: kts,kte
-!    REAL, INTENT(IN)   :: ust, rmo, pmz, phh, flt, flq
-    REAL, INTENT(IN)   :: ust, rmo
-    REAL, DIMENSION(kts:kte), INTENT(in) :: dz
-    REAL, DIMENSION(kts:kte+1), INTENT(in) :: zw
-    REAL, DIMENSION(kts:kte), INTENT(in) :: u,v,thl,qw
 
-    REAL, DIMENSION(kts:kte), INTENT(out) :: tsq,qsq,cov
-    REAL, DIMENSION(kts:kte), INTENT(inout) :: el,qke
-
-    REAL, DIMENSION(kts:kte) :: &
-         &ql,pdk,pdt,pdq,pdc,dtl,dqw,dtv,&
+    integer, intent(in)           :: kts,kte
+    integer, intent(in)           :: bl_mynn_mixlength
+    logical, intent(in)           :: INITIALIZE_QKE
+!    real(kind_phys), intent(in)   :: ust, rmol, pmz, phh, flt, flq
+    real(kind_phys), intent(in)   :: rmol, Psig_bl, xland
+    real(kind_phys), intent(in)   :: dx, ust, zi
+    real(kind_phys), dimension(kts:kte),   intent(in) :: dz
+    real(kind_phys), dimension(kts:kte+1), intent(in) :: zw
+    real(kind_phys), dimension(kts:kte),   intent(in) :: u,v,thl,&
+         &thlv,qw,cldfra_bl1,edmf_w1,edmf_a1,edmf_w_dd1,edmf_a_dd1
+    real(kind_phys), dimension(kts:kte),   intent(inout) :: tsq,qsq,cov
+    real(kind_phys), dimension(kts:kte),   intent(inout) :: el,qke
+    real(kind_phys), dimension(kts:kte) ::                       &
+         &ql,pdk,pdt,pdq,pdc,dtl,dqw,dtv,                        &
          &gm,gh,sm,sh,qkw,vt,vq
-    INTEGER :: k,l,lmax
-    REAL :: phm,vkz,elq,elv,b1l,b2l,pmz=1.,phh=1.,flt=0.,flq=0.,tmpq
-!JOE-BouLac and PBLH mod
-    REAL :: zi
-    REAL, DIMENSION(kts:kte) :: theta
-!JOE-end
+    integer :: k,l,lmax
+    real(kind_phys):: phm,vkz,elq,elv,b1l,b2l,pmz=1.,phh=1.,     &
+         &flt=0.,fltv=0.,flq=0.,tmpq
+    real(kind_phys), dimension(kts:kte) :: theta,thv
+    real(kind_phys), dimension(kts:kte) :: pattern_spp_pbl1
+    integer ::spp_pbl
 
-
-!   **  At first ql, vt and vq are set to zero.  **
+!> - At first ql, vt and vq are set to zero.
     DO k = kts,kte
        ql(k) = 0.0
        vt(k) = 0.0
        vq(k) = 0.0
     END DO
 !
-    CALL mym_level2 ( kts,kte,&
-         &            dz,  &
-         &            u, v, thl, qw, &
-         &            ql, vt, vq, &
+!> - Call mym_level2() to calculate the stability functions at level 2.
+    CALL mym_level2 ( kts,kte,                      &
+         &            dz,                           &
+         &            u, v, thl, thv, thlv, qw,     &
+         &            ql, vt, vq,                   &
          &            dtl, dqw, dtv, gm, gh, sm, sh )
 !
 !   **  Preliminary setting  **
 
     el (kts) = 0.0
-    qke(kts) = ust**2 * ( b1*pmz )**(2.0/3.0)
+    IF (INITIALIZE_QKE) THEN
+       !qke(kts) = ust**2 * ( b1*pmz )**(2.0/3.0)
+       qke(kts) = 1.5 * ust**2 * ( b1*pmz )**(2.0/3.0)
+       DO k = kts+1,kte
+          !qke(k) = 0.0
+          !linearly taper off towards top of pbl
+          qke(k)=qke(kts)*MAX((ust*700. - zw(k))/(MAX(ust,0.01)*700.), 0.01)
+       ENDDO
+    ENDIF
 !
     phm      = phh*b2 / ( b1*pmz )**(1.0/3.0)
     tsq(kts) = phm*( flt/ust )**2
@@ -339,9 +1352,9 @@ CONTAINS
     cov(kts) = phm*( flt/ust )*( flq/ust )
 !
     DO k = kts+1,kte
-       vkz = vk*zw(k)
+       vkz = karman*zw(k)
        el (k) = vkz/( 1.0 + vkz/100.0 )
-       qke(k) = 0.0
+!       qke(k) = 0.0
 !
        tsq(k) = 0.0
        qsq(k) = 0.0
@@ -350,61 +1363,68 @@ CONTAINS
 !
 !   **  Initialization with an iterative manner          **
 !   **  lmax is the iteration count. This is arbitrary.  **
-    lmax = 5 
+    lmax = 5
 !
     DO l = 1,lmax
 !
-       CALL mym_length ( kts,kte,&
-            &            dz, zw, &
-            &            rmo, flt, flq, &
-            &            vt, vq, &
-            &            qke, &
-            &            dtv, &
-            &            el, &
-!JOE-added for BouLac/PBHL
-            &            zi,theta,&
-!JOE-end
-            &            qkw)
+!> - call mym_length() to calculate the master length scale.
+       CALL mym_length (                          &
+            &            kts,kte,xland,           &
+            &            dz, dx, zw,              &
+            &            rmol, flt, fltv, flq,    &
+            &            vt, vq,                  &
+            &            u, v, qke,               &
+            &            dtv,                     &
+            &            el,                      &
+            &            zi,theta,                &
+            &            qkw,Psig_bl,cldfra_bl1,  &
+            &            bl_mynn_mixlength,       &
+            &            edmf_w1,edmf_a1,         &
+            &            edmf_w_dd1,edmf_a_dd1    )
 !
        DO k = kts+1,kte
           elq = el(k)*qkw(k)
-          pdk(k) = elq*( sm(k)*gm (k)+&
-               &sh(k)*gh (k) )
+          pdk(k) = elq*( sm(k)*gm(k) + &
+               &         sh(k)*gh(k) )
           pdt(k) = elq*  sh(k)*dtl(k)**2
           pdq(k) = elq*  sh(k)*dqw(k)**2
           pdc(k) = elq*  sh(k)*dtl(k)*dqw(k)
        END DO
 !
-!   **  Strictly, vkz*h(i,j) -> vk*( 0.5*dz(1)*h(i,j)+z0 )  **
-       vkz = vk*0.5*dz(kts)
-!
-       elv = 0.5*( el(kts+1)+el(kts) ) /  vkz 
-       qke(kts) = ust**2 * ( b1*pmz*elv    )**(2.0/3.0)
-!
+!   **  Strictly, vkz*h(i,j) -> karman*( 0.5*dz(1)*h(i,j)+z0 )  **
+       vkz = karman*half*dz(kts)
+       elv = half*( el(kts+1)+el(kts) ) /  vkz
+       IF (INITIALIZE_QKE)THEN 
+          !qke(kts) = ust**2 * ( b1*pmz*elv    )**(2.0/3.0)
+          qke(kts) = 1.0 * MAX(ust,0.02)**2 * ( b1*pmz*elv    )**(2.0/3.0) 
+       ENDIF
+
        phm      = phh*b2 / ( b1*pmz/elv**2 )**(1.0/3.0)
        tsq(kts) = phm*( flt/ust )**2
        qsq(kts) = phm*( flq/ust )**2
        cov(kts) = phm*( flt/ust )*( flq/ust )
-!
+
        DO k = kts+1,kte-1
           b1l = b1*0.25*( el(k+1)+el(k) )
-          tmpq=MAX(b1l*( pdk(k+1)+pdk(k) ),qkemin)
+          !tmpq=MAX(b1l*( pdk(k+1)+pdk(k) ),qkemin)
+          !add MIN to limit unreasonable QKE
+          tmpq=MIN(MAX(b1l*( pdk(k+1)+pdk(k) ),qkemin),125.)
 !          PRINT *,'tmpqqqqq',tmpq,pdk(k+1),pdk(k)
-          qke(k) = tmpq**(2.0/3.0)
+          IF (INITIALIZE_QKE)THEN
+             qke(k) = tmpq**twothirds
+          ENDIF
 
-!
           IF ( qke(k) .LE. 0.0 ) THEN
              b2l = 0.0
           ELSE
              b2l = b2*( b1l/b1 ) / SQRT( qke(k) )
           END IF
-!
+
           tsq(k) = b2l*( pdt(k+1)+pdt(k) )
           qsq(k) = b2l*( pdq(k+1)+pdq(k) )
           cov(k) = b2l*( pdc(k+1)+pdc(k) )
        END DO
 
-!
     END DO
 
 !!    qke(kts)=qke(kts+1)
@@ -412,7 +1432,10 @@ CONTAINS
 !!    qsq(kts)=qsq(kts+1)
 !!    cov(kts)=cov(kts+1)
 
-    qke(kte)=qke(kte-1)
+    IF (INITIALIZE_QKE)THEN
+       qke(kts)=0.5*(qke(kts)+qke(kts+1))
+       qke(kte)=qke(kte-1)
+    ENDIF
     tsq(kte)=tsq(kte-1)
     qsq(kte)=qsq(kte-1)
     cov(kte)=cov(kte-1)
@@ -421,6 +1444,7 @@ CONTAINS
 !    RETURN
 
   END SUBROUTINE mym_initialize
+!> @}
   
 !
 ! ==================================================================
@@ -429,60 +1453,84 @@ CONTAINS
 !     Input variables:    see subroutine mym_initialize
 !
 !     Output variables:
-!       dtl(mx,my,nz) : Vertical gradient of Theta_l             (K/m)
-!       dqw(mx,my,nz) : Vertical gradient of Q_w
-!       dtv(mx,my,nz) : Vertical gradient of Theta_V             (K/m)
-!       gm (mx,my,nz) : G_M divided by L^2/q^2                (s^(-2))
-!       gh (mx,my,nz) : G_H divided by L^2/q^2                (s^(-2))
-!       sm (mx,my,nz) : Stability function for momentum, at Level 2
-!       sh (mx,my,nz) : Stability function for heat, at Level 2
+!       dtl(nx,nz,ny) : Vertical gradient of Theta_l             (K/m)
+!       dqw(nx,nz,ny) : Vertical gradient of Q_w
+!       dtv(nx,nz,ny) : Vertical gradient of Theta_V             (K/m)
+!       gm (nx,nz,ny) : G_M divided by L^2/q^2                (s^(-2))
+!       gh (nx,nz,ny) : G_H divided by L^2/q^2                (s^(-2))
+!       sm (nx,nz,ny) : Stability function for momentum, at Level 2
+!       sh (nx,nz,ny) : Stability function for heat, at Level 2
 !
 !       These are defined on the walls of the grid boxes.
 !
-  SUBROUTINE  mym_level2 (kts,kte,&
-       &            dz, &
-       &            u, v, thl, qw, &
-       &            ql, vt, vq, &
+
+!>\ingroup gsd_mynn_edmf
+!! This subroutine calculates the level 2, non-dimensional wind shear
+!! \f$G_M\f$ and vertical temperature gradient \f$G_H\f$ as well as 
+!! the level 2 stability funcitons \f$S_h\f$ and \f$S_m\f$.
+!!\param kts    horizontal dimension
+!!\param kte    vertical dimension
+!!\param dz     vertical grid spacings (\f$m\f$)
+!!\param u      west-east component of the horizontal wind (\f$m s^{-1}\f$)
+!!\param v      south-north component of the horizontal wind (\f$m s^{-1}\f$)
+!!\param thl    liquid water potential temperature
+!!\param qw     total water content \f$Q_w\f$
+!!\param ql     liquid water content (\f$kg kg^{-1}\f$)
+!!\param vt
+!!\param vq
+!!\param dtl     vertical gradient of \f$\theta_l\f$ (\f$K m^{-1}\f$)
+!!\param dqw     vertical gradient of \f$Q_w\f$
+!!\param dtv     vertical gradient of \f$\theta_V\f$ (\f$K m^{-1}\f$)
+!!\param gm      \f$G_M\f$ divided by \f$L^{2}/q^{2}\f$ (\f$s^{-2}\f$)
+!!\param gh      \f$G_H\f$ divided by \f$L^{2}/q^{2}\f$ (\f$s^{-2}\f$)
+!!\param sm      stability function for momentum, at Level 2
+!!\param sh      stability function for heat, at Level 2
+!!\section gen_mym_level2 GSD MYNN-EDMF mym_level2 General Algorithm
+!! @ {
+  SUBROUTINE  mym_level2 (kts,kte,                &
+       &            dz,                           &
+       &            u, v, thl, thv, thlv,         &
+       &            qw, ql, vt, vq,               &
        &            dtl, dqw, dtv, gm, gh, sm, sh )
 !
 !-------------------------------------------------------------------
 
-    INTEGER, INTENT(IN)   :: kts,kte
-    REAL, DIMENSION(kts:kte), INTENT(in) :: dz
-    REAL, DIMENSION(kts:kte), INTENT(in) :: u,v,thl,qw,ql,vt,vq
+    integer, intent(in)   :: kts,kte
 
-    REAL, DIMENSION(kts:kte), INTENT(out) :: &
+#ifdef HARDCODE_VERTICAL
+# define kts 1
+# define kte HARDCODE_VERTICAL
+#endif
+
+    real(kind_phys), dimension(kts:kte), intent(in)  :: dz
+    real(kind_phys), dimension(kts:kte), intent(in)  :: u,v, &
+         &thl,qw,ql,vt,vq,thv,thlv
+    real(kind_phys), dimension(kts:kte), intent(out) ::      &
          &dtl,dqw,dtv,gm,gh,sm,sh
 
-    INTEGER :: k
+    integer :: k
 
-    REAL :: rfc,f1,f2,rf1,rf2,smc,shc,&
-         &ri1,ri2,ri3,ri4,duz,dtz,dqz,vtt,vqq,dtq,dzk,afk,abk,ri,rf
+    real(kind_phys):: rfc,f1,f2,rf1,rf2,smc,shc,             &
+         &ri1,ri2,ri3,ri4,duz,dtz,dqz,vtt,vqq,dtq,dzk,       &
+         &afk,abk,ri,rf
 
-!JOE-Canuto/Kitamura mod
-    REAL ::   a2den
-!JOE-end
+    real(kind_phys):: a2fac
 
 !    ev  = 2.5e6
 !    tv0 = 0.61*tref
 !    tv1 = 1.61*tref
 !    gtr = 9.81/tref
 !
-    rfc = g1/( g1+g2 )
-    f1  = b1*( g1-c1 ) +3.0*a2*( 1.0    -c2 )*( 1.0-c5 ) &
-    &                   +2.0*a1*( 3.0-2.0*c2 )
-    f2  = b1*( g1+g2 ) -3.0*a1*( 1.0    -c2 )
-    rf1 = b1*( g1-c1 )/f1
-    rf2 = b1*  g1     /f2
-    smc = a1 /a2*  f1/f2
-    shc = 3.0*a2*( g1+g2 )
-!
-    ri1 = 0.5/smc
-    ri2 = rf1*smc
-    ri3 = 4.0*rf2*smc -2.0*ri2
-    ri4 = ri2**2
-!
-    DO k = kts+1,kte
+!intialize output
+    dtl(kts)=0.0
+    dqw(kts)=0.0
+    dtv(kts)=0.0
+    gm(kts)=0.0
+    gh(kts)=0.0
+    sm(kts)=0.0
+    sh(kts)=0.0
+
+    do k = kts+1,kte
        dzk = 0.5  *( dz(k)+dz(k-1) )
        afk = dz(k)/( dz(k)+dz(k-1) )
        abk = 1.0 -afk
@@ -491,55 +1539,65 @@ CONTAINS
        dtz = ( thl(k)-thl(k-1) )/( dzk )
        dqz = ( qw(k)-qw(k-1) )/( dzk )
 !
-       vtt =  1.0 +vt(k)*abk +vt(k-1)*afk
-       vqq =  tv0 +vq(k)*abk +vq(k-1)*afk
-       dtq =  vtt*dtz +vqq*dqz
-!
+       vtt =  1.0 +vt(k)*abk +vt(k-1)*afk  ! Beta-theta in NN09, Eq. 39
+       vqq =  tv0 +vq(k)*abk +vq(k-1)*afk  ! Beta-q
+       if (use_buoy) then
+          !use the buoyancy flux functions
+          dtq =  vtt*dtz +vqq*dqz
+       else
+          !alternatively, use theta-l-v with the SGS clouds
+          dtq = ( thlv(k)-thlv(k-1) )/( dzk )
+       endif
        dtl(k) =  dtz
        dqw(k) =  dqz
        dtv(k) =  dtq
 !?      dtv(i,j,k) =  dtz +tv0*dqz
-!?   :              +( ev/pi0(i,j,k)-tv1 )
+!?   :              +( xlv/pi0(i,j,k)-tv1 )
 !?   :              *( ql(i,j,k)-ql(i,j,k-1) )/( dzk*h(i,j) )
 !
-       gm (k) =  duz
-       gh (k) = -dtq*gtr
+       gm(k)  =  duz
+       gh(k)  = -dtq*gtr
 !
 !   **  Gradient Richardson number  **
        ri = -gh(k)/MAX( duz, 1.0e-10 )
 
-!JOE-Canuto/Kitamura mod
-    IF (CKmod .eq. 1) THEN
-       a2den = 1. + MAX(ri,0.0)
-    ELSE
-       a2den = 1. + 0.0
-    ENDIF
+       !a2fac is needed for the Canuto/Kitamura mod
+       if (CKmod .eq. 1) then
+          a2fac = 1./(1. + MAX(ri,0.0))
+       else
+          a2fac = 1.
+       endif
 
        rfc = g1/( g1+g2 )
-       f1  = b1*( g1-c1 ) +3.0*(a2/a2den)*( 1.0    -c2 )*( 1.0-c5 ) &
+       f1  = b1*( g1-c1 ) +3.0*a2*a2fac *( 1.0    -c2 )*( 1.0-c5 ) &
     &                     +2.0*a1*( 3.0-2.0*c2 )
        f2  = b1*( g1+g2 ) -3.0*a1*( 1.0    -c2 )
        rf1 = b1*( g1-c1 )/f1
        rf2 = b1*  g1     /f2
-       smc = a1 /(a2/a2den)*  f1/f2
-       shc = 3.0*(a2/a2den)*( g1+g2 )
+       smc = a1 /(a2*a2fac)*  f1/f2
+       shc = 3.0*(a2*a2fac)*( g1+g2 )
 
        ri1 = 0.5/smc
        ri2 = rf1*smc
        ri3 = 4.0*rf2*smc -2.0*ri2
        ri4 = ri2**2
-!JOE-end
 
 !   **  Flux Richardson number  **
-       rf = MIN( ri1*( ri+ri2-SQRT(ri**2-ri3*ri+ri4) ), rfc )
+       rf = MIN( ri1*( ri + ri2-SQRT(ri**2 - ri3*ri + ri4) ), rfc )
 !
-       sh (k) = shc*( rfc-rf )/( 1.0-rf )
-       sm (k) = smc*( rf1-rf )/( rf2-rf ) * sh(k)
-    END DO
+       sh(k) = shc*( rfc-rf )/( 1.0-rf )
+       sm(k) = smc*( rf1-rf )/( rf2-rf ) * sh(k)
+    enddo
 !
-    RETURN
+!    RETURN
+
+#ifdef HARDCODE_VERTICAL
+# undef kts
+# undef kte
+#endif
 
   END SUBROUTINE mym_level2
+!! @}
 
 ! ==================================================================
 !     SUBROUTINE  mym_length:
@@ -549,182 +1607,441 @@ CONTAINS
 !     Output variables:   see subroutine mym_initialize
 !
 !     Work arrays:
-!       elt(mx,ny)      : Length scale depending on the PBL depth    (m)
-!       vsc(mx,ny)      : Velocity scale q_c                       (m/s)
+!       elt(nx,ny)      : Length scale depending on the PBL depth    (m)
+!       vsc(nx,ny)      : Velocity scale q_c                       (m/s)
 !                         at first, used for computing elt
 !
 !     NOTE: the mixing lengths are meant to be calculated at the full-
 !           sigmal levels (or interfaces beween the model layers).
 !
-  SUBROUTINE  mym_length ( kts,kte,&
-    &            dz, zw, &
-    &            rmo, flt, flq, &
-    &            vt, vq, &
-    &            qke, &
-    &            dtv, &
-    &            el, &
-    &            zi,theta,&       !JOE-BouLac mod
-    &            qkw)
+!>\ingroup gsd_mynn_edmf
+!! This subroutine calculates the mixing lengths.
+  SUBROUTINE  mym_length (                     & 
+    &            kts,kte,xland,                &
+    &            dz, dx, zw,                   &
+    &            rmol, flt, fltv, flq,         &
+    &            vt, vq,                       &
+    &            u1, v1, qke,                  &
+    &            dtv,                          &
+    &            el,                           &
+    &            pblh, theta, qkw,             &
+    &            Psig_bl, cldfra_bl1,          &
+    &            bl_mynn_mixlength,            &
+    &            edmf_w1,edmf_a1,              &
+    &            edmf_w_dd1,edmf_a_dd1         )
     
 !-------------------------------------------------------------------
 
-    INTEGER, INTENT(IN)   :: kts,kte
-    REAL, DIMENSION(kts:kte), INTENT(in)   :: dz
-    REAL, DIMENSION(kts:kte+1), INTENT(in) :: zw
-    REAL, INTENT(in) :: rmo,flt,flq
-    REAL, DIMENSION(kts:kte), INTENT(IN)   :: qke,vt,vq
+    integer, intent(in)   :: kts,kte
 
-    REAL, DIMENSION(kts:kte), INTENT(out)  :: qkw, el
-    REAL, DIMENSION(kts:kte), INTENT(in)   :: dtv
+#ifdef HARDCODE_VERTICAL
+# define kts 1
+# define kte HARDCODE_VERTICAL
+#endif
 
-    REAL :: elt,vsc
-!JOE-added for BouLac ML
-    REAL, DIMENSION(kts:kte), INTENT(IN) :: theta
-    REAL, DIMENSION(kts:kte) :: qtke,elBLmin,elBLavg,thetaw
-    REAL :: wt,zi,zi2,h1,h2
+    integer, intent(in)   :: bl_mynn_mixlength
+    real(kind_phys), dimension(kts:kte),   intent(in) :: dz
+    real(kind_phys), dimension(kts:kte+1), intent(in) :: zw
+    real(kind_phys), intent(in) :: rmol,flt,fltv,flq,Psig_bl,xland
+    real(kind_phys), intent(in) :: dx,pblh
+    real(kind_phys), dimension(kts:kte), intent(in)   :: u1,v1,  &
+         &qke,vt,vq,cldfra_bl1,edmf_w1,edmf_a1,edmf_w_dd1,edmf_a_dd1
+    real(kind_phys), dimension(kts:kte), intent(out)  :: qkw, el
+    real(kind_phys), dimension(kts:kte), intent(in)   :: dtv
+    real(kind_phys):: elt,vsc
+    real(kind_phys), dimension(kts:kte), intent(in) :: theta
+    real(kind_phys), dimension(kts:kte) :: qtke,elBLmin,elBLavg,thetaw
+    real(kind_phys):: wt,wt2,pblh2,h1,h2,hs,elBLmin0,elBLavg0,cldavg
+
+    ! THE FOLLOWING CONSTANTS ARE IMPORTANT FOR REGULATING THE
+    ! MIXING LENGTHS:
+    real(kind_phys):: cns,   &   !< for surface layer (els) in stable conditions
+            alp1,            &   !< for turbulent length scale (elt)
+            alp2,            &   !< for buoyancy length scale (elb)
+            alp3,            &   !< for buoyancy enhancement factor of elb
+            alp4,            &   !< for surface layer (els) in unstable conditions
+            alp5,            &   !< for BouLac mixing length or above PBLH
+            alp6                 !< for mass-flux/
 
     !THE FOLLOWING LIMITS DO NOT DIRECTLY AFFECT THE ACTUAL PBLH.
     !THEY ONLY IMPOSE LIMITS ON THE CALCULATION OF THE MIXING LENGTH 
     !SCALES SO THAT THE BOULAC MIXING LENGTH (IN FREE ATMOS) DOES
     !NOT ENCROACH UPON THE BOUNDARY LAYER MIXING LENGTH (els, elb & elt).
-    REAL, PARAMETER :: minzi = 300.  !min mixed-layer height
-    REAL, PARAMETER :: maxdz = 750.  !max (half) transition layer depth
-                                     !=0.3*2500 m PBLH, so the transition
-                                     !layer stops growing for PBLHs > 2.5 km.
-    REAL, PARAMETER :: mindz = 300.  !min (half) transition layer depth
+    real(kind_phys), parameter :: minpblh     = 300.  !< min mixed-layer height
+    real(kind_phys), parameter :: maxdz       = 750.  !< max (half) transition layer depth
+                                     !! =0.3*2500 m PBLH, so the transition
+                                     !! layer stops growing for PBLHs > 2.5 km.
+    real(kind_phys), parameter :: mindz       = 300.  !< 300  !min (half) transition layer depth
 
     !SURFACE LAYER LENGTH SCALE MODS TO REDUCE IMPACT IN UPPER BOUNDARY LAYER
-    REAL, PARAMETER :: ZSLH = 100. ! Max height correlated to surface conditions (m)
-    REAL, PARAMETER :: CSL = 2.    ! CSL = constant of proportionality to L O(1)
-    REAL :: z_m
+    real(kind_phys), parameter :: ZSLH        = 100.  !< Max height correlated to surface conditions (m)
+    real(kind_phys), parameter :: CSL         = 2.    !< CSL = constant of proportionality to L O(1)
+    real(kind_phys), parameter :: qkw_elb_min = 0.18
 
-!Joe-end
-
-    INTEGER :: i,j,k
-    REAL :: afk,abk,zwk,dzk,qdz,vflx,bv,elb,els,elf
+    integer :: i,j,k
+    real(kind_phys):: afk,abk,zwk,zwk1,dzk,qdz,vflx,bv,tau_cloud,     &
+            & wstar,elb,els,elf,el_stab,el_mf,el_stab_mf,elb_mf,      &
+            & PBLH_PLUS_ENT,Uonset,Ugrid,wt_u1,wt_u2,el_les,qkw_mf
+    real(kind_phys), parameter :: ctau = 1000. !constant for tau_cloud
 
 !    tv0 = 0.61*tref
 !    gtr = 9.81/tref
-!
-!JOE-added to impose limits on the height integration for elt as well 
-!    as the transition layer depth
-    IF ( BLmod .EQ. 0. ) THEN
-       zi2=5000.  !originally integrated to model top, not just 5000 m.
-    ELSE
-       zi2=MAX(zi,minzi)
-    ENDIF
-    h1=MAX(0.3*zi2,mindz)
-    h1=MIN(h1,maxdz)         ! 1/2 transition layer depth
-    h2=h1/2.0                ! 1/4 transition layer depth
 
-    qtke(kts)=MAX(qke(kts)/2.,0.01) !tke at full sigma levels
-    thetaw(kts)=theta(kts)          !theta at full-sigma levels
-!JOE-end
-    qkw(kts) = SQRT(MAX(qke(kts),1.0e-10))
+    SELECT CASE(bl_mynn_mixlength)
 
-    DO k = kts+1,kte
-       afk = dz(k)/( dz(k)+dz(k-1) )
-       abk = 1.0 -afk
-       qkw(k) = SQRT(MAX(qke(k)*abk+qke(k-1)*afk,1.0e-3))
+      CASE (0) ! ORIGINAL MYNN MIXING LENGTH + BouLac
 
-!JOE- BouLac Start 
-       qtke(k) = (qkw(k)**2.)/2.    ! q -> TKE
-       thetaw(k)= theta(k)*abk + theta(k-1)*afk
-!JOE- BouLac End
+        cns  = 2.7
+        alp1 = 0.23
+        alp2 = 1.0
+        alp3 = 5.0
+        alp4 = 100.
+        alp5 = 0.3
 
-    END DO
-!
-    elt = 1.0e-5
-    vsc = 1.0e-5
-!
-!   **  Strictly, zwk*h(i,j) -> ( zwk*h(i,j)+z0 )  **
-!JOE-Lt mod: only integrate to top of PBL (+ transition/entrainment
-!   layer), since TKE aloft is not relevant. Make WHILE loop, so it
-!   exits after looping through the boundary layer.
-!
-     k = kts+1
-     zwk = zw(k)
-     DO WHILE (zwk .LE. MIN((zi2+h1), 4000.)) !JOE: 20130523 reduce too high diffusivity over mts 
-       dzk = 0.5*( dz(k)+dz(k-1) )
-       qdz = MAX( qkw(k)-qmin, 0.03 )*dzk
-             elt = elt +qdz*zwk
-             vsc = vsc +qdz
-       k   = k+1
-       zwk = zw(k)
-    END DO
-!
-    elt =  alp1*elt/vsc
-    vflx = ( vt(kts)+1.0 )*flt +( vq(kts)+tv0 )*flq
-    vsc = ( gtr*elt*MAX( vflx, 0.0 ) )**(1.0/3.0)
-!
-!   **  Strictly, el(i,j,1) is not zero.  **
-    el(kts) = 0.0
-!
-!JOE- BouLac Start
-    IF ( BLmod .GT. 0. ) THEN
-       ! COMPUTE BouLac mixing length
-       CALL boulac_length(kts,kte,zw,dz,qtke,thetaw,elBLmin,elBLavg)
-    ENDIF
-!JOE- BouLac END
+        ! Impose limits on the height integration for elt and the transition layer depth
+        pblh2= min(10000.,zw(kte-2))  !originally integrated to model top, not just 10 km.
+        h1   = max(0.3*pblh2,mindz)
+        h1   = min(h1,maxdz)         ! 1/2 transition layer depth
+        h2   = h1/2.0                ! 1/4 transition layer depth
 
-    DO k = kts+1,kte
-       zwk = zw(k)              !full-sigma levels
+        qkw(kts) = SQRT(MAX(qke(kts), qkemin))
+        DO k = kts+1,kte
+           afk = dz(k)/( dz(k)+dz(k-1) )
+           abk = 1.0 -afk
+           qkw(k) = SQRT(MAX(qke(k)*abk+qke(k-1)*afk, qkemin))
+        END DO
 
-!   **  Length scale limited by the buoyancy effect  **
-       IF ( dtv(k) .GT. 0.0 ) THEN
-          bv  = SQRT( gtr*dtv(k) )
-          elb = alp2*qkw(k) / bv &
-               &       *( 1.0 + alp3/alp2*&
-               &SQRT( vsc/( bv*elt ) ) )
+        elt = 1.0e-5
+        vsc = 1.0e-5        
 
-          elf = alp2 * qkw(k)/bv
-       ELSE
-          elb = 1.0e10
-          elf = elb
-       END IF
-!
-       z_m = MAX(ZSLH,CSL*zwk*rmo)
+        !   **  Strictly, zwk*h(i,j) -> ( zwk*h(i,j)+z0 )  **
+        k   = kts+1
+        zwk = zw(k)
+        DO WHILE (zwk .LE. pblh2+h1)
+           dzk = half*( dz(k)+dz(k-1) )
+           qdz = MAX( qkw(k)-qmin, 0.03 )*dzk
+           elt = elt +qdz*zwk
+           vsc = vsc +qdz
+           k   = k+1
+           zwk = zw(k)
+        END DO
 
-!   **  Length scale in the surface layer  **
-       IF ( rmo .GT. 0.0 ) THEN
-       !   IF ( zwk <= z_m ) THEN  ! use original cns
-             els = vk*zwk/(1.0+cns*MIN( zwk*rmo, zmax ))
-             !els = vk*zwk/(1.0+cns*MIN( 0.5*zw(kts+1)*rmo, zmax ))
-       !   ELSE
-       !      !blend to neutral values (kz) above z_m
-       !      els = vk*z_m/(1.0+cns*MIN( zwk*rmo, zmax )) + vk*(zwk - z_m)
-       !   ENDIF
-       ELSE
-          els =  vk*zwk*( 1.0 - alp4* zwk*rmo )**0.2
-       END IF
-!
-!   ** HARMONC AVERGING OF MIXING LENGTH SCALES: 
-!       el(k) =      MIN(elb/( elb/elt+elb/els+1.0 ),elf)
-!       el(k) =      elb/( elb/elt+elb/els+1.0 )
-!JOE- BouLac Start
-       IF ( BLmod .EQ. 0. ) THEN
-          el(k) = MIN(elb/( elb/elt+elb/els+1.0 ),elf)
-       ELSE
-          !add blending to use BouLac mixing length in free atmos;
-          !defined relative to the PBLH (zi) + transition layer (h1)
-          el(k) = MIN(elb/( elb/elt+elb/els+1.0 ),elf)
-          wt=.5*TANH((zwk - (zi2+h1))/h2) + .5
-          el(k) = el(k)*(1.-wt) + alp5*elBLmin(k)*wt
-       ENDIF
-!JOE- BouLac End
+        elt  = alp1*elt/vsc
+        vflx = ( vt(kts)+1.0 )*flt +( vq(kts)+tv0 )*flq
+        vsc  = ( gtr*elt*MAX( vflx, 0.0 ) )**onethird
 
-       !IF (el(k) > 1000.) THEN
-       !   print*,"SUSPICIOUSLY LARGE Lm:",el(k),k
-       !ENDIF
-    END DO
-!
-    RETURN
+        !   **  Strictly, el(i,k=1) is not zero.  **
+        el(kts) = 0.0
+        zwk1    = zw(kts+1)
+
+        DO k = kts+1,kte
+           zwk = zw(k)              !full-sigma levels
+
+           !   **  Length scale limited by the buoyancy effect  **
+           IF ( dtv(k) .GT. 0.0 ) THEN
+              bv  = SQRT( gtr*dtv(k) )
+              elb = alp2*qkw(k) / bv &
+                  &       *( 1.0 + alp3/alp2*&
+                  &SQRT( vsc/( bv*elt ) ) )
+              elf = alp2 * qkw(k)/bv
+
+           ELSE
+              elb = 1.0e10
+              elf = elb
+           ENDIF
+
+           !   **  Length scale in the surface layer  **
+           IF ( rmol .GT. 0.0 ) THEN
+              els  = karman*zwk/(1.0+cns*MIN( zwk*rmol, zmax ))
+           ELSE
+              els  =  karman*zwk*( 1.0 - alp4* zwk*rmol )**0.2
+           END IF
+
+           !   ** HARMONC AVERGING OF MIXING LENGTH SCALES:
+           !       el(k) =    MIN(elb/( elb/elt+elb/els+1.0 ),elf)
+           !       el(k) =    elb/( elb/elt+elb/els+1.0 )
+
+           wt=half*TANH((zwk - (pblh2+h1))/h2) + half
+
+           el(k) = MIN(elb/( elb/elt+elb/els+1.0 ),elf)
+
+        END DO
+
+      CASE (1) !NONLOCAL (using BouLac) FORM OF MIXING LENGTH
+
+        !wt_u* are for hurricane tuning, meant to reduce diffusion in hurricanes
+        ugrid = sqrt(u1(kts)**2 + v1(kts)**2)
+        uonset= 15.
+        wt_u1 = 1.0 - min(max(ugrid - uonset, 0.0)/20.0, 0.50) !reduce to 0.5
+        wt_u2 = 1.0 - min(max(ugrid - uonset, 0.0)/20.0, 0.01) !reduce to 0.01
+        cns   = 3.5
+        alp1  = 0.23
+        alp2  = 0.3
+        alp3  = 2.5 * wt_u1 !taper off bouyancy enhancement in shear-driven pbls
+        alp4  = 5.0
+        alp5  = 0.3
+        alp6  = 50.
+
+        ! Impose limits on the height integration for elt and the transition layer depth
+        pblh2= max(pblh,300.) !minpblh)
+        h1   = max(0.3*pblh2,300.)
+        h1   = min(h1,600.)          ! 1/2 transition layer depth
+        h2   = h1/2.0                ! 1/4 transition layer depth
+
+        qtke(kts)  =max(half*qke(kts), half*qkemin) !tke at full sigma levels
+        thetaw(kts)=theta(kts)            !theta at full-sigma levels
+        qkw(kts)   =sqrt(max(qke(kts), qkemin))
+
+        DO k = kts+1,kte
+           afk      = dz(k)/( dz(k)+dz(k-1) )
+           abk      = 1.0 -afk
+           qkw(k)   = sqrt(max(qke(k)*abk+qke(k-1)*afk, qkemin))
+           qtke(k)  = max(half*(qkw(k)**2), 0.005) ! q -> TKE
+           thetaw(k)= theta(k)*abk + theta(k-1)*afk
+        END DO
+
+        elt = 1.0e-5
+        vsc = 1.0e-5
+
+        !   **  Strictly, zwk*h(i,j) -> ( zwk*h(i,j)+z0 )  **
+        k   = kts+1
+        zwk = zw(k)
+        DO WHILE (zwk .LE. pblh2+h1)
+           dzk = half*( dz(k)+dz(k-1) )
+           qdz = min(max( qkw(k)-qmin, 0.01 ), 30.0)*dzk
+           elt = elt +qdz*zwk
+           vsc = vsc +qdz
+           k   = k+1
+           zwk = zw(k)
+        END DO
+
+        elt = MIN( MAX( alp1*elt/vsc, 8.), 400.)
+        !avoid use of buoyancy flux functions which are ill-defined at the surface
+        !vflx = ( vt(kts)+1.0 )*flt + ( vq(kts)+tv0 )*flq
+        vflx= fltv
+        vsc = ( gtr*elt*MAX( vflx, 0.0 ) )**onethird
+
+        !   **  Strictly, el(i,j,1) is not zero.  **
+        el(kts) = 0.0
+        zwk1    = zw(kts+1)         !full-sigma levels
+
+        ! COMPUTE BouLac mixing length
+        CALL boulac_length(kts,kte,zw,dz,qtke,thetaw,elBLmin,elBLavg)
+
+        DO k = kts+1,kte
+           zwk    = zw(k)          !full-sigma levels
+           qkw_mf = max(edmf_a1(k-1)*edmf_w1(k-1),                &
+                  & abs(edmf_a_dd1(k-1)*edmf_w_dd1(k-1)))
+
+           !   **  Length scale limited by the buoyancy effect  **
+           IF ( dtv(k) .GT. 0.0 ) THEN
+              bv     = max( sqrt( gtr*dtv(k) ), 0.001)
+              elb_mf = alp6*qkw_mf/bv
+              elb_mf = elb_mf / (1. + (elb_mf/100.))
+              elb    = alp2*(max(qkw(k),qkw_elb_min*wt_u2))/bv    &
+                     &  *( 1.0 + alp3*SQRT( vsc/(bv*elt) ) )
+              elb    = max(elb, elb_mf)
+              elb    = MIN(elb, zwk)
+              elf    = 1.0 * max(qkw(k), qkw_elb_min*wt_u2)/bv
+              elf    = max(elf, elb_mf)
+              elBLavg(k) = MAX(elBLavg(k), elb_mf)
+           ELSE
+              elb    = 1.0e10
+              elf    = elb
+           ENDIF
+
+           !   **  Length scale in the surface layer  **
+           IF ( rmol .GT. 0.0 ) THEN
+              els  = karman*zwk/(1.0+cns*MIN( zwk*rmol, zmax ))
+           ELSE
+              els  = karman*zwk*( 1.0 - alp4* zwk*rmol)**0.2
+           END IF
+
+           !   ** NOW BLEND THE MIXING LENGTH SCALES:
+           wt=half*TANH((zwk - (pblh2+h1))/h2) + half
+
+           !add blending to use BouLac mixing length in free atmos;
+           !defined relative to the PBLH (pblh) + transition layer (h1)
+           !el(k) = MIN(elb/( elb/elt+elb/els+1.0 ),elf)
+           !try squared-blending - but take out elb (makes it underdiffusive)
+           !el(k) = SQRT( els**2/(1. + (els**2/elt**2) +(els**2/elb**2)))
+           el(k) = sqrt( els**2/(1. + (els**2/elt**2)))
+           el(k) = min(el(k), elb)
+           el(k) = min(el(k), elf)  !elf can be smaller than elb in upper pbl
+           el(k) = el(k)*(1.-wt) + alp5*elBLavg(k)*wt
+
+           !if (el(k) > 1000.) then
+           !   print*,"big ML at k=",k," el=",el(k),"elb=",elb," elBL=",elBLavg(k), &
+           !   " elt=",elt," els=",els," N=",bv," qtke=",qtke(k), &
+           !   " pblh=",pblh2," zwk=",zwk," wt=",wt
+           !endif
+
+           ! include scale-awareness, except for original MYNN
+           el(k) = el(k)*Psig_bl
+
+        END DO
+
+     CASE (2) !Local (mostly) mixing length formulation
+
+        Uonset = 3.5 + dz(kts)*0.1
+        Ugrid  = sqrt(u1(kts)**2 + v1(kts)**2)
+        cns  = 3.5 !JOE-test  * (1.0 - MIN(MAX(Ugrid - Uonset, 0.0)/10.0, 1.0))
+        alp1 = 0.22
+        alp2 = 0.30
+        alp3 = 2.5
+        alp4 = 5.0
+        alp5 = alp2 !like alp2, but for free atmosphere
+        alp6 = 50.0 !used for MF mixing length
+
+        ! Impose limits on the height integration for elt and the transition layer depth
+        !pblh2=MAX(pblh,minpblh)
+        pblh2=MAX(pblh,    300.)
+        !h1=MAX(0.3*pblh2,mindz)
+        !h1=MIN(h1,maxdz)         ! 1/2 transition layer depth
+        h1=MAX(0.3*pblh2,300.)
+        h1=MIN(h1,600.)
+        h2=h1*half                ! 1/4 transition layer depth
+
+        qtke(kts)=MAX(half*qke(kts), half*qkemin) !tke at full sigma levels
+        qkw(kts) = SQRT(MAX(qke(kts), qkemin))
+
+        DO k = kts+1,kte
+           afk    = dz(k)/( dz(k)+dz(k-1) )
+           abk    = 1.0 -afk
+           qkw(k) = SQRT(MAX(qke(k)*abk+qke(k-1)*afk, qkemin))
+           qtke(k)= half*qkw(k)**2  ! qkw -> TKE
+        END DO
+
+        elt = 1.0e-5
+        vsc = 1.0e-5
+
+        !   **  Strictly, zwk*h(i,j) -> ( zwk*h(i,j)+z0 )  **
+        PBLH_PLUS_ENT = MAX(pblh+h1, 100.)
+        k = kts+1
+        zwk = zw(k)
+        DO WHILE (zwk .LE. PBLH_PLUS_ENT)
+           dzk = half*( dz(k)+dz(k-1) )
+           qdz = min(max( qkw(k)-qmin, 0.03 ), 30.0)*dzk
+           elt = elt +qdz*zwk
+           vsc = vsc +qdz
+           k   = k+1
+           zwk = zw(k)
+        END DO
+
+        elt = MIN( MAX(alp1*elt/vsc, 10.), 400.)
+        !avoid use of buoyancy flux functions which are ill-defined at the surface
+        !vflx = ( vt(kts)+1.0 )*flt +( vq(kts)+tv0 )*flq
+        vflx = fltv
+        vsc = ( gtr*elt*MAX( vflx, 0.0 ) )**onethird
+
+        !   **  Strictly, el(i,j,1) is not zero.  **
+        el(kts) = 0.0
+        zwk1    = zw(kts+1)
+
+        DO k = kts+1,kte
+           zwk = zw(k)              !full-sigma levels
+           dzk = 0.5*( dz(k)+dz(k-1) )
+           cldavg = 0.5*(cldfra_bl1(k-1)+cldfra_bl1(k))
+           qkw_mf = max(edmf_a1(k-1)*edmf_w1(k-1),               &
+                  & abs(edmf_a_dd1(k-1)*edmf_w_dd1(k-1)))
+
+           !   **  Length scale limited by the buoyancy effect  **
+           IF ( dtv(k) .GT. 0.0 ) THEN
+              !impose min value on bv
+              bv  = MAX( SQRT( gtr*dtv(k) ), 0.001)  
+              !elb_mf = alp2*qkw(k) / bv  &
+              elb_mf = MAX(alp2*qkw(k),                    &
+                  &        alp6*qkw_mf) / bv               &
+                  &  *( 1.0 + alp3*SQRT( vsc/( bv*elt ) ) )
+              elb = MIN(MAX(alp5*qkw(k), alp6*qkw_mf)/bv, zwk)
+
+              !tau_cloud = MIN(MAX(0.5*pblh/((gtr*pblh*MAX(vflx,1.0e-4))**onethird),30.),150.)
+              wstar = 1.25*(gtr*pblh*MAX(vflx,1.0e-4))**onethird
+              tau_cloud = MIN(MAX(ctau * wstar/grav, 30.), 150.)
+              !minimize influence of surface heat flux on tau far away from the PBLH.
+              wt=half*TANH((zwk - (pblh2+h1))/h2) + half
+              tau_cloud = tau_cloud*(1.-wt) + 50.*wt
+              elf = MIN(MAX(tau_cloud*SQRT(MIN(qtke(k),40.)), &
+                  &         alp6*qkw_mf/bv), zwk)
+
+              !IF (zwk > pblh .AND. elf > 400.) THEN
+              !   ! COMPUTE BouLac mixing length
+              !   !CALL boulac_length0(k,kts,kte,zw,dz,qtke,thetaw,elBLmin0,elBLavg0)
+              !   !elf = alp5*elBLavg0
+              !   elf = MIN(MAX(50.*SQRT(qtke(k)), 400.), zwk)
+              !ENDIF
+
+           ELSE
+              ! use version in development for RAP/HRRR 2016
+              ! JAYMES-
+              ! tau_cloud is an eddy turnover timescale;
+              ! see Teixeira and Cheinet (2004), Eq. 1, and
+              ! Cheinet and Teixeira (2003), Eq. 7.  The
+              ! coefficient 0.5 is tuneable. Expression in
+              ! denominator is identical to vsc (a convective
+              ! velocity scale), except that elt is relpaced
+              ! by pblh, and zero is replaced by 1.0e-4 to
+              ! prevent division by zero.
+              !tau_cloud = MIN(MAX(0.5*pblh/((gtr*pblh*MAX(vflx,1.0e-4))**onethird),50.),150.)
+              wstar     = 1.25*(gtr*pblh*MAX(vflx,1.0e-4))**onethird
+              tau_cloud = MIN(MAX(ctau * wstar/grav, 50.), 200.)
+              !minimize influence of surface heat flux on tau far away from the PBLH.
+              wt        = half*TANH((zwk - (pblh2+h1))/h2) + half
+              !tau_cloud = tau_cloud*(1.-wt) + 50.*wt
+              tau_cloud = tau_cloud*(1.-wt) + MAX(100.,dzk*0.25)*wt
+
+              elb       = MIN(tau_cloud*SQRT(MIN(qtke(k),40.)), zwk)
+              !elf = elb
+              elf       = elb !/(1. + (elb/800.))  !bound free-atmos mixing length to < 800 m.
+              elb_mf    = elb
+         END IF
+         elf    = elf/(1. + (elf/800.))  !bound free-atmos mixing length to < 800 m.
+         elb_mf = MAX(elb_mf, 0.01) !to avoid divide-by-zero below
+
+         !   **  Length scale in the surface layer  **
+         IF ( rmol .GT. 0.0 ) THEN
+            els  = karman*zwk/(1.0+cns*MIN( zwk*rmol, zmax ))
+         ELSE
+            els  =  karman*zwk*( 1.0 - alp4* zwk*rmol)**0.2
+         END IF
+
+         !   ** NOW BLEND THE MIXING LENGTH SCALES:
+         wt=half*TANH((zwk - (pblh2+h1))/h2) + half
+
+         !try squared-blending
+         el(k) = SQRT( els**2/(1. + (els**2/elt**2) +(els**2/elb_mf**2)))
+         el(k) = el(k)*(1.-wt) + elf*wt
+
+         ! include scale-awareness. For now, use simple asymptotic kz -> 12 m (should be ~dz).
+         el_les= MIN(els/(1. + (els/12.)), elb_mf)
+         el(k) = el(k)*Psig_bl + (1.-Psig_bl)*el_les
+
+       END DO
+
+    END SELECT
+
+
+#ifdef HARDCODE_VERTICAL
+# undef kts
+# undef kte
+#endif
 
   END SUBROUTINE mym_length
 
-!JOE- BouLac Code Start -
 ! ==================================================================
-  SUBROUTINE boulac_length(kts,kte,zw,dz,qtke,theta,lb1,lb2)
+!>\ingroup gsd_mynn_edmf
+!! This subroutine was taken from the BouLac scheme in WRF-ARW and modified for
+!! integration into the MYNN PBL scheme. WHILE loops were added to reduce the
+!! computational expense. This subroutine computes the length scales up and down
+!! and then computes the min, average of the up/down length scales, and also
+!! considers the distance to the surface.
+!\param dlu  the distance a parcel can be lifted upwards give a finite
+!  amount of TKE.
+!\param dld  the distance a parcel can be displaced downwards given a
+!  finite amount of TKE.
+!\param lb1  the minimum of the length up and length down
+!\param lb2  the average of the length up and length down
+  SUBROUTINE boulac_length0(k,kts,kte,zw,dz,qtke,theta,lb1,lb2)
 !
 !    NOTE: This subroutine was taken from the BouLac scheme in WRF-ARW
 !          and modified for integration into the MYNN PBL scheme.
@@ -734,6 +2051,156 @@ CONTAINS
 !          length scales, and also considers the distance to the
 !          surface.
 !
+!      dlu = the distance a parcel can be lifted upwards give a finite
+!            amount of TKE.
+!      dld = the distance a parcel can be displaced downwards given a
+!            finite amount of TKE.
+!      lb1 = the minimum of the length up and length down
+!      lb2 = the average of the length up and length down
+!-------------------------------------------------------------------
+
+     integer, intent(in) :: k,kts,kte
+     real(kind_phys), dimension(kts:kte), intent(in) :: qtke,dz,theta
+     real(kind_phys), intent(out) :: lb1,lb2
+     real(kind_phys), dimension(kts:kte+1), intent(in) :: zw
+
+     !LOCAL VARS
+     integer :: izz, found
+     real(kind_phys):: dlu,dld
+     real(kind_phys):: dzt, zup, beta, zup_inf, bbb, tl, zdo, zdo_sup, zzz
+
+
+     !----------------------------------
+     ! FIND DISTANCE UPWARD             
+     !----------------------------------
+     zup=0.
+     dlu=zw(kte+1)-zw(k)-dz(k)*0.5
+     zzz=0.
+     zup_inf=0.
+     beta=gtr           !Buoyancy coefficient (g/tref)
+
+     !print*,"FINDING Dup, k=",k," zw=",zw(k)
+
+     if (k .lt. kte) then      !cant integrate upwards from highest level
+        found = 0
+        izz=k
+        DO WHILE (found .EQ. 0)
+
+           if (izz .lt. kte) then
+              dzt=dz(izz)                   ! layer depth above
+              zup=zup-beta*theta(k)*dzt     ! initial PE the parcel has at k
+              !print*,"  ",k,izz,theta(izz),dz(izz)
+              zup=zup+beta*(theta(izz+1)+theta(izz))*dzt*0.5 ! PE gained by lifting a parcel to izz+1
+              zzz=zzz+dzt                   ! depth of layer k to izz+1
+              !print*,"  PE=",zup," TKE=",qtke(k)," z=",zw(izz)
+              if (qtke(k).lt.zup .and. qtke(k).ge.zup_inf) then
+                 bbb=(theta(izz+1)-theta(izz))/dzt
+                 if (bbb .ne. 0.) then
+                    !fractional distance up into the layer where TKE becomes < PE
+                    tl=(-beta*(theta(izz)-theta(k)) + &
+                      & sqrt( max(0.,(beta*(theta(izz)-theta(k)))**2 + &
+                      &       2.*bbb*beta*(qtke(k)-zup_inf))))/bbb/beta
+                 else
+                    if (theta(izz) .ne. theta(k))then
+                       tl=(qtke(k)-zup_inf)/(beta*(theta(izz)-theta(k)))
+                    else
+                       tl=0.
+                    endif
+                 endif
+                 dlu=zzz-dzt+tl
+                 !print*,"  FOUND Dup:",dlu," z=",zw(izz)," tl=",tl
+                 found =1
+              endif
+              zup_inf=zup
+              izz=izz+1
+           ELSE
+              found = 1
+           ENDIF
+
+        ENDDO
+
+     endif
+
+     !----------------------------------
+     ! FIND DISTANCE DOWN               
+     !----------------------------------
+     zdo=0.
+     zdo_sup=0.
+     dld=zw(k)
+     zzz=0.
+
+     !print*,"FINDING Ddown, k=",k," zwk=",zw(k)
+     if (k .gt. kts) then  !cant integrate downwards from lowest level
+
+        found = 0
+        izz=k
+        DO WHILE (found .EQ. 0)
+
+           if (izz .gt. kts) then
+              dzt=dz(izz-1)
+              zdo=zdo+beta*theta(k)*dzt
+              !print*,"  ",k,izz,theta(izz),dz(izz-1)
+              zdo=zdo-beta*(theta(izz-1)+theta(izz))*dzt*0.5
+              zzz=zzz+dzt
+              !print*,"  PE=",zdo," TKE=",qtke(k)," z=",zw(izz)
+              if (qtke(k).lt.zdo .and. qtke(k).ge.zdo_sup) then
+                 bbb=(theta(izz)-theta(izz-1))/dzt
+                 if (bbb .ne. 0.) then
+                    tl=(beta*(theta(izz)-theta(k))+ &
+                      & sqrt( max(0.,(beta*(theta(izz)-theta(k)))**2 + &
+                      &       2.*bbb*beta*(qtke(k)-zdo_sup))))/bbb/beta
+                 else
+                    if (theta(izz) .ne. theta(k)) then
+                       tl=(qtke(k)-zdo_sup)/(beta*(theta(izz)-theta(k)))
+                    else
+                       tl=0.
+                    endif
+                 endif
+                 dld=zzz-dzt+tl
+                 !print*,"  FOUND Ddown:",dld," z=",zw(izz)," tl=",tl
+                 found = 1
+              endif
+              zdo_sup=zdo
+              izz=izz-1
+           ELSE
+              found = 1
+           ENDIF
+        ENDDO
+
+     endif
+
+     !----------------------------------
+     ! GET MINIMUM (OR AVERAGE)         
+     !----------------------------------
+     !The surface layer length scale can exceed z for large z/L,
+     !so keep maximum distance down > z.
+     dld = min(dld,zw(k+1))!not used in PBL anyway, only free atmos
+     lb1 = min(dlu,dld)     !minimum
+     !JOE-fight floating point errors
+     dlu=MAX(0.1,MIN(dlu,1000.))
+     dld=MAX(0.1,MIN(dld,1000.))
+     lb2 = sqrt(dlu*dld)    !average - biased towards smallest
+     !lb2 = 0.5*(dlu+dld)   !average
+
+     if (k .eq. kte) then
+        lb1 = 0.
+        lb2 = 0.
+     endif
+     !print*,"IN MYNN-BouLac",k,lb1
+     !print*,"IN MYNN-BouLac",k,dld,dlu
+
+  END SUBROUTINE boulac_length0
+
+! ==================================================================
+!>\ingroup gsd_mynn_edmf
+!! This subroutine was taken from the BouLac scheme in WRF-ARW
+!! and modified for integration into the MYNN PBL scheme.
+!! WHILE loops were added to reduce the computational expense.
+!! This subroutine computes the length scales up and down
+!! and then computes the min, average of the up/down
+!! length scales, and also considers the distance to the
+!! surface.
+  SUBROUTINE boulac_length(kts,kte,zw,dz,qtke,theta,lb1,lb2)
 !      dlu = the distance a parcel can be lifted upwards give a finite 
 !            amount of TKE.
 !      dld = the distance a parcel can be displaced downwards given a
@@ -742,16 +2209,16 @@ CONTAINS
 !      lb2 = the average of the length up and length down
 !-------------------------------------------------------------------
 
-     INTEGER, INTENT(IN) :: kts,kte
-     REAL, DIMENSION(kts:kte), INTENT(IN) :: qtke,dz,theta
-     REAL, DIMENSION(kts:kte), INTENT(OUT) :: lb1,lb2
-     REAL, DIMENSION(kts:kte+1), INTENT(IN) :: zw
+     integer, intent(in) :: kts,kte
+     real(kind_phys), dimension(kts:kte),   intent(in) :: qtke,dz,theta
+     real(kind_phys), dimension(kts:kte),   intent(out):: lb1,lb2
+     real(kind_phys), dimension(kts:kte+1), intent(in) :: zw
 
      !LOCAL VARS
-     INTEGER :: iz, izz, found
-     REAL, DIMENSION(kts:kte) :: dlu,dld
-     REAL, PARAMETER :: Lmax=2000.  !soft limit
-     REAL :: dzt, zup, beta, zup_inf, bbb, tl, zdo, zdo_sup, zzz
+     integer :: iz, izz, found
+     real(kind_phys), dimension(kts:kte) :: dlu,dld
+     real(kind_phys), parameter :: Lmax=1500.  !soft limit
+     real(kind_phys):: dzt, zup, beta, zup_inf, bbb, tl, zdo, zdo_sup, zzz
 
      !print*,"IN MYNN-BouLac",kts, kte
 
@@ -761,24 +2228,24 @@ CONTAINS
         ! FIND DISTANCE UPWARD
         !----------------------------------
         zup=0.
-        dlu(iz)=zw(kte+1)-zw(iz)-dz(iz)/2.
+        dlu(iz)=zw(kte+1)-zw(iz)-dz(iz)*0.5
         zzz=0.
         zup_inf=0.
-        beta=g/theta(iz)           !Buoyancy coefficient
+        beta=gtr           !Buoyancy coefficient (g/tref)
 
         !print*,"FINDING Dup, k=",iz," zw=",zw(iz)
 
         if (iz .lt. kte) then      !cant integrate upwards from highest level
 
           found = 0
-          izz=iz       
-          DO WHILE (found .EQ. 0) 
+          izz=iz
+          DO WHILE (found .EQ. 0)
 
             if (izz .lt. kte) then
-              dzt=dz(izz)                    ! layer depth above 
+              dzt=dz(izz)                    ! layer depth above
               zup=zup-beta*theta(iz)*dzt     ! initial PE the parcel has at iz
               !print*,"  ",iz,izz,theta(izz),dz(izz)
-              zup=zup+beta*(theta(izz+1)+theta(izz))*dzt/2. ! PE gained by lifting a parcel to izz+1
+              zup=zup+beta*(theta(izz+1)+theta(izz))*dzt*0.5 ! PE gained by lifting a parcel to izz+1
               zzz=zzz+dzt                   ! depth of layer iz to izz+1
               !print*,"  PE=",zup," TKE=",qtke(iz)," z=",zw(izz)
               if (qtke(iz).lt.zup .and. qtke(iz).ge.zup_inf) then
@@ -786,7 +2253,7 @@ CONTAINS
                  if (bbb .ne. 0.) then
                     !fractional distance up into the layer where TKE becomes < PE
                     tl=(-beta*(theta(izz)-theta(iz)) + &
-                      & sqrt( max(0.,(beta*(theta(izz)-theta(iz)))**2. + &
+                      & sqrt( max(0.,(beta*(theta(izz)-theta(iz)))**2 + &
                       &       2.*bbb*beta*(qtke(iz)-zup_inf))))/bbb/beta
                  else
                     if (theta(izz) .ne. theta(iz))then
@@ -828,14 +2295,14 @@ CONTAINS
               dzt=dz(izz-1)
               zdo=zdo+beta*theta(iz)*dzt
               !print*,"  ",iz,izz,theta(izz),dz(izz-1)
-              zdo=zdo-beta*(theta(izz-1)+theta(izz))*dzt/2.
+              zdo=zdo-beta*(theta(izz-1)+theta(izz))*dzt*0.5
               zzz=zzz+dzt
               !print*,"  PE=",zdo," TKE=",qtke(iz)," z=",zw(izz)
               if (qtke(iz).lt.zdo .and. qtke(iz).ge.zdo_sup) then
                  bbb=(theta(izz)-theta(izz-1))/dzt
                  if (bbb .ne. 0.) then
                     tl=(beta*(theta(izz)-theta(iz))+ &
-                      & sqrt( max(0.,(beta*(theta(izz)-theta(iz)))**2. + &
+                      & sqrt( max(0.,(beta*(theta(izz)-theta(iz)))**2 + &
                       &       2.*bbb*beta*(qtke(iz)-zdo_sup))))/bbb/beta
                  else
                     if (theta(izz) .ne. theta(iz)) then
@@ -860,51 +2327,47 @@ CONTAINS
         !----------------------------------
         ! GET MINIMUM (OR AVERAGE)
         !----------------------------------
-        !The surface layer length scale can exceed z for large z/L,
-        !so keep maximum distance down > z.
-        dld(iz) = min(dld(iz),zw(iz+1))!not used in PBL anyway, only free atmos
-        lb1(iz) = min(dlu(iz),dld(iz))     !minimum
-        lb2(iz) = sqrt(dlu(iz)*dld(iz))    !average - biased towards smallest
-        !lb2(iz) = 0.5*(dlu(iz)+dld(iz))   !average
+        !The length scale down should not exceed z.
+        dld(iz) = min(dld(iz),zw(iz+1))
+        !apply soft upper limit (only impacts very large lb; lb=100 by 5%, lb=500 by 20%)
+        dlu(iz)=MAX(0.1, dlu(iz)/(1. + (dlu(iz)/Lmax)) )
+        dld(iz)=MAX(0.1, dld(iz)/(1. + (dld(iz)/Lmax)) )
 
-        !Apply soft limit (only impacts very large lb; lb=100 by 5%, lb=500 by 20%).
-        lb1(iz) = lb1(iz)/(1. + (lb1(iz)/Lmax))
-        lb2(iz) = lb2(iz)/(1. + (lb2(iz)/Lmax))
- 
-        if (iz .eq. kte) then
-           lb1(kte) = lb1(kte-1)
-           lb2(kte) = lb2(kte-1)
-        endif
+        !minimum of up/down length scales
+        lb1(iz) = min(dlu(iz),dld(iz))
+        !average - biased towards smallest
+        lb2(iz) = sqrt(dlu(iz)*dld(iz))
+
         !print*,"IN MYNN-BouLac",kts, kte,lb1(iz)
         !print*,"IN MYNN-BouLac",iz,dld(iz),dlu(iz)
 
      ENDDO
-                   
+
+     lb1(kte) = lb1(kte-1)
+     lb2(kte) = lb2(kte-1)
+        
   END SUBROUTINE boulac_length
 !
-!JOE-END BOULAC CODE
-
 ! ==================================================================
 !     SUBROUTINE  mym_turbulence:
 !
 !     Input variables:    see subroutine mym_initialize
-!       levflag         : <>3;  Level 2.5
-!                         = 3;  Level 3
+!       closure        : closure level (2.5, 2.6, or 3.0)
 !
 !     # ql, vt, vq, qke, tsq, qsq and cov are changed to input variables.
 !
 !     Output variables:   see subroutine mym_initialize
-!       dfm(mx,my,nz) : Diffusivity coefficient for momentum,
+!       dfm(nx,nz,ny) : Diffusivity coefficient for momentum,
 !                         divided by dz (not dz*h(i,j))            (m/s)
-!       dfh(mx,my,nz) : Diffusivity coefficient for heat,
+!       dfh(nx,nz,ny) : Diffusivity coefficient for heat,
 !                         divided by dz (not dz*h(i,j))            (m/s)
-!       dfq(mx,my,nz) : Diffusivity coefficient for q^2,
+!       dfq(nx,nz,ny) : Diffusivity coefficient for q^2,
 !                         divided by dz (not dz*h(i,j))            (m/s)
-!       tcd(mx,my,nz)   : Countergradient diffusion term for Theta_l
+!       tcd(nx,nz,ny)   : Countergradient diffusion term for Theta_l
 !                                                                  (K/s)
-!       qcd(mx,my,nz)   : Countergradient diffusion term for Q_w
+!       qcd(nx,nz,ny)   : Countergradient diffusion term for Q_w
 !                                                              (kg/kg s)
-!       pd?(mx,my,nz) : Half of the production terms
+!       pd?(nx,nz,ny) : Half of the production terms
 !
 !       Only tcd and qcd are defined at the center of the grid boxes
 !
@@ -916,64 +2379,98 @@ CONTAINS
 !     # dtl, dqw, dtv, gm and gh are allowed to share storage units with
 !       dfm, dfh, dfq, tcd and qcd, respectively, for saving memory.
 !
-  SUBROUTINE  mym_turbulence ( kts,kte,&
-    &            levflag, &
-    &            dz, zw, &
-    &            u, v, thl, ql, qw, &
-    &            qke, tsq, qsq, cov, &
-    &            vt, vq,&
-    &            rmo, flt, flq, &
-!JOE-BouLac/PBLH test
-    &            zi,theta,&
-    &            sh,&
-!JOE-end
-    &            El,&
-    &            Dfm, Dfh, Dfq, Tcd, Qcd, Pdk, Pdt, Pdq, Pdc &
-!JOE-TKE BUDGET
-    &		 ,qWT1D,qSHEAR1D,qBUOY1D,qDISS1D &
-    &            ,bl_mynn_tkebudget &
-!JOE-end
-    &)
+!>\ingroup gsd_mynn_edmf
+!! This subroutine calculates the vertical diffusivity coefficients and the 
+!! production terms for the turbulent quantities.      
+!>\section gen_mym_turbulence GSD mym_turbulence General Algorithm
+!! Two subroutines mym_level2() and mym_length() are called within this
+!!subrouine to collect variable to carry out successive calculations:
+!! - mym_level2() calculates the level 2 nondimensional wind shear \f$G_M\f$
+!! and vertical temperature gradient \f$G_H\f$ as well as the level 2 stability
+!! functions \f$S_h\f$ and \f$S_m\f$.
+!! - mym_length() calculates the mixing lengths.
+!! - The stability criteria from Helfand and Labraga (1989) are applied.
+!! - The stability functions for level 2.5 or level 3.0 are calculated.
+!! - If level 3.0 is used, counter-gradient terms are calculated.
+!! - Production terms of TKE,\f$\theta^{'2}\f$,\f$q^{'2}\f$, and \f$\theta^{'}q^{'}\f$
+!! are calculated.
+!! - Eddy diffusivity \f$K_h\f$ and eddy viscosity \f$K_m\f$ are calculated.
+!! - TKE budget terms are calculated (if the namelist parameter \p tke_budget 
+!! is set to True)
+  SUBROUTINE  mym_turbulence (                                &
+    &            kts,kte,                                     &
+    &            xland,closure,                               &
+    &            dz, dx, zw,                                  &
+    &            u, v, thl, thv, thlv, ql, qw,                &
+    &            qke, tsq, qsq, cov,                          &
+    &            vt, vq,                                      &
+    &            rmol, flt, fltv, flq,                        &
+    &            pblh,theta,                                  &
+    &            sh, sm,                                      &
+    &            El,                                          &
+    &            Dfm, Dfh, Dfq, Tcd, Qcd, Pdk, Pdt, Pdq, Pdc, &
+    &		 qWT1,qSHEAR1,qBUOY1,qDISS1,                  &
+    &            tke_budget,                                  &
+    &            Psig_bl,Psig_shcu,cldfra_bl1,                &
+    &            bl_mynn_mixlength,                           &
+    &            edmf_w1,edmf_a1,                             &
+    &            edmf_w_dd1,edmf_a_dd1,                       &
+    &            TKEprod_dn,TKEprod_up,                       &
+    &            spp_pbl,pattern_spp_pbl1                     )
 
 !-------------------------------------------------------------------
-!
-    INTEGER, INTENT(IN)   :: kts,kte
-    INTEGER, INTENT(IN)   :: levflag
-    REAL, DIMENSION(kts:kte), INTENT(in) :: dz
-    REAL, DIMENSION(kts:kte+1), INTENT(in) :: zw
-    REAL, INTENT(in) :: rmo,flt,flq   
-    REAL, DIMENSION(kts:kte), INTENT(in) :: u,v,thl,qw,& 
-         &ql,vt,vq,qke,tsq,qsq,cov
 
-    REAL, DIMENSION(kts:kte), INTENT(out) :: dfm,dfh,dfq,&
+    integer, intent(in)   :: kts,kte
+
+#ifdef HARDCODE_VERTICAL
+# define kts 1
+# define kte HARDCODE_VERTICAL
+#endif
+
+    integer, intent(in)               :: bl_mynn_mixlength,tke_budget
+    real(kind_phys), intent(in)       :: closure
+    real(kind_phys), dimension(kts:kte),   intent(in) :: dz
+    real(kind_phys), dimension(kts:kte+1), intent(in) :: zw
+    real(kind_phys), intent(in)       :: rmol,flt,fltv,flq,                &
+         &Psig_bl,Psig_shcu,xland,dx,pblh
+    real(kind_phys), dimension(kts:kte), intent(in) :: u,v,thl,thv,        &
+         &thlv,qw,ql,vt,vq,qke,tsq,qsq,cov,cldfra_bl1,edmf_w1,edmf_a1,     &
+         &edmf_w_dd1,edmf_a_dd1,TKEprod_dn,TKEprod_up
+
+    real(kind_phys), dimension(kts:kte), intent(out) :: dfm,dfh,dfq,       &
          &pdk,pdt,pdq,pdc,tcd,qcd,el
 
-!JOE-TKE BUDGET
-    REAL, DIMENSION(kts:kte), INTENT(inout) :: &
-         qWT1D,qSHEAR1D,qBUOY1D,qDISS1D
-    REAL :: q3sq_old,dlsq1,qWTP_old,qWTP_new
-    REAL :: dudz,dvdz,dTdz,&
-            upwp,vpwp,Tpwp
-    INTEGER, INTENT(in) :: bl_mynn_tkebudget
-!JOE-end
+    real(kind_phys), dimension(kts:kte), intent(inout) ::                  &
+         qWT1,qSHEAR1,qBUOY1,qDISS1
+    real(kind_phys):: q3sq_old,dlsq1,qWTP_old,qWTP_new
+    real(kind_phys):: dudz,dvdz,dTdz,upwp,vpwp,Tpwp
 
-    REAL, DIMENSION(kts:kte) :: qkw,dtl,dqw,dtv,gm,gh,sm,sh
+    real(kind_phys), dimension(kts:kte) :: qkw,dtl,dqw,dtv,gm,gh,sm,sh
 
-    INTEGER :: k
-!    REAL :: cc2,cc3,e1c,e2c,e3c,e4c,e5c
-    REAL :: e6c,dzk,afk,abk,vtt,vqq,&
+    integer :: k
+!    real(kind_phys):: cc2,cc3,e1c,e2c,e3c,e4c,e5c
+    real(kind_phys):: e6c,dzk,afk,abk,vtt,vqq,                             &
          &cw25,clow,cupp,gamt,gamq,smd,gamv,elq,elh
 
-!JOE-added for BouLac/PBLH test
-    REAL :: zi
-    REAL, DIMENSION(kts:kte), INTENT(in) :: theta
-!JOE-end
+    real(kind_phys):: cldavg
+    real(kind_phys), dimension(kts:kte), intent(in) :: theta
 
-    REAL ::  a2den, duz, ri, HLmod  !JOE-Canuto/Kitamura mod
+    real(kind_phys)::  a2fac, duz, ri !JOE-Canuto/Kitamura mod
+
+    real:: auh,aum,adh,adm,aeh,aem,Req,Rsl,Rsl2,                           &
+           gmelq,sm20,sh20,sm25max,sh25max,sm25min,sh25min,                &
+           sm_pbl,sh_pbl,pblh2,wt,slht,wtpr,mfmax
 
     DOUBLE PRECISION  q2sq, t2sq, r2sq, c2sq, elsq, gmel, ghel
     DOUBLE PRECISION  q3sq, t3sq, r3sq, c3sq, dlsq, qdiv
     DOUBLE PRECISION  e1, e2, e3, e4, enum, eden, wden
+
+!   Stochastic
+    integer,         intent(in)                   :: spp_pbl
+    real(kind_phys), dimension(kts:kte)           :: pattern_spp_pbl1
+    real(kind_phys):: Prnum, shb
+    real(kind_phys), parameter :: Prlimit = 5.0
+
 !
 !    tv0 = 0.61*tref
 !    gtr = 9.81/tref
@@ -987,21 +2484,25 @@ CONTAINS
 !    e5c =  6.0*a1*a1
 !
 
-    CALL mym_level2 (kts,kte,&
-    &            dz, &
-    &            u, v, thl, qw, &
-    &            ql, vt, vq, &
-    &            dtl, dqw, dtv, gm, gh, sm, sh )
+    CALL mym_level2 (kts,kte,                   &
+    &            dz,                            &
+    &            u, v, thl, thv, thlv,          &
+    &            qw, ql, vt, vq,                &
+    &            dtl, dqw, dtv, gm, gh, sm, sh  )
 !
-    CALL mym_length (kts,kte, &
-    &            dz, zw, &
-    &            rmo, flt, flq, &
-    &            vt, vq, &
-    &            qke, &
-    &            dtv, &
-    &            el, &
-    &            zi,theta,&  !JOE-hybrid PBLH
-    &            qkw)
+    CALL mym_length (                           &
+    &            kts,kte,xland,                 &
+    &            dz, dx, zw,                    &
+    &            rmol, flt, fltv, flq,          &
+    &            vt, vq,                        &
+    &            u, v, qke,                     &
+    &            dtv,                           &
+    &            el,                            &
+    &            pblh,theta,                    &
+    &            qkw,Psig_bl,cldfra_bl1,        &
+    &            bl_mynn_mixlength,             &
+    &            edmf_w1,edmf_a1,               &
+    &            edmf_w_dd1,edmf_a_dd1          )
 !
 
     DO k = kts+1,kte
@@ -1009,107 +2510,181 @@ CONTAINS
        afk = dz(k)/( dz(k)+dz(k-1) )
        abk = 1.0 -afk
        elsq = el (k)**2
-       q2sq = b1*elsq*( sm(k)*gm(k)+sh(k)*gh(k) )
        q3sq = qkw(k)**2
+       q2sq = b1*elsq*( sm(k)*gm(k)+sh(k)*gh(k) )
 
-!JOE-Canuto/Kitamura mod
+       sh20 = MAX(sh(k), 1e-5)
+       sm20 = MAX(sm(k), 1e-5)
+       sh(k)= MAX(sh(k), 1e-5)
+
+       !Canuto/Kitamura mod
        duz = ( u(k)-u(k-1) )**2 +( v(k)-v(k-1) )**2
        duz =   duz                    /dzk**2
        !   **  Gradient Richardson number  **
        ri = -gh(k)/MAX( duz, 1.0e-10 )
        IF (CKmod .eq. 1) THEN
-          a2den = 1. + MAX(ri,0.0)
+          a2fac = 1./(1. + MAX(ri,0.0))
        ELSE
-          a2den = 1. + 0.0
+          a2fac = 1.
        ENDIF
-!JOE-end
+       !end Canuto/Kitamura mod
+
+       !level 2.0 Prandtl number
+       !Prnum = MIN(sm20/sh20, 4.0)
+       !The form of Zilitinkevich et al. (2006) but modified
+       !half-way towards Esau and Grachev (2007, Wind Eng)
+       !Prnum = MIN(0.76 + 3.0*MAX(ri,0.0), Prlimit)
+       Prnum = MIN(0.76 + 4.0*MAX(ri,0.0), Prlimit)
+       !Prnum = MIN(0.76 + 5.0*MAX(ri,0.0), Prlimit)
 !
 !  Modified: Dec/22/2005, from here, (dlsq -> elsq)
        gmel = gm (k)*elsq
        ghel = gh (k)*elsq
 !  Modified: Dec/22/2005, up to here
-!
-!JOE-add prints
-       IF (sh(k)<0.0 .OR. sm(k)<0.0) THEN
-          PRINT*,"MYM_TURBULENCE2.0: k=",k," sh=",sh(k)
-          PRINT*," gm=",gm(k)," gh=",gh(k)," sm=",sm(k)
-          PRINT*," q2sq=",q2sq," q3sq=",q3sq," q3/q2=",q3sq/q2sq
-          PRINT*," qke=",qke(k)," el=",el(k)," ri=",ri
-          PRINT*," PBLH=",zi," u=",u(k)," v=",v(k)
-       ENDIF
-!JOE-Apply Helfand & Labraga stability check for all Ric
-!    when CKmod == 1. Suggested by Kitamura. Not applied below.
-       IF (CKmod .eq. 1) THEN
-          HLmod = q2sq -1.
-       ELSE
-          HLmod = q3sq
-       ENDIF
-!     **  Since qkw is set to more than 0.0, q3sq > 0.0.  **
-       IF ( q3sq .LT. q2sq ) THEN
-!       IF ( HLmod .LT. q2sq ) THEN
-!JOE-END
-          qdiv = SQRT( q3sq/q2sq )   !HL89: (1-alfa)
-          sm(k) = sm(k) * qdiv
-          sh(k) = sh(k) * qdiv
-!
-!JOE-Canuto/Kitamura mod
-!          e1   = q3sq - e1c*ghel * qdiv**2
-!          e2   = q3sq - e2c*ghel * qdiv**2
-!          e3   = e1   + e3c*ghel * qdiv**2
-!          e4   = e1   - e4c*ghel * qdiv**2
-          e1   = q3sq - e1c*ghel/a2den * qdiv**2
-          e2   = q3sq - e2c*ghel/a2den * qdiv**2
-          e3   = e1   + e3c*ghel/(a2den**2) * qdiv**2
-          e4   = e1   - e4c*ghel/a2den * qdiv**2
-!JOE-end
-          eden = e2*e4 + e3*e5c*gmel * qdiv**2
-          eden = MAX( eden, 1.0d-20 )
-       ELSE
-!JOE-Canuto/Kitamura mod
-!          e1   = q3sq - e1c*ghel
-!          e2   = q3sq - e2c*ghel
-!          e3   = e1   + e3c*ghel
-!          e4   = e1   - e4c*ghel
-          e1   = q3sq - e1c*ghel/a2den
-          e2   = q3sq - e2c*ghel/a2den
-          e3   = e1   + e3c*ghel/(a2den**2)
-          e4   = e1   - e4c*ghel/a2den
-!JOE-end
-          eden = e2*e4 + e3*e5c*gmel
-          eden = MAX( eden, 1.0d-20 )
-!
-          qdiv = 1.0
-          sm(k) = q3sq*a1*( e3-3.0*c1*e4       )/eden
-!JOE-Canuto/Kitamura mod
-!          sh(k) = q3sq*a2*( e2+3.0*c1*e5c*gmel )/eden
-          sh(k) = q3sq*(a2/a2den)*( e2+3.0*c1*e5c*gmel )/eden
-!JOE-end
-       END IF
-!
-!      HL88 , lev2.5 criteria from eqs. 3.17, 3.19, & 3.20
-       IF (sh(k)<0.0 .OR. sm(k)<0.0 .OR. &
-           sh(k) > 0.76*b2 .or. (sm(k)**2*gm(k) .gt. .44**2)) THEN
-          PRINT*,"MYM_TURBULENCE2.5: k=",k," sh=",sh(k)
-          PRINT*," gm=",gm(k)," gh=",gh(k)," sm=",sm(k)
-          PRINT*," q2sq=",q2sq," q3sq=",q3sq," q3/q2=",q3sq/q2sq
-          PRINT*," qke=",qke(k)," el=",el(k)," ri=",ri
-          PRINT*," PBLH=",zi," u=",u(k)," v=",v(k)
+
+       ! Level 2.0 debug prints
+       IF ( debug_code ) THEN
+         IF (sh(k)<0.0 .OR. sm(k)<0.0) THEN
+           print*,"MYNN; mym_turbulence 2.0; sh=",sh(k)," k=",k
+           print*," gm=",gm(k)," gh=",gh(k)," sm=",sm(k)
+           print*," q2sq=",q2sq," q3sq=",q3sq," q3/q2=",q3sq/q2sq
+           print*," qke=",qke(k)," el=",el(k)," ri=",ri
+           print*," PBLH=",pblh," u=",u(k)," v=",v(k)
+         ENDIF
        ENDIF
 
+!     **  Since qkw is set to more than 0.0, q3sq > 0.0.  **
+
+!     new stability criteria in level 2.5 (as well as level 3) - little/no impact
+!     **  Limitation on q, instead of L/q  **
+       dlsq =  elsq
+       IF ( q3sq/dlsq .LT. -gh(k) ) q3sq = -dlsq*gh(k)
+
+       IF ( q3sq .LT. q2sq ) THEN
+          !Apply Helfand & Labraga mod
+          qdiv = SQRT( q3sq/q2sq )   !HL89: (1-alfa)
+!
+          !Use level 2.5 stability functions
+          !e1   = q3sq - e1c*ghel*a2fac
+          !e2   = q3sq - e2c*ghel*a2fac
+          !e3   = e1   + e3c*ghel*a2fac**2
+          !e4   = e1   - e4c*ghel*a2fac
+          !eden = e2*e4 + e3*e5c*gmel
+          !eden = MAX( eden, 1.0d-20 )
+          !sm(k) = q3sq*a1*( e3-3.0*c1*e4       )/eden
+          !!JOE-Canuto/Kitamura mod
+          !!sh(k) = q3sq*a2*( e2+3.0*c1*e5c*gmel )/eden
+          !sh(k) = q3sq*(a2*a2fac)*( e2+3.0*c1*e5c*gmel )/eden
+          !sm(k) = Prnum*sh(k)
+          !sm(k) = sm(k) * qdiv
+
+          !Use level 2.0 functions as in original MYNN
+          sh(k) = sh(k) * qdiv
+          sm(k) = sm(k) * qdiv
+        !  !sm_pbl = sm(k) * qdiv
+        !
+        !  !Or, use the simple Pr relationship
+        !  sm(k) = Prnum*sh(k)
+        !
+        !  !or blend them:
+        !  pblh2   = MAX(pblh, 300.)
+        !  wt    =.5*TANH((zw(k) - pblh2)/200.) + .5
+        !  sm(k) = sm_pbl*(1.-wt) + sm(k)*wt
+
+          !Recalculate terms for later use
+          !JOE-Canuto/Kitamura mod
+          !e1   = q3sq - e1c*ghel * qdiv**2
+          !e2   = q3sq - e2c*ghel * qdiv**2
+          !e3   = e1   + e3c*ghel * qdiv**2
+          !e4   = e1   - e4c*ghel * qdiv**2
+          e1   = q3sq - e1c*ghel*a2fac * qdiv**2
+          e2   = q3sq - e2c*ghel*a2fac * qdiv**2
+          e3   = e1   + e3c*ghel*a2fac**2 * qdiv**2
+          e4   = e1   - e4c*ghel*a2fac * qdiv**2
+          eden = e2*e4 + e3*e5c*gmel * qdiv**2
+          eden = MAX( eden, 1.0d-20 )
+          !!JOE-Canuto/Kitamura mod
+          !!sh(k) = q3sq*a2*( e2+3.0*c1*e5c*gmel )/eden  - retro 5
+          !sh(k) = q3sq*(a2*a2fac)*( e2+3.0*c1*e5c*gmel )/eden
+          !sm(k) = Prnum*sh(k)
+       ELSE
+          !JOE-Canuto/Kitamura mod
+          !e1   = q3sq - e1c*ghel
+          !e2   = q3sq - e2c*ghel
+          !e3   = e1   + e3c*ghel
+          !e4   = e1   - e4c*ghel
+          e1   = q3sq - e1c*ghel*a2fac
+          e2   = q3sq - e2c*ghel*a2fac
+          e3   = e1   + e3c*ghel*a2fac**2
+          e4   = e1   - e4c*ghel*a2fac
+          eden = e2*e4 + e3*e5c*gmel
+          eden = MAX( eden, 1.0d-20 )
+
+          qdiv = 1.0
+          !Use level 2.5 stability functions
+          sm(k) = q3sq*a1*( e3-3.0*c1*e4       )/eden
+        !  sm_pbl = q3sq*a1*( e3-3.0*c1*e4       )/eden
+          !!JOE-Canuto/Kitamura mod
+          !!sh(k) = q3sq*a2*( e2+3.0*c1*e5c*gmel )/eden
+          sh(k) = q3sq*(a2*a2fac)*( e2+3.0*c1*e5c*gmel )/eden
+        !  sm(k) = Prnum*sh(k)
+
+        !  !or blend them:
+        !  pblh2   = MAX(pblh, 300.)
+        !  wt    = .5*TANH((zw(k) - pblh2)/200.) + .5
+        !  sm(k) = sm_pbl*(1.-wt) + sm(k)*wt
+       END IF !end Helfand & Labraga check
+
+       !Impose broad limits on Sh and Sm:
+       gmelq    = MAX(gmel/q3sq, 1e-8)
+       sm25max  = 4.  !MIN(sm20*3.0, SQRT(.1936/gmelq))
+       sh25max  = 4.  !MIN(sh20*3.0, 0.76*b2)
+       sm25min  = 0.0 !MAX(sm20*0.1, 1e-6)
+       sh25min  = 0.0 !MAX(sh20*0.1, 1e-6)
+
+       !JOE: Level 2.5 debug prints
+       ! HL88 , lev2.5 criteria from eqs. 3.17, 3.19, & 3.20
+       IF ( debug_code ) THEN
+         IF ((sh(k)<sh25min .OR. sm(k)<sm25min .OR. &
+              sh(k)>sh25max .OR. sm(k)>sm25max) ) THEN
+           print*,"In mym_turbulence 2.5: k=",k
+           print*," sm=",sm(k)," sh=",sh(k)
+           print*," ri=",ri," Pr=",sm(k)/MAX(sh(k),1e-8)
+           print*," gm=",gm(k)," gh=",gh(k)
+           print*," q2sq=",q2sq," q3sq=",q3sq, q3sq/q2sq
+           print*," qke=",qke(k)," el=",el(k)
+           print*," PBLH=",pblh," u=",u(k)," v=",v(k)
+           print*," SMnum=",q3sq*a1*( e3-3.0*c1*e4)," SMdenom=",eden
+           print*," SHnum=",q3sq*(a2*a2fac)*( e2+3.0*c1*e5c*gmel ),&
+                  " SHdenom=",eden
+         ENDIF
+       ENDIF
+
+       !Enforce constraints for level 2.5 functions
+       IF ( sh(k) > sh25max ) sh(k) = sh25max
+       IF ( sh(k) < sh25min ) sh(k) = sh25min
+       !IF ( sm(k) > sm25max ) sm(k) = sm25max
+       !IF ( sm(k) < sm25min ) sm(k) = sm25min
+
+       !shb   = max(sh(k), 0.002)
+       shb   = max(sh(k), 0.02)
+       sm(k) = min(sm(k), Prlimit*shb)
+
 !   **  Level 3 : start  **
-       IF ( levflag .EQ. 3 ) THEN
+       IF ( closure .GE. 3.0 ) THEN
           t2sq = qdiv*b2*elsq*sh(k)*dtl(k)**2
           r2sq = qdiv*b2*elsq*sh(k)*dqw(k)**2
           c2sq = qdiv*b2*elsq*sh(k)*dtl(k)*dqw(k)
           t3sq = MAX( tsq(k)*abk+tsq(k-1)*afk, 0.0 )
           r3sq = MAX( qsq(k)*abk+qsq(k-1)*afk, 0.0 )
           c3sq =      cov(k)*abk+cov(k-1)*afk
-!
+
 !  Modified: Dec/22/2005, from here
           c3sq = SIGN( MIN( ABS(c3sq), SQRT(t3sq*r3sq) ), c3sq )
 !
           vtt  = 1.0 +vt(k)*abk +vt(k-1)*afk
           vqq  = tv0 +vq(k)*abk +vq(k-1)*afk
+
           t2sq = vtt*t2sq +vqq*c2sq
           r2sq = vtt*c2sq +vqq*r2sq
           c2sq = MAX( vtt*t2sq+vqq*r2sq, 0.0d0 )
@@ -1124,26 +2699,52 @@ CONTAINS
           IF ( q3sq/dlsq .LT. -gh(k) ) q3sq = -dlsq*gh(k)
 !
 !     **  Limitation on c3sq (0.12 =< cw =< 0.76) **
-!JOE-Canuto/Kitamura mod
-!          e2   = q3sq - e2c*ghel * qdiv**2
-!          e3   = q3sq + e3c*ghel * qdiv**2
-!          e4   = q3sq - e4c*ghel * qdiv**2
-          e2   = q3sq - e2c*ghel/a2den * qdiv**2
-          e3   = q3sq + e3c*ghel/(a2den**2) * qdiv**2
-          e4   = q3sq - e4c*ghel/a2den * qdiv**2
-!JOE-end
+          ! Use Janjic's (2001; p 13-17) methodology (eqs 4.11-414 and 5.7-5.10)
+          ! to calculate an exact limit for c3sq:
+          auh = 27.*a1*((a2*a2fac)**2)*b2*(gtr)**2
+          aum = 54.*(a1**2)*(a2*a2fac)*b2*c1*(gtr)
+          adh = 9.*a1*((a2*a2fac)**2)*(12.*a1 + 3.*b2)*(gtr)**2
+          adm = 18.*(a1**2)*(a2*a2fac)*(b2 - 3.*(a2*a2fac))*(gtr)
+
+          aeh = (9.*a1*((a2*a2fac)**2)*b1 +9.*a1*((a2*a2fac)**2)* &
+                (12.*a1 + 3.*b2))*(gtr)
+          aem = 3.*a1*(a2*a2fac)*b1*(3.*(a2*a2fac) + 3.*b2*c1 + &
+                (18.*a1*c1 - b2)) + &
+                (18.)*(a1**2)*(a2*a2fac)*(b2 - 3.*(a2*a2fac))
+
+          Req = -aeh/aem
+          Rsl = (auh + aum*Req)/(3.*adh + 3.*adm*Req)
+          !For now, use default values, since tests showed little/no sensitivity
+          Rsl = .12             !lower limit
+          Rsl2= 1.0 - 2.*Rsl    !upper limit
+          !IF (k==2)print*,"Dynamic limit RSL=",Rsl
+          !IF (Rsl < 0.10 .OR. Rsl > 0.18) THEN
+          !   print*,'--- ERROR: MYNN: Dynamic Cw '// &
+          !        'limit exceeds reasonable limits'
+          !   print*," MYNN: Dynamic Cw limit needs attention=",Rsl
+          !ENDIF
+
+          !JOE-Canuto/Kitamura mod
+          !e2   = q3sq - e2c*ghel * qdiv**2
+          !e3   = q3sq + e3c*ghel * qdiv**2
+          !e4   = q3sq - e4c*ghel * qdiv**2
+          e2   = q3sq - e2c*ghel*a2fac * qdiv**2
+          e3   = q3sq + e3c*ghel*a2fac**2 * qdiv**2
+          e4   = q3sq - e4c*ghel*a2fac * qdiv**2
           eden = e2*e4  + e3 *e5c*gmel * qdiv**2
-!
-!JOE-Canuto/Kitamura mod
-!          wden = cc3*gtr**2 * dlsq**2/elsq * qdiv**2 &
-!               &        *( e2*e4c - e3c*e5c*gmel * qdiv**2 )
+
+          !JOE-Canuto/Kitamura mod
+          !wden = cc3*gtr**2 * dlsq**2/elsq * qdiv**2 &
+          !     &        *( e2*e4c - e3c*e5c*gmel * qdiv**2 )
           wden = cc3*gtr**2 * dlsq**2/elsq * qdiv**2 &
-               &        *( e2*e4c/a2den - e3c*e5c*gmel/(a2den**2) * qdiv**2 )
-!JOE-end
-!
+               &        *( e2*e4c*a2fac - e3c*e5c*gmel*a2fac**2 * qdiv**2 )
+
           IF ( wden .NE. 0.0 ) THEN
+             !JOE: test dynamic limits
              clow = q3sq*( 0.12-cw25 )*eden/wden
              cupp = q3sq*( 0.76-cw25 )*eden/wden
+             !clow = q3sq*( Rsl -cw25 )*eden/wden
+             !cupp = q3sq*( Rsl2-cw25 )*eden/wden
 !
              IF ( wden .GT. 0.0 ) THEN
                 c3sq  = MIN( MAX( c3sq, c2sq+clow ), c2sq+cupp )
@@ -1155,56 +2756,61 @@ CONTAINS
           e1   = e2 + e5c*gmel * qdiv**2
           eden = MAX( eden, 1.0d-20 )
 !  Modified: Dec/22/2005, up to here
-!
-!JOE-Canuto/Kitamura mod
-!          e6c  = 3.0*a2*cc3*gtr * dlsq/elsq
-          e6c  = 3.0*(a2/a2den)*cc3*gtr * dlsq/elsq
-!JOE-end
-!
-!     **  for Gamma_theta  **
-!!          enum = qdiv*e6c*( t3sq-t2sq )
+
+          !JOE-Canuto/Kitamura mod
+          !e6c  = 3.0*a2*cc3*gtr * dlsq/elsq
+          e6c  = 3.0*(a2*a2fac)*cc3*gtr * dlsq/elsq
+
+          !============================
+          !     **  for Gamma_theta  **
+          !!          enum = qdiv*e6c*( t3sq-t2sq )
           IF ( t2sq .GE. 0.0 ) THEN
              enum = MAX( qdiv*e6c*( t3sq-t2sq ), 0.0d0 )
           ELSE
              enum = MIN( qdiv*e6c*( t3sq-t2sq ), 0.0d0 )
           ENDIF
-
           gamt =-e1  *enum    /eden
-!
-!     **  for Gamma_q  **
-!!          enum = qdiv*e6c*( r3sq-r2sq )
+
+          !============================
+          !     **  for Gamma_q  **
+          !!          enum = qdiv*e6c*( r3sq-r2sq )
           IF ( r2sq .GE. 0.0 ) THEN
              enum = MAX( qdiv*e6c*( r3sq-r2sq ), 0.0d0 )
           ELSE
              enum = MIN( qdiv*e6c*( r3sq-r2sq ), 0.0d0 )
           ENDIF
-
           gamq =-e1  *enum    /eden
-!
-!     **  for Sm' and Sh'd(Theta_V)/dz  **
-!!          enum = qdiv*e6c*( c3sq-c2sq )
+
+          !============================
+          !     **  for Sm' and Sh'd(Theta_V)/dz  **
+          !!          enum = qdiv*e6c*( c3sq-c2sq )
           enum = MAX( qdiv*e6c*( c3sq-c2sq ), 0.0d0)
 
-!JOE-Canuto/Kitamura mod
-!          smd  = dlsq*enum*gtr/eden * qdiv**2 * (e3c+e4c)*a1/a2
-          smd  = dlsq*enum*gtr/eden * qdiv**2 * (e3c/(a2den**2) + &
-               & e4c/a2den)*a1/(a2/a2den)
-!JOE-end
+          !JOE-Canuto/Kitamura mod
+          !smd  = dlsq*enum*gtr/eden * qdiv**2 * (e3c+e4c)*a1/a2
+          smd  = dlsq*enum*gtr/eden * qdiv**2 * (e3c*a2fac**2 + &
+               & e4c*a2fac)*a1/(a2*a2fac)
+
           gamv = e1  *enum*gtr/eden
-!
           sm(k) = sm(k) +smd
-!
-!     **  For elh (see below), qdiv at Level 3 is reset to 1.0.  **
+
+          !============================
+          !     **  For elh (see below), qdiv at Level 3 is reset to 1.0.  **
           qdiv = 1.0
-!   **  Level 3 : end  **
-!
-          IF (sh(k)<0.0 .OR. sm(k)<0.0) THEN
-            PRINT*,"MYM_TURBULENCE3.0: k=",k," sh=",sh(k)
-            PRINT*," gm=",gm(k)," gh=",gh(k)," sm=",sm(k)
-            PRINT*," q2sq=",q2sq," q3sq=",q3sq," q3/q2=",q3sq/q2sq
-            PRINT*," qke=",qke(k)," el=",el(k)," ri=",ri
-            PRINT*," PBLH=",zi," u=",u(k)," v=",v(k)
+
+          ! Level 3 debug prints
+          IF ( debug_code ) THEN
+            IF (sh(k)<-0.3 .OR. sm(k)<-0.3 .OR. &
+              qke(k) < -0.1 .or. ABS(smd) .gt. 2.0) THEN
+              print*," MYNN; mym_turbulence3.0; sh=",sh(k)," k=",k
+              print*," gm=",gm(k)," gh=",gh(k)," sm=",sm(k)
+              print*," q2sq=",q2sq," q3sq=",q3sq," q3/q2=",q3sq/q2sq
+              print*," qke=",qke(k)," el=",el(k)," ri=",ri
+              print*," PBLH=",pblh," u=",u(k)," v=",v(k)
+            ENDIF
           ENDIF
+
+!   **  Level 3 : end  **
 
        ELSE
 !     **  At Level 2.5, qdiv is not reset.  **
@@ -1213,73 +2819,89 @@ CONTAINS
           gamv = 0.0
        END IF
 !
+!      Add min background stability function (diffusivity) within model levels
+!      with active plumes and clouds.
+       cldavg = 0.5*(cldfra_bl1(k-1) + cldfra_bl1(k))
+       mfmax  = max(edmf_a1(k)*edmf_w1(k),abs(edmf_a_dd1(k)*edmf_w_dd1(k)))
+       ! impose minimum for mass-flux columns
+       sm(k) = max(sm(k), 0.04*min(10.*mfmax,1.0) )
+       sh(k) = max(sh(k), 0.04*min(10.*mfmax,1.0) )
+       ! impose minimum for clouds
+       sm(k) = max(sm(k), 0.04*min(cldavg,1.0) )
+       sh(k) = max(sh(k), 0.04*min(cldavg,1.0) )
+!
        elq = el(k)*qkw(k)
        elh = elq*qdiv
-!
-       pdk(k) = elq*( sm(k)*gm(k) &
-            &                    +sh(k)*gh(k)+gamv )
+
+       ! Production of TKE (pdk), T-variance (pdt),
+       ! q-variance (pdq), and covariance (pdc)
+       pdk(k) = elq*( sm(k)*gm(k)                &
+            &        +sh(k)*gh(k)+gamv ) +       &
+            &    0.5*TKEprod_dn(k)       +       & ! xmchen
+            &    0.5*TKEprod_up(k)
        pdt(k) = elh*( sh(k)*dtl(k)+gamt )*dtl(k)
        pdq(k) = elh*( sh(k)*dqw(k)+gamq )*dqw(k)
-       pdc(k) = elh*( sh(k)*dtl(k)+gamt )&
-            &*dqw(k)*0.5 &
-                  &+elh*( sh(k)*dqw(k)+gamq )*dtl(k)*0.5
-!
+       pdc(k) = elh*( sh(k)*dtl(k)+gamt )        &
+            &   *dqw(k)*0.5                      &
+            & + elh*( sh(k)*dqw(k)+gamq )*dtl(k)*0.5
+
+       ! Contergradient terms
        tcd(k) = elq*gamt
        qcd(k) = elq*gamq
-!
-       dfm(k) = elq*sm (k) / dzk
-       dfh(k) = elq*sh (k) / dzk
+
+       ! Eddy Diffusivity/Viscosity divided by dz
+       dfm(k) = elq*sm(k) / dzk
+       dfh(k) = elq*sh(k) / dzk
 !  Modified: Dec/22/2005, from here
 !   **  In sub.mym_predict, dfq for the TKE and scalar variance **
 !   **  are set to 3.0*dfm and 1.0*dfm, respectively. (Sqfac)   **
        dfq(k) =     dfm(k)
 !  Modified: Dec/22/2005, up to here
 
-   IF ( bl_mynn_tkebudget == 1) THEN
+   IF (tke_budget .eq. 1) THEN
        !TKE BUDGET
-       dudz = ( u(k)-u(k-1) )/dzk
-       dvdz = ( v(k)-v(k-1) )/dzk
-       dTdz = ( thl(k)-thl(k-1) )/dzk
+!       dudz = ( u(k)-u(k-1) )/dzk
+!       dvdz = ( v(k)-v(k-1) )/dzk
+!       dTdz = ( thl(k)-thl(k-1) )/dzk
 
-       upwp = -elq*sm(k)*dudz
-       vpwp = -elq*sm(k)*dvdz
-       Tpwp = -elq*sh(k)*dTdz
-       Tpwp = SIGN(MAX(ABS(Tpwp),1.E-6),Tpwp)
+!       upwp = -elq*sm(k)*dudz
+!       vpwp = -elq*sm(k)*dvdz
+!       Tpwp = -elq*sh(k)*dTdz
+!       Tpwp = SIGN(MAX(ABS(Tpwp),1.E-6),Tpwp)
 
-       IF ( k .EQ. kts+1 ) THEN
-          qWT1D(kts)=0.
-          q3sq_old =0.
-          qWTP_old =0.
-          !**  Limitation on q, instead of L/q  **
-          dlsq1 = MAX(el(kts)**2,1.0)
-          IF ( q3sq_old/dlsq1 .LT. -gh(k) ) q3sq_old = -dlsq1*gh(k)
-       ENDIF
-
-       !!!Vertical Transport Term
-       qWTP_new = elq*Sqfac*sm(k)*(q3sq - q3sq_old)/dzk
-       qWT1D(k) = 0.5*(qWTP_new - qWTP_old)/dzk
-       qWTP_old = elq*Sqfac*sm(k)*(q3sq - q3sq_old)/dzk
-       q3sq_old = q3sq
+       
+!!  TKE budget  (Puhales, 2020, WRF 4.2.1)  << EOB   
 
        !!!Shear Term
-       !!!qSHEAR1D(k)=-(upwp*dudz + vpwp*dvdz)
-       qSHEAR1D(k) = elq*sm(k)*gm(k)
+       !!!qSHEAR1(k)=-(upwp*dudz + vpwp*dvdz)
+       qSHEAR1(k) = elq*sm(k)*gm(k) !staggered
 
        !!!Buoyancy Term    
-       !!!qBUOY1D(k)=g*Tpwp/thl(k)
-       !qBUOY1D(k)= elq*(sh(k)*gh(k) + gamv)
-       qBUOY1D(k) = elq*(sh(k)*(-dTdz*g/thl(k)) + gamv)
+       !!!qBUOY1(k)=grav*Tpwp/thl(k)
+       !qBUOY1(k)= elq*(sh(k)*gh(k) + gamv)
+       !qBUOY1(k) = elq*(sh(k)*(-dTdz*grav/thl(k)) + gamv) !! ORIGINAL CODE
+       
+       !! Buoyncy term takes the TKEprodTD(k) production now
+       qBUOY1(k) = elq*(sh(k)*gh(k)+gamv)   +         &
+       &           0.5*TKEprod_dn(k)        +         & ! xmchen
+       &           0.5*TKEprod_up(k) 
 
-       !!!Dissipation Term
-       qDISS1D(k) = (q3sq**(3./2.))/(b1*MAX(el(k),1.))
+       !!!Dissipation Term (now it evaluated in mym_predict)
+       !qDISS1(k) = (q3sq**(3./2.))/(b1*MAX(el(k),1.)) !! ORIGINAL CODE
+       
+       !! >> EOB
     ENDIF
 
     END DO
 !
-
+    !make sure all inent(out) vars are initialized
     dfm(kts) = 0.0
     dfh(kts) = 0.0
     dfq(kts) = 0.0
+    pdk(kts) = 0.0
+    pdt(kts) = 0.0
+    pdq(kts) = 0.0
+    pdc(kts) = 0.0
     tcd(kts) = 0.0
     qcd(kts) = 0.0
 
@@ -1293,16 +2915,18 @@ CONTAINS
        qcd(k) = ( qcd(k+1)-qcd(k) )/( dzk )
     END DO
 !
+    if (spp_pbl==1) then
+       DO k = kts,kte
+          dfm(k)= dfm(k) + dfm(k)* pattern_spp_pbl1(k) * 1.5 * MAX(exp(-MAX(zw(k)-8000.,0.0)/2000.),0.001)
+          dfh(k)= dfh(k) + dfh(k)* pattern_spp_pbl1(k) * 1.5 * MAX(exp(-MAX(zw(k)-8000.,0.0)/2000.),0.001)
+       END DO
+    endif
 
-   IF ( bl_mynn_tkebudget == 1) THEN
-      !JOE-TKE BUDGET
-      qWT1D(kts)=0.
-      qSHEAR1D(kts)=qSHEAR1D(kts+1)
-      qBUOY1D(kts)=qBUOY1D(kts+1)
-      qDISS1D(kts)=qDISS1D(kts+1)
-   ENDIF
-
-    RETURN
+!    RETURN
+#ifdef HARDCODE_VERTICAL
+# undef kts
+# undef kte
+#endif
 
   END SUBROUTINE mym_turbulence
 
@@ -1310,17 +2934,17 @@ CONTAINS
 !     SUBROUTINE  mym_predict:
 !
 !     Input variables:    see subroutine mym_initialize and turbulence
-!       qke(mx,my,nz) : qke at (n)th time level
+!       qke(nx,nz,ny) : qke at (n)th time level
 !       tsq, ...cov     : ditto
 !
 !     Output variables:
-!       qke(mx,my,nz) : qke at (n+1)th time level
+!       qke(nx,nz,ny) : qke at (n+1)th time level
 !       tsq, ...cov     : ditto
 !
 !     Work arrays:
-!       qkw(mx,my,nz)   : q at the center of the grid boxes        (m/s)
-!       bp (mx,my,nz)   : = 1/2*F,     see below
-!       rp (mx,my,nz)   : = P-1/2*F*Q, see below
+!       qkw(nx,nz,ny)   : q at the center of the grid boxes        (m/s)
+!       bp (nx,nz,ny)   : = 1/2*F,     see below
+!       rp (nx,nz,ny)   : = P-1/2*F*Q, see below
 !
 !     # The equation for a turbulent quantity Q can be expressed as
 !          dQ/dt + Ah + Av = Dh + Dv + P - F*Q,                      (1)
@@ -1350,57 +2974,109 @@ CONTAINS
 !       scheme (program).
 !
 !-------------------------------------------------------------------
-  SUBROUTINE  mym_predict (kts,kte,&
-       &            levflag,  &
-       &            delt,&
-       &            dz, &
-       &            ust, flt, flq, pmz, phh, &
-       &            el, dfq, &
-       &            pdk, pdt, pdq, pdc,&
-       &            qke, tsq, qsq, cov &
-       &)
+!>\ingroup gsd_mynn_edmf
+!! This subroutine predicts the turbulent quantities at the next step.
+  SUBROUTINE  mym_predict (kts,kte,                                     &
+       &            closure,                                            &
+       &            delt,                                               &
+       &            dz,                                                 &
+       &            ust, flt, flq, pmz, phh,                            &
+       &            el,  dfq, rho,                                      &
+       &            pdk, pdt, pdq, pdc,                                 &
+       &            qke, tsq, qsq, cov,                                 &
+       &            s_aw,s_awqke,bl_mynn_edmf_tke,                      &
+       &            qWT1, qDISS1,tke_budget                             )
 
 !-------------------------------------------------------------------
-    INTEGER, INTENT(IN)   :: kts,kte    
-    INTEGER, INTENT(IN) :: levflag
-    REAL, INTENT(IN) :: delt
-    REAL, DIMENSION(kts:kte), INTENT(IN) :: dz, dfq,el
-    REAL, DIMENSION(kts:kte), INTENT(INOUT) :: pdk, pdt, pdq, pdc
-    REAL, INTENT(IN) ::  flt, flq, ust, pmz, phh
-    REAL, DIMENSION(kts:kte), INTENT(INOUT) :: qke,tsq, qsq, cov
+    integer, intent(in) :: kts,kte    
 
-    INTEGER :: k,nz
-    REAL, DIMENSION(kts:kte) :: qkw, bp, rp, df3q
-    REAL :: vkz,pdk1,phm,pdt1,pdq1,pdc1,b1l,b2l
-    REAL, DIMENSION(kts:kte) :: dtz
-    REAL, DIMENSION(1:kte-kts+1) :: a,b,c,d
+#ifdef HARDCODE_VERTICAL
+# define kts 1
+# define kte HARDCODE_VERTICAL
+#endif
 
-    nz=kte-kts+1
+    real(kind_phys), intent(in)    :: closure
+    integer, intent(in) :: bl_mynn_edmf_tke,tke_budget
+    real(kind_phys), dimension(kts:kte), intent(in) :: dz, dfq, el, rho
+    real(kind_phys), dimension(kts:kte), intent(inout) :: pdk, pdt, pdq, pdc
+    real(kind_phys), intent(in)    :: flt, flq, pmz, phh
+    real(kind_phys), intent(in)    :: ust, delt
+    real(kind_phys), dimension(kts:kte), intent(inout) :: qke,tsq, qsq, cov
+! WA 8/3/15
+    real(kind_phys), dimension(kts:kte+1), intent(inout) :: s_awqke,s_aw
+    
+    !!  TKE budget  (Puhales, 2020, WRF 4.2.1)  << EOB 
+    real(kind_phys), dimension(kts:kte), intent(out) :: qWT1, qDISS1
+    real(kind_phys), dimension(kts:kte) :: tke_up,dzinv  
+    !! >> EOB
+    
+    integer :: k
+    real(kind_phys), dimension(kts:kte) :: qkw, bp, rp, df3q
+    real(kind_phys):: vkz,pdk1,phm,pdt1,pdq1,pdc1,b1l,b2l,onoff
+    real(kind_phys), dimension(kts:kte) :: dtz
+    real(kind_phys), dimension(kts:kte) :: a,b,c,d,x
 
-!   **  Strictly, vkz*h(i,j) -> vk*( 0.5*dz(1)*h(i,j)+z0 )  **
-    vkz = vk*0.5*dz(kts)
+    real(kind_phys), dimension(kts:kte) :: rhoinv
+    real(kind_phys), dimension(kts:kte+1) :: rhoz,kqdz,kmdz
+
+    ! REGULATE THE MOMENTUM MIXING FROM THE MASS-FLUX SCHEME (on or off)
+    IF (bl_mynn_edmf_tke == 0) THEN
+       onoff=0.0
+    ELSE
+       onoff=1.0
+    ENDIF
+
+!   **  Strictly, vkz*h(i,j) -> karman*( 0.5*dz(1)*h(i,j)+z0 )  **
+    vkz = karman*0.5*dz(kts)
 !
-!  Modified: Dec/22/2005, from here
 !   **  dfq for the TKE is 3.0*dfm.  **
-!    CALL coefvu ( dfq, 3.0 ) ! make change here
-!  Modified: Dec/22/2005, up to here
 !
     DO k = kts,kte
 !!       qke(k) = MAX(qke(k), 0.0)
        qkw(k) = SQRT( MAX( qke(k), 0.0 ) )
-       !df3q(k)=3.*dfq(k)
        df3q(k)=Sqfac*dfq(k)
        dtz(k)=delt/dz(k)
     END DO
 !
+!JOE-add conservation + stability criteria
+    !Prepare "constants" for diffusion equation.
+    !khdz = rho*Kh/dz = rho*dfh
+    rhoz(kts)  =rho(kts)
+    rhoinv(kts)=1./rho(kts)
+    kqdz(kts)  =rhoz(kts)*df3q(kts)
+    kmdz(kts)  =rhoz(kts)*dfq(kts)
+    DO k=kts+1,kte
+       rhoz(k)  =(rho(k)*dz(k-1) + rho(k-1)*dz(k))/(dz(k-1)+dz(k))
+       rhoz(k)  =  MAX(rhoz(k),1E-4)
+       rhoinv(k)=1./MAX(rho(k),1E-4)
+       kqdz(k)  = rhoz(k)*df3q(k) ! for TKE
+       kmdz(k)  = rhoz(k)*dfq(k)  ! for T'2, q'2, and T'q'
+    ENDDO
+    rhoz(kte+1)=rhoz(kte)
+    kqdz(kte+1)=rhoz(kte+1)*df3q(kte)
+    kmdz(kte+1)=rhoz(kte+1)*dfq(kte)
+
+    !stability criteria for mf
+    DO k=kts+1,kte-1
+       kqdz(k) = MAX(kqdz(k),  0.5* s_aw(k))
+       kqdz(k) = MAX(kqdz(k), -0.5*(s_aw(k)-s_aw(k+1)))
+       kmdz(k) = MAX(kmdz(k),  0.5* s_aw(k))
+       kmdz(k) = MAX(kmdz(k), -0.5*(s_aw(k)-s_aw(k+1)))
+!       kqdz(k) = max(kqdz(k),  0.5*(s_aw(k)+sd_aw(k)))
+!       kqdz(k) = max(kqdz(k), -0.5*(s_aw(k)-s_aw(k+1)) -0.5*(sd_aw(k)-sd_aw(k+1)) )
+!       kmdz(k) = max(kmdz(k),  0.5*(s_aw(k)+sd_aw(k)))
+!       kmdz(k) = max(kmdz(k), -0.5*(s_aw(k)-s_aw(k+1)) -0.5*(sd_aw(k)-sd_aw(k+1)) )
+    ENDDO
+    !end conservation mods
+
     pdk1 = 2.0*ust**3*pmz/( vkz )
     phm  = 2.0/ust   *phh/( vkz )
     pdt1 = phm*flt**2
     pdq1 = phm*flq**2
     pdc1 = phm*flt*flq
 !
-!   **  pdk(i,j,1)+pdk(i,j,2) corresponds to pdk1.  **
-    pdk(kts) = pdk1 -pdk(kts+1)
+!   **  pdk(1)+pdk(2) corresponds to pdk1.  **
+    pdk(kts) = pdk1 - pdk(kts+1)
 
 !!    pdt(kts) = pdt1 -pdt(kts+1)
 !!    pdq(kts) = pdq1 -pdq(kts+1)
@@ -1414,9 +3090,9 @@ CONTAINS
     DO k = kts,kte-1
        b1l = b1*0.5*( el(k+1)+el(k) )
        bp(k) = 2.*qkw(k) / b1l
-       rp(k) = pdk(k+1) + pdk(k) 
+       rp(k) = pdk(k+1) + pdk(k)
     END DO
-    
+
 !!    a(1)=0.
 !!    b(1)=1.
 !!    c(1)=-1.
@@ -1424,10 +3100,26 @@ CONTAINS
 
 ! Since df3q(kts)=0.0, a(1)=0.0 and b(1)=1.+dtz(k)*df3q(k+1)+bp(k)*delt.
     DO k=kts,kte-1
-       a(k-kts+1)=-dtz(k)*df3q(k)
-       b(k-kts+1)=1.+dtz(k)*(df3q(k)+df3q(k+1))+bp(k)*delt
-       c(k-kts+1)=-dtz(k)*df3q(k+1)
-       d(k-kts+1)=rp(k)*delt + qke(k)
+!       a(k-kts+1)=-dtz(k)*df3q(k)
+!       b(k-kts+1)=1.+dtz(k)*(df3q(k)+df3q(k+1))+bp(k)*delt
+!       c(k-kts+1)=-dtz(k)*df3q(k+1)
+!       d(k-kts+1)=rp(k)*delt + qke(k)
+! WA 8/3/15 add EDMF contribution
+!       a(k)=   - dtz(k)*df3q(k) + 0.5*dtz(k)*s_aw(k)*onoff
+!       b(k)=1. + dtz(k)*(df3q(k)+df3q(k+1)) &
+!               + 0.5*dtz(k)*(s_aw(k)-s_aw(k+1))*onoff + bp(k)*delt
+!       c(k)=   - dtz(k)*df3q(k+1) - 0.5*dtz(k)*s_aw(k+1)*onoff
+!       d(k)=rp(k)*delt + qke(k) + dtz(k)*(s_awqke(k)-s_awqke(k+1))*onoff
+!JOE 8/22/20 improve conservation
+       a(k)=   - dtz(k)*kqdz(k)*rhoinv(k)                       &
+           &   + 0.5*dtz(k)*rhoinv(k)*s_aw(k)*onoff
+       b(k)=1. + dtz(k)*(kqdz(k)+kqdz(k+1))*rhoinv(k)           &
+           &   + 0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))*onoff &
+           &   + bp(k)*delt
+       c(k)=   - dtz(k)*kqdz(k+1)*rhoinv(k)                     &
+           &   - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*onoff
+       d(k)=rp(k)*delt + qke(k)                                 &
+           &   + dtz(k)*rhoinv(k)*(s_awqke(k)-s_awqke(k+1))*onoff
     ENDDO
 
 !!    DO k=kts+1,kte-1
@@ -1437,24 +3129,106 @@ CONTAINS
 !!       d(k-kts+1)=rp(k)*delt + qke(k) - qke(k)*bp(k)*delt
 !!    ENDDO
 
-    a(nz)=-1. !0.
-    b(nz)=1.
-    c(nz)=0.
-    d(nz)=0.
+!! "no flux at top"
+!    a(kte)=-1. !0.
+!    b(kte)=1.
+!    c(kte)=0.
+!    d(kte)=0.
+!! "prescribed value"
+    a(kte)=0.
+    b(kte)=1.
+    c(kte)=0.
+    d(kte)=qke(kte)
 
-    CALL tridiag(nz,a,b,c,d)
+!    CALL tridiag(kte,a,b,c,d)
+    CALL tridiag2(kte,a,b,c,d,x)
 
-    DO k=kts,kte   
-       qke(k)=d(k-kts+1)
+    DO k=kts,kte
+!       qke(k)=max(d(k-kts+1), qkemin)
+       qke(k)=max(x(k), qkemin)
+       qke(k)=min(qke(k), 150.)
     ENDDO
       
+   
+!!  TKE budget  (Puhales, 2020, WRF 4.2.1)  << EOB 
+    IF (tke_budget .eq. 1) THEN
+       !! TKE Vertical transport << EOBvt
+        tke_up=0.5*qke
+        dzinv=1./dz
+        k=kts
+        qWT1(k)=dzinv(k)*(                                     &
+            &  (kqdz(k+1)*(tke_up(k+1)-tke_up(k))-kqdz(k)*tke_up(k)) &
+            &  + 0.5*rhoinv(k)*(s_aw(k+1)*tke_up(k+1)          &
+            &  +      (s_aw(k+1)-s_aw(k))*tke_up(k)            &
+            &  +      (s_awqke(k)-s_awqke(k+1)))*onoff) !unstaggered
+        DO k=kts+1,kte-1
+            qWT1(k)=dzinv(k)*(                                 &
+            & (kqdz(k+1)*(tke_up(k+1)-tke_up(k))-kqdz(k)*(tke_up(k)-tke_up(k-1))) &
+            &  + 0.5*rhoinv(k)*(s_aw(k+1)*tke_up(k+1)          &
+            &  +      (s_aw(k+1)-s_aw(k))*tke_up(k)            &
+            &  -                  s_aw(k)*tke_up(k-1)          &
+            &  +      (s_awqke(k)-s_awqke(k+1)))*onoff) !unstaggered
+        ENDDO
+        k=kte
+        qWT1(k)=dzinv(k)*(-kqdz(k)*(tke_up(k)-tke_up(k-1)) &
+            &  + 0.5*rhoinv(k)*(-s_aw(k)*tke_up(k)-s_aw(k)*tke_up(k-1)+s_awqke(k))*onoff) !unstaggered
+        !!  >> EOBvt
+        qDISS1=bp*tke_up !! TKE dissipation rate !unstaggered
+    END IF
+!! >> EOB 
+   
+    IF ( closure > 2.5 ) THEN
 
-    IF ( levflag .EQ. 3 ) THEN
+       !   **  Prediction of the moisture variance  **
+       DO k = kts,kte-1
+          b2l   = b2*0.5*( el(k+1)+el(k) )
+          bp(k) = 2.*qkw(k) / b2l
+          rp(k) = pdq(k+1) + pdq(k)
+       END DO
+
+       !zero gradient for qsq at bottom and top
+       !a(1)=0.
+       !b(1)=1.
+       !c(1)=-1.
+       !d(1)=0.
+
+       ! Since dfq(kts)=0.0, a(1)=0.0 and b(1)=1.+dtz(k)*dfq(k+1)+bp(k)*delt.
+       DO k=kts,kte-1
+          a(k)=   - dtz(k)*kmdz(k)*rhoinv(k)
+          b(k)=1. + dtz(k)*(kmdz(k)+kmdz(k+1))*rhoinv(k) + bp(k)*delt
+          c(k)=   - dtz(k)*kmdz(k+1)*rhoinv(k)
+          d(k)=rp(k)*delt + qsq(k)
+       ENDDO
+
+       a(kte)=-1. !0.
+       b(kte)=1.
+       c(kte)=0.
+       d(kte)=0.
+
+!       CALL tridiag(kte,a,b,c,d)
+    CALL tridiag2(kte,a,b,c,d,x)
+       
+       DO k=kts,kte
+          !qsq(k)=d(k-kts+1)
+          qsq(k)=MAX(x(k),1e-17)
+       ENDDO
+    ELSE
+       !level 2.5 - use level 2 diagnostic
+       DO k = kts,kte-1
+          IF ( qkw(k) .LE. 0.0 ) THEN
+             b2l = 0.0
+          ELSE
+             b2l = b2*0.25*( el(k+1)+el(k) )/qkw(k)
+          END IF
+          qsq(k) = b2l*( pdq(k+1)+pdq(k) )
+       END DO
+       qsq(kte)=qsq(kte-1)
+    END IF
+!!!!!!!!!!!!!!!!!!!!!!end level 2.6   
+
+    IF ( closure .GE. 3.0 ) THEN
 !
-!  Modified: Dec/22/2005, from here
 !   **  dfq for the scalar variance is 1.0*dfm.  **
-!       CALL coefvu ( dfq, 1.0 ) make change here 
-!  Modified: Dec/22/2005, up to here
 !
 !   **  Prediction of the temperature variance  **
 !!       DO k = kts+1,kte-1
@@ -1473,10 +3247,15 @@ CONTAINS
 
 ! Since dfq(kts)=0.0, a(1)=0.0 and b(1)=1.+dtz(k)*dfq(k+1)+bp(k)*delt.
        DO k=kts,kte-1
-          a(k-kts+1)=-dtz(k)*dfq(k)
-          b(k-kts+1)=1.+dtz(k)*(dfq(k)+dfq(k+1))+bp(k)*delt
-          c(k-kts+1)=-dtz(k)*dfq(k+1)
-          d(k-kts+1)=rp(k)*delt + tsq(k)
+          !a(k-kts+1)=-dtz(k)*dfq(k)
+          !b(k-kts+1)=1.+dtz(k)*(dfq(k)+dfq(k+1))+bp(k)*delt
+          !c(k-kts+1)=-dtz(k)*dfq(k+1)
+          !d(k-kts+1)=rp(k)*delt + tsq(k)
+!JOE 8/22/20 improve conservation
+          a(k)=   - dtz(k)*kmdz(k)*rhoinv(k)
+          b(k)=1. + dtz(k)*(kmdz(k)+kmdz(k+1))*rhoinv(k) + bp(k)*delt
+          c(k)=   - dtz(k)*kmdz(k+1)*rhoinv(k)
+          d(k)=rp(k)*delt + tsq(k)
        ENDDO
 
 !!       DO k=kts+1,kte-1
@@ -1486,58 +3265,19 @@ CONTAINS
 !!          d(k-kts+1)=rp(k)*delt + tsq(k) - tsq(k)*bp(k)*delt
 !!       ENDDO
 
-       a(nz)=-1. !0.
-       b(nz)=1.
-       c(nz)=0.
-       d(nz)=0.
+       a(kte)=-1. !0.
+       b(kte)=1.
+       c(kte)=0.
+       d(kte)=0.
        
-       CALL tridiag(nz,a,b,c,d)
-       
+!       CALL tridiag(kte,a,b,c,d)
+       CALL tridiag2(kte,a,b,c,d,x)
+
        DO k=kts,kte
-          tsq(k)=d(k-kts+1)
-       ENDDO
-       
-!   **  Prediction of the moisture variance  **
-!!       DO k = kts+1,kte-1
-       DO k = kts,kte-1
-          b2l = b2*0.5*( el(k+1)+el(k) )
-          bp(k) = 2.*qkw(k) / b2l
-          rp(k) = pdq(k+1) +pdq(k) 
-       END DO
-       
-!zero gradient for qsq at bottom and top
-       
-!!       a(1)=0.
-!!       b(1)=1.
-!!       c(1)=-1.
-!!       d(1)=0.
-
-! Since dfq(kts)=0.0, a(1)=0.0 and b(1)=1.+dtz(k)*dfq(k+1)+bp(k)*delt.
-       DO k=kts,kte-1
-          a(k-kts+1)=-dtz(k)*dfq(k)
-          b(k-kts+1)=1.+dtz(k)*(dfq(k)+dfq(k+1))+bp(k)*delt
-          c(k-kts+1)=-dtz(k)*dfq(k+1)
-          d(k-kts+1)=rp(k)*delt + qsq(k)
+!          tsq(k)=d(k-kts+1)
+           tsq(k)=x(k)
        ENDDO
 
-!!       DO k=kts+1,kte-1
-!!          a(k-kts+1)=-dtz(k)*dfq(k)
-!!          b(k-kts+1)=1.+dtz(k)*(dfq(k)+dfq(k+1))
-!!          c(k-kts+1)=-dtz(k)*dfq(k+1)
-!!          d(k-kts+1)=rp(k)*delt + qsq(k) -qsq(k)*bp(k)*delt
-!!       ENDDO
-
-       a(nz)=-1. !0.
-       b(nz)=1.
-       c(nz)=0.
-       d(nz)=0.
-       
-       CALL tridiag(nz,a,b,c,d)
-       
-       DO k=kts,kte
-          qsq(k)=d(k-kts+1)
-       ENDDO
-       
 !   **  Prediction of the temperature-moisture covariance  **
 !!       DO k = kts+1,kte-1
        DO k = kts,kte-1
@@ -1555,10 +3295,15 @@ CONTAINS
 
 ! Since dfq(kts)=0.0, a(1)=0.0 and b(1)=1.+dtz(k)*dfq(k+1)+bp(k)*delt.
        DO k=kts,kte-1
-          a(k-kts+1)=-dtz(k)*dfq(k)
-          b(k-kts+1)=1.+dtz(k)*(dfq(k)+dfq(k+1))+bp(k)*delt
-          c(k-kts+1)=-dtz(k)*dfq(k+1)
-          d(k-kts+1)=rp(k)*delt + cov(k)
+          !a(k-kts+1)=-dtz(k)*dfq(k)
+          !b(k-kts+1)=1.+dtz(k)*(dfq(k)+dfq(k+1))+bp(k)*delt
+          !c(k-kts+1)=-dtz(k)*dfq(k+1)
+          !d(k-kts+1)=rp(k)*delt + cov(k)
+!JOE 8/22/20 improve conservation
+          a(k)=   - dtz(k)*kmdz(k)*rhoinv(k)
+          b(k)=1. + dtz(k)*(kmdz(k)+kmdz(k+1))*rhoinv(k) + bp(k)*delt
+          c(k)=   - dtz(k)*kmdz(k+1)*rhoinv(k)
+          d(k)=rp(k)*delt + cov(k)
        ENDDO
 
 !!       DO k=kts+1,kte-1
@@ -1568,19 +3313,22 @@ CONTAINS
 !!          d(k-kts+1)=rp(k)*delt + cov(k) - cov(k)*bp(k)*delt
 !!       ENDDO
 
-       a(nz)=-1. !0.
-       b(nz)=1.
-       c(nz)=0.
-       d(nz)=0.
-       
-       CALL tridiag(nz,a,b,c,d)
+       a(kte)=-1. !0.
+       b(kte)=1.
+       c(kte)=0.
+       d(kte)=0.
+
+!       CALL tridiag(kte,a,b,c,d)
+    CALL tridiag2(kte,a,b,c,d,x)
        
        DO k=kts,kte
-          cov(k)=d(k-kts+1)
+!          cov(k)=d(k-kts+1)
+          cov(k)=x(k)
        ENDDO
        
     ELSE
-!!       DO k = kts+1,kte-1
+
+       !Not level 3 - default to level 2 diagnostic
        DO k = kts,kte-1
           IF ( qkw(k) .LE. 0.0 ) THEN
              b2l = 0.0
@@ -1589,19 +3337,18 @@ CONTAINS
           END IF
 !
           tsq(k) = b2l*( pdt(k+1)+pdt(k) )
-          qsq(k) = b2l*( pdq(k+1)+pdq(k) )
           cov(k) = b2l*( pdc(k+1)+pdc(k) )
        END DO
        
-!!       tsq(kts)=tsq(kts+1)
-!!       qsq(kts)=qsq(kts+1)
-!!       cov(kts)=cov(kts+1)
-
        tsq(kte)=tsq(kte-1)
-       qsq(kte)=qsq(kte-1)
        cov(kte)=cov(kte-1)
       
     END IF
+
+#ifdef HARDCODE_VERTICAL
+# undef kts
+# undef kte
+#endif
 
   END SUBROUTINE mym_predict
   
@@ -1617,60 +3364,119 @@ CONTAINS
 !                         virtual potential temperature minus tref.
 !
 !     Output variables:   see subroutine mym_initialize
-!       cld(mx,my,nz)   : Cloud fraction
+!       cld(nx,nz,ny)   : Cloud fraction
 !
-!     Work arrays:
-!       qmq(mx,my,nz)   : Q_w-Q_{sl}, where Q_{sl} is the saturation
+!     Work arrays/variables:
+!       qmq             : Q_w-Q_{sl}, where Q_{sl} is the saturation
 !                         specific humidity at T=Tl
-!       alp(mx,my,nz)   : Functions in the condensation process
-!       bet(mx,my,nz)   : ditto
-!       sgm(mx,my,nz)   : Combined standard deviation sigma_s
+!       alp(nx,nz,ny)   : Functions in the condensation process
+!       bet(nx,nz,ny)   : ditto
+!       sgm(nx,nz,ny)   : Combined standard deviation sigma_s
 !                         multiplied by 2/alp
 !
 !     # qmq, alp, bet and sgm are allowed to share storage units with
 !       any four of other work arrays for saving memory.
 !
-!     # Results are sensitive particularly to values of cp and rd.
+!     # Results are sensitive particularly to values of cp and r_d.
 !       Set these values to those adopted by you.
 !
 !-------------------------------------------------------------------
-  SUBROUTINE  mym_condensation (kts,kte, &
-    &            dz, &
-    &            thl, qw, &
-    &            p,exner, &
-    &            tsq, qsq, cov, &
-    &            Sh, el, bl_mynn_cloudpdf,&  !JOE - cloud PDF testing
-    &            Vt, Vq)
+!>\ingroup gsd_mynn_edmf 
+!! This subroutine calculates the nonconvective component of the 
+!! subgrid cloud fraction and mixing ratio as well as the functions used to 
+!! calculate the buoyancy flux. Different cloud PDFs can be selected by
+!! use of the namelist parameter \p bl_mynn_cloudpdf .
+  SUBROUTINE  mym_condensation (kts,kte,   &
+    &            dx, dz, zw, xland,        &
+    &            thl, qw, qv, qc, qi, qs,  &
+    &            p,exner,                  &
+    &            tsq, qsq, cov,            &
+    &            Sh, el, bl_mynn_cloudpdf, &
+    &            qc_bl1, qi_bl1,           &
+    &            cldfra_bl1,               &
+    &            PBLH1,HFX1,               &
+    &            Vt, Vq, th, sgm,          &
+    &            spp_pbl,pattern_spp_pbl1  )
 
 !-------------------------------------------------------------------
-    INTEGER, INTENT(IN)   :: kts,kte, bl_mynn_cloudpdf
 
-    REAL, DIMENSION(kts:kte), INTENT(IN) :: dz
-    REAL, DIMENSION(kts:kte), INTENT(IN) :: p,exner, thl, qw, &
-         &tsq, qsq, cov
+    integer, intent(in)   :: kts,kte, bl_mynn_cloudpdf
 
-    REAL, DIMENSION(kts:kte), INTENT(OUT) :: vt,vq
+#ifdef HARDCODE_VERTICAL
+# define kts 1
+# define kte HARDCODE_VERTICAL
+#endif
 
-    REAL, DIMENSION(kts:kte) :: qmq,alp,bet,sgm,ql,cld
+    real(kind_phys), intent(in)      :: HFX1,xland
+    real(kind_phys), intent(in)      :: dx,pblh1
+    real(kind_phys), dimension(kts:kte), intent(in) :: dz
+    real(kind_phys), dimension(kts:kte+1), intent(in) :: zw
+    real(kind_phys), dimension(kts:kte), intent(in) :: p,exner,thl,qw,   &
+         &qv,qc,qi,qs,tsq,qsq,cov,th
 
+    real(kind_phys), dimension(kts:kte), intent(inout) :: vt,vq,sgm
+
+    real(kind_phys), dimension(kts:kte) :: alp,a,bet,b,ql,q1,RH
+    real(kind_phys), dimension(kts:kte), intent(out) :: qc_bl1,qi_bl1, &
+         &cldfra_bl1
     DOUBLE PRECISION :: t3sq, r3sq, c3sq
-!
 
-    REAL :: p2a,t,esl,qsl,dqsl,q1,cld0,eq1,qll,&
-         &q2p,pt,rac,qt
-    INTEGER :: i,j,k
+    real(kind_phys):: qsl,esat,qsat,dqsl,cld0,q1k,qlk,eq1,qll,           &
+         &q2p,pt,rac,qt,t,xl,rsl,cpm,Fng,qww,alpha,beta,bb,              &
+         &ls,wt,wt2,qpct,cld_factor,fac_damp,liq_frac,ql_ice,ql_water,   &
+         &qmq,qsat_tk,q1_rh,rh_hack,dzm1,zsl,maxqc
+    real(kind_phys), parameter :: qpct_sfc=0.025
+    real(kind_phys), parameter :: qpct_pbl=0.030
+    real(kind_phys), parameter :: qpct_trp=0.040
+    real(kind_phys), parameter :: rhcrit  =0.83 !for cloudpdf = 2
+    real(kind_phys), parameter :: rhmax   =1.02 !for cloudpdf = 2
+    integer :: i,j,k
 
-    REAL :: erf
+    real(kind_phys):: erf
 
-    !JOE: NEW VARIABLES FOR ALTERNATE SIGMA
-    REAL::dth,dqw,dzk
-    REAL, DIMENSION(kts:kte), INTENT(IN) :: Sh,el
+    !VARIABLES FOR ALTERNATIVE SIGMA
+    real:: dth,dtl,dqw,dzk,els
+    real(kind_phys), dimension(kts:kte), intent(in) :: Sh,el
 
-! Note: kte needs to be larger than kts, i.e., kte >= kts+1.
+    !variables for SGS BL clouds
+    real(kind_phys)           :: zagl,damp,PBLH2
+    real(kind_phys)           :: cfmax
 
-    DO k = kts,kte-1
-       p2a = exner(k)
-       t  = thl(k)*p2a 
+    !JAYMES:  variables for tropopause-height estimation
+    real(kind_phys)           :: theta1, theta2, ht1, ht2
+    integer                   :: k_tropo
+
+!   Stochastic
+    integer,  intent(in)      :: spp_pbl
+    real(kind_phys), dimension(kts:kte) :: pattern_spp_pbl1
+    real(kind_phys)           :: qw_pert
+
+! First, obtain an estimate for the tropopause height (k), using the method employed in the
+! Thompson subgrid-cloud scheme.  This height will be a consideration later when determining 
+! the "final" subgrid-cloud properties.
+! JAYMES:  added 3 Nov 2016, adapted from G. Thompson
+
+    DO k = kte-3, kts, -1
+       theta1 = th(k)
+       theta2 = th(k+2)
+       ht1 = 44307.692 * (1.0 - (p(k)/101325.)**0.190)
+       ht2 = 44307.692 * (1.0 - (p(k+2)/101325.)**0.190)
+       if ( (((theta2-theta1)/(ht2-ht1)) .lt. 10./1500. ) .AND.       &
+     &                       (ht1.lt.19000.) .and. (ht1.gt.4000.) ) then 
+          goto 86
+       endif
+    ENDDO
+ 86   continue
+    k_tropo = MAX(kts+2, k+2)
+
+    zagl = 0.
+
+    SELECT CASE(bl_mynn_cloudpdf)
+
+      CASE (0) ! ORIGINAL MYNN PARTIAL-CONDENSATION SCHEME
+
+        DO k = kts,kte-1
+           t  = th(k)*exner(k)
 
 !x      if ( ct .gt. 0.0 ) then
 !       a  =  17.27
@@ -1681,197 +3487,543 @@ CONTAINS
 !x      end if
 !
 !   **  3.8 = 0.622*6.11 (hPa)  **
-       !SATURATED VAPOR PRESSURE
-       esl=svp11*EXP(svp2*(t-svpt0)/(t-svp3))
-       !SATURATED SPECIFIC HUMIDITY
-       qsl=ep_2*esl/(p(k)-ep_3*esl)
-       !dqw/dT: Clausius-Clapeyron
-       dqsl = qsl*ep_2*ev/( rd*t**2 )
-       !DEFICIT/EXCESS WATER CONTENT
-       qmq(k) = qw(k) -qsl
 
-       alp(k) = 1.0/( 1.0+dqsl*xlvcp )
-       bet(k) = dqsl*p2a
-!
-       t3sq = MAX( tsq(k), 0.0 )
-       r3sq = MAX( qsq(k), 0.0 )
-       c3sq =      cov(k)
-       c3sq = SIGN( MIN( ABS(c3sq), SQRT(t3sq*r3sq) ), c3sq )
-!
-       r3sq = r3sq +bet(k)**2*t3sq -2.0*bet(k)*c3sq
-       IF (bl_mynn_cloudpdf == 0) THEN
-          !ORIGINAL STANDARD DEVIATION: limit e-6 produces ~10% more BL clouds than e-10
-          sgm(k) = SQRT( MAX( r3sq, 1.0d-10 ))
-       ELSE
-          !ALTERNATIVE FORM (Nakanishi & Niino 2004 BLM, eq. B6, and 
-          ! Kuwano-Yoshida et al. 2010 QJRMS, eq. 7):
-          if (k .eq. kts) then 
+           !SATURATED VAPOR PRESSURE
+           esat = esat_blend(t)
+           !SATURATED SPECIFIC HUMIDITY
+           !qsl=ep_2*esat/(p(k)-ep_3*esat)
+           qsl=ep_2*esat/max(1.e-4,(p(k)-ep_3*esat))
+           !dqw/dT: Clausius-Clapeyron
+           dqsl = qsl*ep_2*xlv/( r_d*t**2 )
+
+           alp(k) = 1.0/( 1.0+dqsl*xlvcp )
+           bet(k) = dqsl*exner(k)
+
+           !Sommeria and Deardorff (1977) scheme, as implemented
+           !in Nakanishi and Niino (2009), Appendix B
+           t3sq = MAX( tsq(k), 0.0 )
+           r3sq = MAX( qsq(k), 0.0 )
+           c3sq =      cov(k)
+           c3sq = SIGN( MIN( ABS(c3sq), SQRT(t3sq*r3sq) ), c3sq )
+           r3sq = r3sq +bet(k)**2*t3sq -2.0*bet(k)*c3sq
+           !DEFICIT/EXCESS WATER CONTENT
+           qmq  = qw(k) -qsl
+           !ORIGINAL STANDARD DEVIATION
+           sgm(k) = SQRT( MAX( r3sq, 1.0d-10 ))
+           !NORMALIZED DEPARTURE FROM SATURATION
+           q1(k)   = qmq / sgm(k)
+           !CLOUD FRACTION. rr2 = 1/SQRT(2) = 0.707
+           cldfra_bl1(k) = 0.5*( 1.0+erf( q1(k)*rr2 ) )
+
+           q1k  = q1(k)
+           eq1  = rrp*EXP( -0.5*q1k*q1k )
+           qll  = MAX( cldfra_bl1(k)*q1k + eq1, 0.0 )
+           !ESTIMATED LIQUID WATER CONTENT (UNNORMALIZED)
+           ql(k) = alp(k)*sgm(k)*qll
+           !LIMIT SPECIES TO TEMPERATURE RANGES
+           liq_frac = min(1.0, max(0.0,(t-240.0)/29.0))
+           qc_bl1(k) = liq_frac*ql(k)
+           qi_bl1(k) = (1.0 - liq_frac)*ql(k)
+
+           !Now estimate the buoyancy flux functions
+           q2p = xlvcp/exner(k)
+           pt = thl(k) +q2p*ql(k) ! potential temp
+
+           !qt is a THETA-V CONVERSION FOR TOTAL WATER (i.e., THETA-V = qt*THETA)
+           qt   = 1.0 +p608*qw(k) -(1.+p608)*(qc_bl1(k)+qi_bl1(k))*cldfra_bl1(k)
+           rac  = alp(k)*( cldfra_bl1(K)-qll*eq1 )*( q2p*qt-(1.+p608)*pt )
+
+           !BUOYANCY FACTORS: wherever vt and vq are used, there is a
+           !"+1" and "+tv0", respectively, so these are subtracted out here.
+           !vt is unitless and vq has units of K.
+           vt(k) =      qt-1.0 -rac*bet(k)
+           vq(k) = p608*pt-tv0 +rac
+
+        END DO
+
+      CASE (1, -1) !ALTERNATIVE FORM (Nakanishi & Niino 2004 BLM, eq. B6, and
+                       !Kuwano-Yoshida et al. 2010 QJRMS, eq. 7):
+        DO k = kts,kte-1
+           t  = th(k)*exner(k)
+           !SATURATED VAPOR PRESSURE
+           esat = esat_blend(t)
+           !SATURATED SPECIFIC HUMIDITY
+           !qsl=ep_2*esat/(p(k)-ep_3*esat)
+           qsl=ep_2*esat/max(1.e-4,(p(k)-ep_3*esat))
+           !dqw/dT: Clausius-Clapeyron
+           dqsl = qsl*ep_2*xlv/( r_d*t**2 )
+
+           alp(k) = 1.0/( 1.0+dqsl*xlvcp )
+           bet(k) = dqsl*exner(k)
+
+           if (k .eq. kts) then 
              dzk = 0.5*dz(k)
-          else
-             dzk = 0.5*( dz(k) + dz(k-1) )
-          end if
-          dth = 0.5*(thl(k+1)+thl(k)) - 0.5*(thl(k)+thl(MAX(k-1,kts)))
-          dqw = 0.5*(qw(k+1) + qw(k)) - 0.5*(qw(k) + qw(MAX(k-1,kts)))
-          sgm(k) = SQRT( MAX( (alp(k)**2 * MAX(el(k)**2,1.) * &
+           else
+             dzk = dz(k)
+           end if
+           dth = 0.5*(thl(k+1)+thl(k)) - 0.5*(thl(k)+thl(MAX(k-1,kts)))
+           dqw = 0.5*(qw(k+1) + qw(k)) - 0.5*(qw(k) + qw(MAX(k-1,kts)))
+           sgm(k) = SQRT( MAX( (alp(k)**2 * MAX(el(k)**2,0.1) * &
                              b2 * MAX(Sh(k),0.03))/4. * &
                       (dqw/dzk - bet(k)*(dth/dzk ))**2 , 1.0e-10) )
-       ENDIF
-    END DO
+           qmq   = qw(k) -qsl
+           q1(k) = qmq / sgm(k)
+           cldfra_bl1(K) = 0.5*( 1.0+erf( q1(k)*rr2 ) )
+
+           !now compute estimated lwc for PBL scheme's use 
+           !qll IS THE NORMALIZED LIQUID WATER CONTENT (Sommeria and
+           !Deardorff (1977, eq 29a). rrp = 1/(sqrt(2*pi)) = 0.3989
+           q1k  = q1(k)
+           eq1  = rrp*EXP( -0.5*q1k*q1k )
+           qll  = MAX( cldfra_bl1(K)*q1k + eq1, 0.0 )
+           !ESTIMATED LIQUID WATER CONTENT (UNNORMALIZED)
+           ql (k) = alp(k)*sgm(k)*qll
+           liq_frac = min(1.0, max(0.0,(t-240.0)/29.0))
+           qc_bl1(k) = liq_frac*ql(k)
+           qi_bl1(k) = (1.0 - liq_frac)*ql(k)
+
+           !Now estimate the buoyancy flux functions
+           q2p = xlvcp/exner(k)
+           pt = thl(k) +q2p*ql(k) ! potential temp
+
+           !qt is a THETA-V CONVERSION FOR TOTAL WATER (i.e., THETA-V = qt*THETA)
+           qt   = 1.0 +p608*qw(k) -(1.+p608)*(qc_bl1(k)+qi_bl1(k))*cldfra_bl1(k)
+           rac  = alp(k)*( cldfra_bl1(K)-qll*eq1 )*( q2p*qt-(1.+p608)*pt )
+
+           !BUOYANCY FACTORS: wherever vt and vq are used, there is a
+           !"+1" and "+tv0", respectively, so these are subtracted out here.
+           !vt is unitless and vq has units of K.
+           vt(k) =      qt-1.0 -rac*bet(k)
+           vq(k) = p608*pt-tv0 +rac
+
+        END DO
+
+      CASE (2, -2)
+
+        !Diagnostic statistical scheme of Chaboureau and Bechtold (2002), JAS
+        !but with use of higher-order moments to estimate sigma
+        pblh2=MAX(10._kind_phys,pblh1)
+        zagl = 0.
+        dzm1 = 0.
+        DO k = kts,kte-1
+           zagl   = zagl + 0.5*(dz(k) + dzm1)
+           dzm1   = dz(k)
+
+           t      = th(k)*exner(k)
+           xl     = xl_blend(t)              ! obtain latent heat
+           qsat_tk= qsat_blend(t,  p(k))     ! saturation water vapor mixing ratio at tk and p
+           rh(k)  = MAX(MIN(rhmax, qw(k)/MAX(1.E-10,qsat_tk)),0.001_kind_phys)
+
+           !dqw/dT: Clausius-Clapeyron
+           dqsl   = qsat_tk*ep_2*xlv/( r_d*t**2 )
+           alp(k) = 1.0/( 1.0+dqsl*xlvcp )
+           bet(k) = dqsl*exner(k)
+ 
+           rsl    = xl*qsat_tk / (r_v*t**2)  ! slope of C-C curve at t (=abs temperature)
+                                             ! CB02, Eqn. 4
+           cpm    = cp + qw(k)*cpv           ! CB02, sec. 2, para. 1
+           a(k)   = 1./(1. + xl*rsl/cpm)     ! CB02 variable "a"
+           b(k)   = a(k)*rsl                 ! CB02 variable "b"
+
+           !SPP
+           qw_pert= qw(k) + qw(k)*0.5*pattern_spp_pbl1(k)*real(spp_pbl)
+
+           !This form of qmq (the numerator of Q1) no longer uses the a(k) factor
+           qmq    = qw_pert - qsat_tk          ! saturation deficit/excess;
+
+           !Use the form of Eq. (6) in Chaboureau and Bechtold (2002)
+           !except neglect all but the first term for sig_r
+           r3sq   = max( qsq(k), 0.0 )
+           !Calculate sigma using higher-order moments:
+           sgm(k) = SQRT( r3sq )
+           !Set constraints on sigma relative to saturation water vapor
+           sgm(k) = min( sgm(k), qsat_tk*0.666 )
+           !sgm(k) = max( sgm(k), qsat_tk*0.035 )
+
+           !introduce vertical grid spacing dependence on min sgm
+           wt     = max(500. - max(dz(k)-100.,0.0), 0.0_kind_phys)/500. !=1 for dz < 100 m, =0 for dz > 600 m
+           sgm(k) = sgm(k) + sgm(k)*0.2*(1.0-wt) !inflate sgm for coarse dz
+
+           !allow min sgm to vary with dz and z.
+           qpct   = qpct_pbl*wt + qpct_trp*(1.0-wt)
+           qpct   = min(qpct, max(qpct_sfc, qpct_pbl*zagl/500.) )
+           sgm(k) = max( sgm(k), qsat_tk*qpct )
+
+           q1(k)  = qmq  / sgm(k)  ! Q1, the normalized saturation
+
+           !Add condition for falling/settling into low-RH layers, so at least
+           !some cloud fraction is applied for all qc, qs, and qi.
+           rh_hack= rh(k)
+           wt2    = min(max( zagl - pblh2, 0.0 )/300., 1.0)
+           !ensure adequate RH & q1 when qi is at least 1e-9 (above the PBLH)
+           if ((qi(k)+qs(k))>1.e-9 .and. (zagl .gt. pblh2)) then
+              rh_hack =min(rhmax, rhcrit + wt2*0.045*(9.0 + log10(qi(k)+qs(k))))
+              rh(k)   =max(rh(k), rh_hack)
+              !add rh-based q1
+              q1_rh   =-3. + 3.*(rh(k)-rhcrit)/(1.-rhcrit)
+              q1(k)   =max(q1_rh, q1(k) )
+           endif
+           !ensure adequate rh & q1 when qc is at least 1e-6 (above the PBLH)
+           if (qc(k)>1.e-6 .and. (zagl .gt. pblh2)) then
+              rh_hack =min(rhmax, rhcrit + wt2*0.08*(6.0 + log10(qc(k))))
+              rh(k)   =max(rh(k), rh_hack)
+              !add rh-based q1
+              q1_rh   =-3. + 3.*(rh(k)-rhcrit)/(1.-rhcrit)
+              q1(k)   =max(q1_rh, q1(k) )
+           endif
+
+           q1k   = q1(k)          ! backup Q1 for later modification
+
+           ! Specify cloud fraction
+           !Original C-B cloud fraction, allows cloud fractions out to q1 = -3.5
+           !cldfra_bl1(K) = max(0., min(1., 0.5+0.36*atan(1.55*q1(k)))) ! Eq. 7 in CB02
+           !Waynes LES fit  - over-diffuse, when limits removed from vt & vq & fng
+           !cldfra_bl1(K) = max(0., min(1., 0.5+0.36*atan(1.2*(q1(k)+0.4))))
+           !Best compromise: Improves marine stratus without adding much cold bias.
+           cldfra_bl1(k) = max(0., min(1., 0.5+0.36*atan(1.8*(q1(k)+0.2))))
+
+           ! Specify hydrometeors
+           ! JAYMES- this option added 8 May 2015
+           ! The cloud water formulations are taken from CB02, Eq. 8.
+           maxqc = max(qw(k) - qsat_tk, 0.0)
+           if (q1k < 0.) then        !unsaturated
+              ql_water = sgm(k)*exp(1.2*q1k-1.)
+              ql_ice   = sgm(k)*exp(1.2*q1k-1.)
+           elseif (q1k > 2.) then    !supersaturated
+              ql_water = min(sgm(k)*q1k, maxqc)
+              ql_ice   =     sgm(k)*q1k
+           else                      !slightly saturated (0 > q1 < 2)
+              ql_water = min(sgm(k)*(exp(-1.) + 0.66*q1k + 0.086*q1k**2), maxqc)
+              ql_ice   =     sgm(k)*(exp(-1.) + 0.66*q1k + 0.086*q1k**2)
+           endif
+
+           !In saturated grid cells, use average of SGS and resolved values
+           !if ( qc(k) > 1.e-6 ) ql_water = 0.5 * ( ql_water + qc(k) ) 
+           !ql_ice is actually the total frozen condensate (snow+ice),
+           !if ( (qi(k)+qs(k)) > 1.e-9 ) ql_ice = 0.5 * ( ql_ice + (qi(k)+qs(k)) )
+
+           if (cldfra_bl1(k) < 0.001) then
+              ql_ice   = 0.0
+              ql_water = 0.0
+              cldfra_bl1(k) = 0.0
+           endif
+
+           liq_frac = MIN(1.0, MAX(0.0, (t-tice)/(tliq-tice)))
+           qc_bl1(k) = liq_frac*ql_water       ! apply liq_frac to ql_water and ql_ice
+           qi_bl1(k) = (1.0-liq_frac)*ql_ice
+
+           !Above tropopause:  eliminate subgrid clouds from CB scheme. Note that this was
+           !"k_tropo - 1" as of 20 Feb 2023. Changed to allow more high-level clouds.
+           if (k .ge. k_tropo) then
+              cldfra_bl1(K) = 0.
+              qc_bl1(k)     = 0.
+              qi_bl1(k)     = 0.
+           endif
+
+           !Buoyancy-flux-related calculations follow...
+           !limiting Q1 to avoid too much diffusion in cloud layers
+           !q1k=max(Q1(k),-2.0)
+           if ((xland-1.5).GE.0) then   ! water
+              q1k=max(Q1(k),-2.5)
+           else                         ! land
+              q1k=max(Q1(k),-2.0)
+           endif
+           ! "Fng" represents the non-Gaussian transport factor
+           ! (non-dimensional) from Bechtold et al. 1995 
+           ! (hereafter BCMT95), section 3(c).  Their suggested 
+           ! forms for Fng (from their Eq. 20) are:
+           !IF (q1k < -2.) THEN
+           !  Fng = 2.-q1k
+           !ELSE IF (q1k > 0.) THEN
+           !  Fng = 1.
+           !ELSE
+           !  Fng = 1.-1.5*q1k
+           !ENDIF
+           ! Use the form of "Fng" from Bechtold and Siebesma (1998, JAS)
+           if (q1k .ge. 1.0) then
+              Fng = 1.0
+           elseif (q1k .ge. -1.7 .and. q1k .lt. 1.0) then
+              Fng = exp(-0.4*(q1k-1.0))
+           elseif (q1k .ge. -2.5 .and. q1k .lt. -1.7) then
+              Fng = 3.0 + exp(-3.8*(q1k+1.7))
+           else
+              Fng = min(23.9 + exp(-1.6*(q1k+2.5)), 60._kind_phys)
+           endif
+
+           cfmax = min(cldfra_bl1(k), 0.6_kind_phys)
+           !Further limit the cf going into vt & vq near the surface
+           zsl   = min(max(25., 0.1*pblh2), 100.)
+           wt    = min(zagl/zsl, 1.0) !=0 at z=0 m, =1 above ekman layer
+           cfmax = cfmax*wt
+
+           bb = b(k)*t/th(k) ! bb is "b" in BCMT95.  Their "b" differs from
+                             ! "b" in CB02 (i.e., b(k) above) by a factor
+                             ! of T/theta.  Strictly, b(k) above is formulated in
+                             ! terms of sat. mixing ratio, but bb in BCMT95 is
+                             ! cast in terms of sat. specific humidity.  The
+                             ! conversion is neglected here.
+           qww   = 1.+0.61*qw(k)
+           alpha = 0.61*th(k)
+           beta  = (th(k)/t)*(xl/cp) - 1.61*th(k)
+           vt(k) = qww   - cfmax*beta*bb*Fng   - 1.
+           vq(k) = alpha + cfmax*beta*a(k)*Fng - tv0
+           ! vt and vq correspond to beta-theta and beta-q, respectively,  
+           ! in NN09, Eq. B8.  They also correspond to the bracketed
+           ! expressions in BCMT95, Eq. 15, since (s*ql/sigma^2) = cldfra*Fng
+           ! The "-1" and "-tv0" terms are included for consistency with 
+           ! the legacy vt and vq formulations (above).
+
+           ! dampen amplification factor where need be
+           fac_damp = min(zagl * 0.0025, 1.0)
+           !cld_factor = 1.0 + fac_damp*MAX(0.0, ( RH(k) - 0.75 ) / 0.26 )**1.9 !HRRRv4
+           !cld_factor = 1.0 + fac_damp*min((max(0.0, ( RH(k) - 0.92 )) / 0.25 )**2, 0.3)
+           cld_factor = 1.0 + fac_damp*min((max(0.0, ( RH(k) - 0.92 )) / 0.145)**2, 0.37)
+           cldfra_bl1(K) = min( 1., cld_factor*cldfra_bl1(K) )
+        enddo
+
+      END SELECT !end cloudPDF option
+
+      !For testing purposes only, option for isolating on the mass-flux clouds.
+      IF (bl_mynn_cloudpdf .LT. 0) THEN
+         DO k = kts,kte-1
+            cldfra_bl1(k) = 0.0
+            qc_bl1(k) = 0.0
+            qi_bl1(k) = 0.0
+         END DO
+      ENDIF
 !
-    DO k = kts,kte-1
-       !NORMALIZED DEPARTURE FROM SATURATION
-       q1   = qmq(k) / sgm(k)
-       !CLOUD FRACTION. rr2 = 1/SQRT(2) = 0.707
-       cld(k) = 0.5*( 1.0+erf( q1*rr2 ) )
-!       IF (cld(k) < 0. .OR. cld(k) > 1.) THEN
-!          PRINT*,"MYM_CONDENSATION, k=",k," cld=",cld(k)
-!          PRINT*," r3sq=",r3sq," t3sq=",t3sq," c3sq=",c3sq
-!       ENDIF
-!       q1=0.
-!       cld(k)=0.
-
-       !qll IS THE NORMALIZED LIQUID WATER CONTENT (Sommeria and
-       !Deardorff (1977, eq 29a). rrp = 1/(sqrt(2*pi)) = 0.3989
-       eq1  = rrp*EXP( -0.5*q1*q1 )
-       qll  = MAX( cld(k)*q1 + eq1, 0.0 )
-       !ESTIMATED LIQUID WATER CONTENT (UNNORMALIZED)
-       ql (k) = alp(k)*sgm(k)*qll
-!
-       q2p  = xlvcp/exner(k) 
-       !POTENTIAL TEMPERATURE
-       pt   = thl(k) +q2p*ql(k)
-       !qt is a THETA-V CONVERSION FOR TOTAL WATER (i.e., THETA-V = qt*THETA)
-       qt   = 1.0 +p608*qw(k) -(1.+p608)*ql(k)
-       rac  = alp(k)*( cld(k)-qll*eq1 )*( q2p*qt-(1.+p608)*pt )
-
-       !BUOYANCY FACTORS: wherever vt and vq are used, there is a
-       !"+1" and "+tv0", respectively, so these are subtracted out here.
-       !vt is unitless and vq has units of K.
-       vt (k) =      qt-1.0 -rac*bet(k)
-       vq (k) = p608*pt-tv0 +rac
-    END DO
-!
-
-    cld(kte) = cld(kte-1)
-    ql(kte) = ql(kte-1)
-    vt(kte) = vt(kte-1)
-    vq(kte) = vq(kte-1)
-
+      ql(kte) = ql(kte-1)
+      vt(kte) = vt(kte-1)
+      vq(kte) = vq(kte-1)
+      qc_bl1(kte)=0.
+      qi_bl1(kte)=0.
+      cldfra_bl1(kte)=0.
     RETURN
+
+#ifdef HARDCODE_VERTICAL
+# undef kts
+# undef kte
+#endif
 
   END SUBROUTINE mym_condensation
 
 ! ==================================================================
-  SUBROUTINE mynn_tendencies(kts,kte,&
-       &levflag,grav_settling,&
-       &delt,&
-       &dz,&
-       &u,v,th,qv,qc,qi,qni,& !qnc,&
-       &p,exner,&
-       &thl,sqv,sqc,sqi,sqw,&
-       &ust,flt,flq,flqv,flqc,wspd,qcg,&
-       &uoce,voce,&
-       &tsq,qsq,cov,&
-       &tcd,qcd,&
-       &dfm,dfh,dfq,&
-       &Du,Dv,Dth,Dqv,Dqc,Dqi,Dqni&!,Dqnc&
-       &,vdfg1&               !Katata/JOE-fogdes
-       &,FLAG_QI,FLAG_QNI,FLAG_QC,FLAG_QNC &
-       &)
+!>\ingroup gsd_mynn_edmf
+!! This subroutine solves for tendencies of U, V, \f$\theta\f$, qv,
+!! qc, and qi
+  SUBROUTINE mynn_tendencies(kts,kte,i,       &
+       &delt,dz,rho,                          &
+       &u,v,th,tk,qv,qc,qi,qs,qnc,qni,        &
+       &psfc,p,exner,                         &
+       &thl,sqv,sqc,sqi,sqs,sqw,              &
+       &qnwfa,qnifa,qnbca,ozone,              &
+       &ust,flt,flq,flqv,flqc,wspd,           &
+       &uoce,voce,                            &
+       &tsq,qsq,cov,                          &
+       &tcd,qcd,                              &
+       &dfm,dfh,dfq,                          &
+       &Du,Dv,Dth,Dqv,Dqc,Dqi,Dqs,Dqnc,Dqni,  &
+       &Dqnwfa,Dqnifa,Dqnbca,Dozone,          &
+       &diss_heat,                            &
+       &s_aw,s_awthl,s_awqt,s_awqv,s_awqc,    &
+       &s_awu,s_awv,                          &
+       &s_awqnc,s_awqni,                      &
+       &s_awqnwfa,s_awqnifa,s_awqnbca,        &
+       &sd_aw,sd_awthl,sd_awqt,sd_awqv,       &
+       &sd_awqc,sd_awqi,                      &
+       &sd_awqnc,sd_awqni,                    &
+       &sd_awqnwfa,sd_awqnifa,                &
+       &sd_awu,sd_awv,                        &
+       &sub_thl,sub_sqv,                      &
+       &sub_u,sub_v,                          &
+       &det_thl,det_sqv,det_sqc,              &
+       &det_u,det_v,                          &
+       &FLAG_QC,FLAG_QI,FLAG_QNC,FLAG_QNI,    &
+       &FLAG_QS,                              &
+       &FLAG_QNWFA,FLAG_QNIFA,FLAG_QNBCA,     &
+       &FLAG_OZONE,                           &
+       &cldfra_bl1,                           &
+       &bl_mynn_cloudmix,                     &
+       &bl_mynn_mixqt,                        &
+       &bl_mynn_edmf,                         &
+       &bl_mynn_edmf_mom,                     &
+       &bl_mynn_mixscalars                    )
 
 !-------------------------------------------------------------------
-    INTEGER, INTENT(in) :: kts,kte
-    INTEGER, INTENT(in) :: grav_settling,levflag
-    LOGICAL, INTENT(IN) :: FLAG_QI,FLAG_QNI,FLAG_QC,FLAG_QNC
+    integer, intent(in) :: kts,kte,i
 
-!! grav_settling = 1 or 2 for gravitational settling of droplets
-!! grav_settling = 0 otherwise
+#ifdef HARDCODE_VERTICAL
+# define kts 1
+# define kte HARDCODE_VERTICAL
+#endif
+
+    integer, intent(in) :: bl_mynn_cloudmix,bl_mynn_mixqt,                &
+                           bl_mynn_edmf,bl_mynn_edmf_mom,                 &
+                           bl_mynn_mixscalars
+    logical, intent(in) :: FLAG_QI,FLAG_QNI,FLAG_QC,FLAG_QS,              &
+         &FLAG_QNC,FLAG_QNWFA,FLAG_QNIFA,FLAG_QNBCA,FLAG_OZONE
+
 ! thl - liquid water potential temperature
 ! qw - total water
-! dfm,dfh,dfq - as above
+! dfm,dfh,dfq - diffusivities i.e., dfh(k) = elq*sh(k) / dzk
 ! flt - surface flux of thl
 ! flq - surface flux of qw
 
-    REAL, DIMENSION(kts:kte), INTENT(in) :: u,v,th,qv,qc,qi,qni,&!qnc,&
-         &p,exner,dfm,dfh,dfq,dz,tsq,qsq,cov,tcd,qcd
-    REAL, DIMENSION(kts:kte), INTENT(inout) :: thl,sqw,sqv,sqc,sqi
-    REAL, DIMENSION(kts:kte), INTENT(inout) :: du,dv,dth,dqv,dqc,dqi,&
-         &dqni!,dqnc
-    REAL, INTENT(IN) :: delt,ust,flt,flq,flqv,flqc,wspd,uoce,voce,qcg
+! mass-flux plumes
+    real(kind_phys), dimension(kts:kte+1), intent(in) :: s_aw,            &
+         &s_awthl,s_awqt,s_awqnc,s_awqni,s_awqv,s_awqc,s_awu,s_awv,       &
+         &s_awqnwfa,s_awqnifa,s_awqnbca,                                  &
+         &sd_aw,sd_awthl,sd_awqt,sd_awqv,sd_awqc,sd_awqi,                 &
+         &sd_awqnc,sd_awqni,sd_awqnwfa,sd_awqnifa,sd_awu,sd_awv
+! tendencies from mass-flux environmental subsidence and detrainment
+    real(kind_phys), dimension(kts:kte), intent(in) :: sub_thl,sub_sqv,   &
+         &sub_u,sub_v,det_thl,det_sqv,det_sqc,det_u,det_v
+    real(kind_phys), dimension(kts:kte), intent(in) :: u,v,th,tk,qv,qc,qi,&
+         &qs,qni,qnc,rho,p,exner,dfq,dz,tsq,qsq,cov,tcd,qcd,              &
+         &cldfra_bl1,diss_heat
+    real(kind_phys), dimension(kts:kte), intent(inout) :: thl,sqw,sqv,sqc,&
+         &sqi,sqs,qnwfa,qnifa,qnbca,ozone,dfm,dfh
+    real(kind_phys), dimension(kts:kte), intent(inout) :: du,dv,dth,dqv,  &
+         &dqc,dqi,dqs,dqni,dqnc,dqnwfa,dqnifa,dqnbca,dozone
+    real(kind_phys), intent(in) :: flt,flq,flqv,flqc,uoce,voce
+    real(kind_phys), intent(in) :: ust,delt,psfc,wspd
+    !debugging
+    real(kind_phys):: wsp,wsp2,tk2,th2
+    logical :: problem
+    integer :: kproblem
 
-!    REAL, INTENT(IN) :: delt,ust,flt,flq,qcg,&
-!         &gradu_top,gradv_top,gradth_top,gradqv_top
+!    real(kind_phys), intent(in) :: gradu_top,gradv_top,gradth_top,gradqv_top
 
 !local vars
 
-    REAL, DIMENSION(kts:kte) :: dtz,vt,vq,qni2!,qnc2
+    real(kind_phys), dimension(kts:kte) :: dtz,dfhc,dfmc,delp
+    real(kind_phys), dimension(kts:kte) :: sqv2,sqc2,sqi2,sqs2,sqw2,      &
+          &qni2,qnc2,qnwfa2,qnifa2,qnbca2,ozone2
+    real(kind_phys), dimension(kts:kte) :: zfac,plumeKh,rhoinv
+    real(kind_phys), dimension(kts:kte) :: a,b,c,d,x
+    real(kind_phys), dimension(kts:kte+1) :: rhoz,                        & !rho on model interface
+          &khdz,kmdz
+    real(kind_phys):: rhs,gfluxm,gfluxp,dztop,maxdfh,mindfh,maxcf,maxKh,zw
+    real(kind_phys):: t,esat,qsl,onoff,kh,km,dzk,rhosfc
+    real(kind_phys):: ustdrag,ustdiff,qvflux
+    real(kind_phys):: th_new,portion_qc,portion_qi,condensate,qsat
+    integer :: k,kk
 
-    REAL, DIMENSION(1:kte-kts+1) :: a,b,c,d
-
-    REAL :: rhs,gfluxm,gfluxp,dztop
-
-    REAL :: grav_settling2,vdfg1    !Katata-fogdes
-
-    INTEGER :: k,kk,nz
-
-    nz=kte-kts+1
+    !Activate nonlocal mixing from the mass-flux scheme for
+    !number concentrations and aerosols (0.0 = no; 1.0 = yes)
+    real(kind_phys), parameter :: nonloc = 1.0
 
     dztop=.5*(dz(kte)+dz(kte-1))
 
-    DO k=kts,kte
-       dtz(k)=delt/dz(k)
+    ! REGULATE THE MOMENTUM MIXING FROM THE MASS-FLUX SCHEME (on or off)
+    ! Note that s_awu and s_awv already come in as 0.0 if bl_mynn_edmf_mom == 0, so
+    ! we only need to zero-out the MF term
+    IF (bl_mynn_edmf_mom == 0) THEN
+       onoff=0.0
+    ELSE
+       onoff=1.0
+    ENDIF
+
+    !Prepare "constants" for diffusion equation.
+    !khdz = rho*Kh/dz = rho*dfh
+    rhosfc     = psfc/(R_d*(tk(kts)+p608*qv(kts)))
+    dtz(kts)   =delt/dz(kts)
+    rhoz(kts)  =rho(kts)
+    rhoinv(kts)=1./rho(kts)
+    khdz(kts)  =rhoz(kts)*dfh(kts)
+    kmdz(kts)  =rhoz(kts)*dfm(kts)
+    delp(kts)  = psfc - (p(kts+1)*dz(kts) + p(kts)*dz(kts+1))/(dz(kts)+dz(kts+1))
+    DO k=kts+1,kte
+       dtz(k)   =delt/dz(k)
+       rhoz(k)  =(rho(k)*dz(k-1) + rho(k-1)*dz(k))/(dz(k-1)+dz(k))
+       rhoz(k)  =  MAX(rhoz(k),1E-4)
+       rhoinv(k)=1./MAX(rho(k),1E-4)
+       dzk      = 0.5  *( dz(k)+dz(k-1) )
+       khdz(k)  = rhoz(k)*dfh(k)
+       kmdz(k)  = rhoz(k)*dfm(k)
     ENDDO
+    DO k=kts+1,kte-1
+       delp(k)  = (p(k)*dz(k-1) + p(k-1)*dz(k))/(dz(k)+dz(k-1)) - &
+                  (p(k+1)*dz(k) + p(k)*dz(k+1))/(dz(k)+dz(k+1))
+    ENDDO
+    delp(kte)  =delp(kte-1)
+    rhoz(kte+1)=rhoz(kte)
+    khdz(kte+1)=rhoz(kte+1)*dfh(kte)
+    kmdz(kte+1)=rhoz(kte+1)*dfm(kte)
+
+    !stability criteria for mf
+    DO k=kts+1,kte-1
+       khdz(k) = max(khdz(k),  0.5*(s_aw(k) +sd_aw(k)))
+       khdz(k) = max(khdz(k), -0.5*(s_aw(k) -s_aw(k+1))  &
+                              -0.5*(sd_aw(k)-sd_aw(k+1)) )
+       kmdz(k) = max(kmdz(k),  0.5*(s_aw(k) +sd_aw(k)))
+       kmdz(k) = max(kmdz(k), -0.5*(s_aw(k) -s_aw(k+1))  &
+                              -0.5*(sd_aw(k)-sd_aw(k+1)) )
+    ENDDO
+
+    ustdrag = MIN(ust*ust,0.99)/wspd  ! limit at ~ 20 m/s
+    ustdiff = MIN(ust*ust,0.01)/wspd  ! limit at ~ 2 m/s
+    dth(kts:kte) = 0.0  ! must initialize for moisture_check routine
 
 !!============================================
 !! u
 !!============================================
-   
+
     k=kts
 
-    a(1)=0.
-    b(1)=1.+dtz(k)*(dfm(k+1)+ust**2/wspd)
-    c(1)=-dtz(k)*dfm(k+1)
-!    d(1)=u(k)
-    d(1)=u(k)+dtz(k)*uoce*ust**2/wspd
+!rho-weighted (drag in b-vector):
+    a(k)=  -dtz(k)*kmdz(k)*rhoinv(k)
+    b(k)=1.+dtz(k)*(kmdz(k+1)+rhosfc*ust**2/wspd)*rhoinv(k)     &
+           & - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*onoff             &
+           & - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)*onoff
+    c(k)=  -dtz(k)*kmdz(k+1)*rhoinv(k) &
+           & - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*onoff             &
+           & - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)*onoff
+    d(k)=u(k)  + dtz(k)*uoce*ust**2/wspd                        &
+           & - dtz(k)*rhoinv(k)*s_awu(k+1)*onoff                &
+           & + dtz(k)*rhoinv(k)*sd_awu(k+1)*onoff               &
+           & + sub_u(k)*delt + det_u(k)*delt
 
-!!    a(1)=0.
-!!    b(1)=1.+dtz(k)*dfm(k+1)
-!!    c(1)=-dtz(k)*dfm(k+1)
-!!    d(1)=u(k)*(1.-ust**2/wspd*dtz(k))
-    
-    DO k=kts+1,kte-1
-       kk=k-kts+1
-       a(kk)=-dtz(k)*dfm(k)
-       b(kk)=1.+dtz(k)*(dfm(k)+dfm(k+1))
-       c(kk)=-dtz(k)*dfm(k+1)
-       d(kk)=u(k)
-    ENDDO
+    do k=kts+1,kte-1
+       a(k)=  -dtz(k)*kmdz(k)*rhoinv(k)                         &
+           &  + 0.5*dtz(k)*rhoinv(k)*s_aw(k)*onoff              &
+           &  + 0.5*dtz(k)*rhoinv(k)*sd_aw(k)*onoff
+       b(k)=1.+ dtz(k)*(kmdz(k)+kmdz(k+1))*rhoinv(k)            &
+           &  + 0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))*onoff  &
+           &  + 0.5*dtz(k)*rhoinv(k)*(sd_aw(k)-sd_aw(k+1))*onoff
+       c(k)=  - dtz(k)*kmdz(k+1)*rhoinv(k)                      &
+           &  - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*onoff            &
+           &  - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)*onoff
+       d(k)=u(k) + dtz(k)*rhoinv(k)*(s_awu(k)-s_awu(k+1))*onoff &
+           &  - dtz(k)*rhoinv(k)*(sd_awu(k)-sd_awu(k+1))*onoff  &
+           &  + sub_u(k)*delt + det_u(k)*delt
+    enddo
 
 !! no flux at the top
-
-!    a(nz)=-1.
-!    b(nz)=1.
-!    c(nz)=0.
-!    d(nz)=0.
+!    a(kte)=-1.
+!    b(kte)=1.
+!    c(kte)=0.
+!    d(kte)=0.
 
 !! specified gradient at the top 
-
-!    a(nz)=-1.
-!    b(nz)=1.
-!    c(nz)=0.
-!    d(nz)=gradu_top*dztop
+!    a(kte)=-1.
+!    b(kte)=1.
+!    c(kte)=0.
+!    d(kte)=gradu_top*dztop
 
 !! prescribed value
+    a(kte)=0
+    b(kte)=1.
+    c(kte)=0.
+    d(kte)=u(kte)
 
-    a(nz)=0
-    b(nz)=1.
-    c(nz)=0.
-    d(nz)=u(kte)
+!    CALL tridiag(kte,a,b,c,d)
+    CALL tridiag2(kte,a,b,c,d,x)
+!    CALL tridiag3(kte,a,b,c,d,x)
 
-    CALL tridiag(nz,a,b,c,d)
-    
     DO k=kts,kte
-       du(k)=(d(k-kts+1)-u(k))/delt
+!       du(k)=(d(k-kts+1)-u(k))/delt
+       du(k)=(x(k)-u(k))/delt
     ENDDO
 
 !!============================================
@@ -1880,507 +4032,1209 @@ CONTAINS
 
     k=kts
 
-    a(1)=0.
-    b(1)=1.+dtz(k)*(dfm(k+1)+ust**2/wspd)
-    c(1)=-dtz(k)*dfm(k+1)
-!    d(1)=v(k)
-    d(1)=v(k)+dtz(k)*voce*ust**2/wspd
+!rho-weighted (drag in b-vector):
+    a(k)=  -dtz(k)*kmdz(k)*rhoinv(k)
+    b(k)=1.+dtz(k)*(kmdz(k+1) + rhosfc*ust**2/wspd)*rhoinv(k)   &
+        &  - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*onoff               &
+        &  - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)*onoff
+    c(k)=  -dtz(k)*kmdz(k+1)*rhoinv(k)                          &
+        &  - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*onoff               &
+        &  - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)*onoff
+    d(k)=v(k)  + dtz(k)*voce*ust**2/wspd                        &
+        &  - dtz(k)*rhoinv(k)*s_awv(k+1)*onoff                  &
+        &  + dtz(k)*rhoinv(k)*sd_awv(k+1)*onoff                 &
+        &  + sub_v(k)*delt + det_v(k)*delt
 
-!!    a(1)=0.
-!!    b(1)=1.+dtz(k)*dfm(k+1)
-!!    c(1)=-dtz(k)*dfm(k+1)
-!!    d(1)=v(k)*(1.-ust**2/wspd*dtz(k))
-
-    DO k=kts+1,kte-1
-       kk=k-kts+1
-       a(kk)=-dtz(k)*dfm(k)
-       b(kk)=1.+dtz(k)*(dfm(k)+dfm(k+1))
-       c(kk)=-dtz(k)*dfm(k+1)
-       d(kk)=v(k)
-    ENDDO
+    do k=kts+1,kte-1
+       a(k)=  -dtz(k)*kmdz(k)*rhoinv(k)                         &
+         & + 0.5*dtz(k)*rhoinv(k)*s_aw(k)*onoff                 &
+         & + 0.5*dtz(k)*rhoinv(k)*sd_aw(k)*onoff
+       b(k)=1.+dtz(k)*(kmdz(k)+kmdz(k+1))*rhoinv(k)             &
+         & + 0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))*onoff     &
+         & + 0.5*dtz(k)*rhoinv(k)*(sd_aw(k)-sd_aw(k+1))*onoff
+       c(k)=  -dtz(k)*kmdz(k+1)*rhoinv(k)                       &
+         & - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*onoff               &
+         & - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)*onoff
+       d(k)=v(k) + dtz(k)*rhoinv(k)*(s_awv(k)-s_awv(k+1))*onoff &
+         & - dtz(k)*rhoinv(k)*(sd_awv(k)-sd_awv(k+1))*onoff     &
+         & + sub_v(k)*delt + det_v(k)*delt
+    enddo
 
 !! no flux at the top
-
-!    a(nz)=-1.
-!    b(nz)=1.
-!    c(nz)=0.
-!    d(nz)=0.
-
+!    a(kte)=-1.
+!    b(kte)=1.
+!    c(kte)=0.
+!    d(kte)=0.
 
 !! specified gradient at the top
-
-!    a(nz)=-1.
-!    b(nz)=1.
-!    c(nz)=0.
-!    d(nz)=gradv_top*dztop
+!    a(kte)=-1.
+!    b(kte)=1.
+!    c(kte)=0.
+!    d(kte)=gradv_top*dztop
 
 !! prescribed value
+    a(kte)=0
+    b(kte)=1.
+    c(kte)=0.
+    d(kte)=v(kte)
 
-    a(nz)=0
-    b(nz)=1.
-    c(nz)=0.
-    d(nz)=v(kte)
+!    CALL tridiag(kte,a,b,c,d)
+    CALL tridiag2(kte,a,b,c,d,x)
+!    CALL tridiag3(kte,a,b,c,d,x)
 
-    CALL tridiag(nz,a,b,c,d)
-    
     DO k=kts,kte
-       dv(k)=(d(k-kts+1)-v(k))/delt
+!       dv(k)=(d(k-kts+1)-v(k))/delt
+       dv(k)=(x(k)-v(k))/delt
     ENDDO
 
 !!============================================
-!! thl 
-!! NOTE: currently, gravitational settling is removed
+!! thl tendency
 !!============================================
     k=kts
 
-    a(1)=0.
-    b(1)=1.+dtz(k)*dfh(k+1)
-    c(1)=-dtz(k)*dfh(k+1)
-    
-!Katata - added
-!    grav_settling2 = MIN(REAL(grav_settling),1.)
-!Katata - end
-!
-! if qcg not used then assume constant flux in the surface layer
-!JOE-remove original code
-!    IF (qcg < qcgmin) THEN
-!       IF (sqc(k) > qcgmin) THEN
-!          gfluxm=grav_settling2*gno*sqc(k)**gpw
-!       ELSE
-!          gfluxm=0.
-!       ENDIF
-!    ELSE
-!       gfluxm=grav_settling2*gno*(qcg/(1.+qcg))**gpw
-!    ENDIF
-!and replace with vdfg1 is computed in module_sf_fogdes.F.
-!    IF (sqc(k) > qcgmin) THEN
-!       !gfluxm=grav_settling2*gno*sqc(k)**gpw
-!       gfluxm=grav_settling2*sqc(k)*vdfg1
-!    ELSE
-!       gfluxm=0.
-!    ENDIF
-!JOE-end
-!
-!    IF (.5*(sqc(k+1)+sqc(k)) > qcgmin) THEN
-!       gfluxp=grav_settling2*gno*(.5*(sqc(k+1)+sqc(k)))**gpw
-!    ELSE
-!       gfluxp=0.
-!    ENDIF
+!rho-weighted: rhosfc*x*rhoinv(k)
+    a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
+    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k)        &
+       &   - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)             &
+       &   - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)                  &
+       &   - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)             &
+       &   - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+    d(k)=thl(k) + dtz(k)*rhosfc*flt*rhoinv(k) + tcd(k)*delt &
+       &   - dtz(k)*rhoinv(k)*s_awthl(k+1)              &
+       &   + dtz(k)*rhoinv(k)*sd_awthl(k+1)             &
+       & + diss_heat(k)*delt + sub_thl(k)*delt + det_thl(k)*delt
 
-    rhs= tcd(k) !-xlvcp/exner(k)*&
-!         ((gfluxp - gfluxm)/dz(k))
-
-    d(1)=thl(k) + dtz(k)*flt + rhs*delt
-    
-    DO k=kts+1,kte-1
-       kk=k-kts+1
-       a(kk)=-dtz(k)*dfh(k)
-       b(kk)=1.+dtz(k)*(dfh(k)+dfh(k+1)) 
-       c(kk)=-dtz(k)*dfh(k+1)
-
-!       IF (.5*(sqc(k+1)+sqc(k)) > qcgmin) THEN
-!          gfluxp=grav_settling2*gno*(.5*(sqc(k+1)+sqc(k)))**gpw
-!       ELSE
-!          gfluxp=0.
-!       ENDIF
-!       
-!       IF (.5*(sqc(k-1)+sqc(k)) > qcgmin) THEN
-!          gfluxm=grav_settling2*gno*(.5*(sqc(k-1)+sqc(k)))**gpw
-!       ELSE
-!          gfluxm=0.
-!       ENDIF
-
-       rhs= tcd(k) !-xlvcp/exner(k)*&
-!            &((gfluxp - gfluxm)/dz(k))
-
-       d(kk)=thl(k) + rhs*delt
-    ENDDO
+    do k=kts+1,kte-1
+       a(k)= -dtz(k)*khdz(k)*rhoinv(k)                  &
+       &    + 0.5*dtz(k)*rhoinv(k)*s_aw(k)              &
+       &    + 0.5*dtz(k)*rhoinv(k)*sd_aw(k)
+       b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))*rhoinv(k)     &
+       &  + 0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))    &
+       &  + 0.5*dtz(k)*rhoinv(k)*(sd_aw(k)-sd_aw(k+1))
+       c(k)= -dtz(k)*khdz(k+1)*rhoinv(k)                &
+       &  - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)              &
+       &  - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+       d(k)=thl(k) + tcd(k)*delt                        &
+       & + dtz(k)*rhoinv(k)*(s_awthl(k)-s_awthl(k+1))   &
+       & - dtz(k)*rhoinv(k)*(sd_awthl(k)-sd_awthl(k+1)) &
+       & +     diss_heat(k)*delt                        &
+       & +     sub_thl(k)*delt + det_thl(k)*delt
+    enddo
 
 !! no flux at the top
+!    a(kte)=-1.
+!    b(kte)=1.
+!    c(kte)=0.
+!    d(kte)=0.
 
-!    a(nz)=-1.
-!    b(nz)=1.
-!    c(nz)=0.
-!    d(nz)=0.
- 
 !! specified gradient at the top
-
 !assume gradthl_top=gradth_top
-
-!    a(nz)=-1.
-!    b(nz)=1.
-!    c(nz)=0.
-!    d(nz)=gradth_top*dztop
+!    a(kte)=-1.
+!    b(kte)=1.
+!    c(kte)=0.
+!    d(kte)=gradth_top*dztop
 
 !! prescribed value
+    a(kte)=0.
+    b(kte)=1.
+    c(kte)=0.
+    d(kte)=thl(kte)
 
-    a(nz)=0.
-    b(nz)=1.
-    c(nz)=0.
-    d(nz)=thl(kte)
+!    CALL tridiag(kte,a,b,c,d)
+    CALL tridiag2(kte,a,b,c,d,x)
+!    CALL tridiag3(kte,a,b,c,d,x)
 
-    CALL tridiag(nz,a,b,c,d)
-    
     DO k=kts,kte
-       thl(k)=d(k-kts+1)
+       !thl(k)=d(k-kts+1)
+       thl(k)=x(k)
     ENDDO
 
-!!============================================
-!! NO LONGER MIX total water (sqw = sqc + sqv)
-!! NOTE: no total water tendency is output
-!!============================================
-!
-!    k=kts
-!  
-!    a(1)=0.
-!    b(1)=1.+dtz(k)*dfh(k+1)
-!    c(1)=-dtz(k)*dfh(k+1)
-!    
-!JOE: replace orig code with fogdep
-!    IF (qcg < qcgmin) THEN
-!       IF (sqc(k) > qcgmin) THEN
-!          gfluxm=grav_settling2*gno*sqc(k)**gpw
-!       ELSE
-!          gfluxm=0.
-!       ENDIF
-!    ELSE
-!       gfluxm=grav_settling2*gno*(qcg/(1.+qcg))**gpw
-!    ENDIF
-!and replace with fogdes code + remove use of qcg:
-!    IF (sqc(k) > qcgmin) THEN
-!       !gfluxm=grav_settling2*gno*(.5*(sqc(k)+sqc(k)))**gpw
-!       gfluxm=grav_settling2*sqc(k)*vdfg1
-!    ELSE
-!       gfluxm=0.
-!    ENDIF
-!JOE-end
-!    
-!    IF (.5*(sqc(k+1)+sqc(k)) > qcgmin) THEN
-!       gfluxp=grav_settling2*gno*(.5*(sqc(k+1)+sqc(k)))**gpw
-!    ELSE
-!       gfluxp=0.
-!    ENDIF
-!
-!    rhs= qcd(k) !+ (gfluxp - gfluxm)/dz(k)& 
-!
-!    d(1)=sqw(k) + dtz(k)*flq + rhs*delt
-!    
-!    DO k=kts+1,kte-1
-!       kk=k-kts+1
-!       a(kk)=-dtz(k)*dfh(k)
-!       b(kk)=1.+dtz(k)*(dfh(k)+dfh(k+1)) 
-!       c(kk)=-dtz(k)*dfh(k+1)
-!
-!       IF (.5*(sqc(k+1)+sqc(k)) > qcgmin) THEN
-!          gfluxp=grav_settling2*gno*(.5*(sqc(k+1)+sqc(k)))**gpw
-!       ELSE
-!          gfluxp=0.
-!       ENDIF
-!
-!       IF (.5*(sqc(k-1)+sqc(k)) > qcgmin) THEN
-!          gfluxm=grav_settling2*gno*(.5*(sqc(k-1)+sqc(k)))**gpw
-!       ELSE
-!          gfluxm=0.
-!       ENDIF
-!
-!       rhs= qcd(k) !+ (gfluxp - gfluxm)/dz(k)&
-!
-!       d(kk)=sqw(k) + rhs*delt
-!    ENDDO
+IF (bl_mynn_mixqt > 0) THEN
+ !============================================
+ ! MIX total water (sqw = sqc + sqv + sqi)
+ ! NOTE: no total water tendency is output; instead, we must calculate
+ !       the saturation specific humidity and then 
+ !       subtract out the moisture excess (sqc & sqi)
+ !============================================
 
+    k=kts
+
+!rho-weighted:
+    a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
+    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k)      &
+       & - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)             &
+       & - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)                &
+       & - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)             &
+       & - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+    d(k)=sqw(k)  + dtz(k)*rhosfc*flq*rhoinv(k) + qcd(k)*delt &
+       &  - dtz(k)*rhoinv(k)*s_awqt(k+1)              &
+       &  + dtz(k)*rhoinv(k)*sd_awqt(k+1)
+
+    do k=kts+1,kte-1
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)               &
+       & + 0.5*dtz(k)*rhoinv(k)*s_aw(k)               &
+       & + 0.5*dtz(k)*rhoinv(k)*sd_aw(k)
+       b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))*rhoinv(k)   &
+       & + 0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))   &
+       & + 0.5*dtz(k)*rhoinv(k)*(sd_aw(k)-sd_aw(k+1))
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)             &
+       & - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)             &
+       & - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+       d(k)=sqw(k) + qcd(k)*delt                      &
+       & + dtz(k)*rhoinv(k)*(s_awqt(k)-s_awqt(k+1))   &
+       & - dtz(k)*rhoinv(k)*(sd_awqt(k)-sd_awqt(k+1))
+    enddo
 
 !! no flux at the top
-
-!    a(nz)=-1.
-!    b(nz)=1.
-!    c(nz)=0.
-!    d(nz)=0.
- 
+!    a(kte)=-1.
+!    b(kte)=1.
+!    c(kte)=0.
+!    d(kte)=0.
 !! specified gradient at the top
 !assume gradqw_top=gradqv_top
-
-!    a(nz)=-1.
-!    b(nz)=1.
-!    c(nz)=0.
-!    d(nz)=gradqv_top*dztop
-
+!    a(kte)=-1.
+!    b(kte)=1.
+!    c(kte)=0.
+!    d(kte)=gradqv_top*dztop
 !! prescribed value
+    a(kte)=0.
+    b(kte)=1.
+    c(kte)=0.
+    d(kte)=sqw(kte)
 
-!    a(nz)=0.
-!    b(nz)=1.
-!    c(nz)=0.
-!    d(nz)=sqw(kte)
-!
-!    CALL tridiag(nz,a,b,c,d)
-!
+!    CALL tridiag(kte,a,b,c,d)
+    CALL tridiag2(kte,a,b,c,d,sqw2)
+!    CALL tridiag3(kte,a,b,c,d,sqw2)
+
 !    DO k=kts,kte
-!       sqw(k)=d(k-kts+1)
+!       sqw2(k)=d(k-kts+1)
 !    ENDDO
-
-!!============================================
-!! cloud water ( sqc )
-!!============================================
-IF (Cloudmix > 0.5 .AND. FLAG_QC) THEN
-
-    k=kts
-
-    a(1)=0.
-    b(1)=1.+dtz(k)*dfh(k+1)
-    c(1)=-dtz(k)*dfh(k+1)
-
-    rhs   =  qcd(k)
-    d(1)=sqc(k) + dtz(k)*flqc + rhs*delt
-
-    DO k=kts+1,kte-1
-       kk=k-kts+1
-       a(kk)=-dtz(k)*dfh(k)
-       b(kk)=1.+dtz(k)*(dfh(k)+dfh(k+1))
-       c(kk)=-dtz(k)*dfh(k+1)
-
-       rhs = qcd(k)
-       d(kk)=sqc(k) + rhs*delt
-    ENDDO
-
-!! prescribed value                                                                                     
-    a(nz)=0.
-    b(nz)=1.
-    c(nz)=0.
-    d(nz)=sqc(kte)
-
-    CALL tridiag(nz,a,b,c,d)
-
-    DO k=kts,kte
-       sqc(k)=d(k-kts+1)
-    ENDDO
-
+ELSE
+    sqw2=sqw
 ENDIF
 
-!!============================================
-!! cloud water number concentration ( qnc )
-!!============================================
-!IF (Cloudmix > 0.5 .AND. FLAG_QNC) THEN
-!
-!    k=kts
-!
-!    a(1)=0.
-!    b(1)=1.+dtz(k)*dfh(k+1)
-!    c(1)=-dtz(k)*dfh(k+1)
-!
-!    rhs =qcd(k)
-!    d(1)=qnc(k) !+ dtz(k)*flqc + rhs*delt
-!
-!    DO k=kts+1,kte-1
-!       kk=k-kts+1
-!       a(kk)=-dtz(k)*dfh(k)
-!       b(kk)=1.+dtz(k)*(dfh(k)+dfh(k+1))
-!       c(kk)=-dtz(k)*dfh(k+1)
-!
-!       rhs = qcd(k)
-!       d(kk)=qnc(k) + rhs*delt
-!    ENDDO
-!
-!! prescribed value
-!    a(nz)=0.
-!    b(nz)=1.
-!    c(nz)=0.
-!    d(nz)=qnc(kte)
-!
-!    CALL tridiag(nz,a,b,c,d)
-!
+IF (bl_mynn_mixqt == 0) THEN
+!============================================
+! cloud water ( sqc ). If mixing total water (bl_mynn_mixqt > 0),
+! then sqc will be backed out of saturation check (below).
+!============================================
+  IF (bl_mynn_cloudmix > 0 .AND. FLAG_QC) THEN
+
+    k=kts
+
+!rho-weighted:
+    a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
+    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k)      &
+    &  - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)               &
+    &  - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)                &
+    &  - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)               &
+    &  - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+    d(k)=sqc(k)  + dtz(k)*rhosfc*flqc*rhoinv(k) + qcd(k)*delt &
+    &  - dtz(k)*rhoinv(k)*s_awqc(k+1)                 &
+    &  + dtz(k)*rhoinv(k)*sd_awqc(k+1)                &
+    &  + det_sqc(k)*delt
+
+    do k=kts+1,kte-1
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)               &
+       & + 0.5*dtz(k)*rhoinv(k)*s_aw(k)               &
+       & + 0.5*dtz(k)*rhoinv(k)*sd_aw(k)
+       b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))*rhoinv(k)   &
+       & + 0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))   &
+       & + 0.5*dtz(k)*rhoinv(k)*(sd_aw(k)-sd_aw(k+1))
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)             &
+       & - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)             &
+       & - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+       d(k)=sqc(k) + qcd(k)*delt                      &
+       & + dtz(k)*rhoinv(k)*(s_awqc(k)-s_awqc(k+1))   &
+       & - dtz(k)*rhoinv(k)*(sd_awqc(k)-sd_awqc(k+1)) &
+       & + det_sqc(k)*delt
+    enddo
+
+! prescribed value
+    a(kte)=0.
+    b(kte)=1.
+    c(kte)=0.
+    d(kte)=sqc(kte)
+
+!    CALL tridiag(kte,a,b,c,d)
+    CALL tridiag2(kte,a,b,c,d,sqc2)
+!    CALL tridiag3(kte,a,b,c,d,sqc2)
+
 !    DO k=kts,kte
-!       qnc2(k)=d(k-kts+1)
+!       sqc2(k)=d(k-kts+1)
 !    ENDDO
-!
-!ELSE
-!    qnc2=qnc
-!ENDIF
+  ELSE
+    !If not mixing clouds, set "updated" array equal to original array
+    sqc2=sqc
+  ENDIF
+ENDIF
 
-!!============================================
-!! MIX WATER VAPOR ONLY ( sqv )                                                                         
-!!============================================                                                          
-
-    k=kts
-
-    a(1)=0.
-    b(1)=1.+dtz(k)*dfh(k+1)
-    c(1)=-dtz(k)*dfh(k+1)
-    d(1)=sqv(k) + dtz(k)*flqv + qcd(k)*delt
-
-    DO k=kts+1,kte-1
-       kk=k-kts+1
-       a(kk)=-dtz(k)*dfh(k)
-       b(kk)=1.+dtz(k)*(dfh(k)+dfh(k+1))
-       c(kk)=-dtz(k)*dfh(k+1)
-       d(kk)=sqv(k) + qcd(k)*delt
-    ENDDO
-
-!! no flux at the top                                                                                   
-!    a(nz)=-1.                                                                                          
-!    b(nz)=1.                                                                                           
-!    c(nz)=0.                                                                                           
-!    d(nz)=0.                                                                                           
-
-!! specified gradient at the top                                                                        
-!assume gradqw_top=gradqv_top                                                                           
-!    a(nz)=-1.                                                                                          
-!    b(nz)=1.                                                                                           
-!    c(nz)=0.                                                                                           
-!    d(nz)=gradqv_top*dztop                                                                             
-
-!! prescribed value                                                                                     
-    a(nz)=0.
-    b(nz)=1.
-    c(nz)=0.
-    d(nz)=sqv(kte)
-
-    CALL tridiag(nz,a,b,c,d)
-
-    DO k=kts,kte
-       sqv(k)=d(k-kts+1)
-    ENDDO
-
-!!============================================
-!! MIX CLOUD ICE ( sqi )                      
-!!============================================
-IF (Cloudmix > 0.5 .AND. FLAG_QI) THEN
+IF (bl_mynn_mixqt == 0) THEN
+  !============================================
+  ! MIX WATER VAPOR ONLY ( sqv ). If mixing total water (bl_mynn_mixqt > 0),
+  ! then sqv will be backed out of saturation check (below).
+  !============================================
 
     k=kts
 
-    a(1)=0.
-    b(1)=1.+dtz(k)*dfh(k+1)
-    c(1)=-dtz(k)*dfh(k+1)
-    d(1)=sqi(k) + qcd(k)*delt !should we have qcd for ice???
+    !limit unreasonably large negative fluxes:
+    qvflux = flqv
+    if (qvflux < 0.0) then
+       !do not allow specified surface flux to reduce qv below 1e-8 kg/kg
+       qvflux = max(qvflux, (min(0.9*sqv(kts) - 1e-8, 0.0)/dtz(kts)))
+    endif
 
-    DO k=kts+1,kte-1
-       kk=k-kts+1
-       a(kk)=-dtz(k)*dfh(k)
-       b(kk)=1.+dtz(k)*(dfh(k)+dfh(k+1))
-       c(kk)=-dtz(k)*dfh(k+1)
-       d(kk)=sqi(k) + qcd(k)*delt
-    ENDDO
+!rho-weighted:
+    a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
+    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k)      &
+    & - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)                &
+    & - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)                &
+    & - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)                &
+    & - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+    d(k)=sqv(k)  + dtz(k)*rhosfc*qvflux*rhoinv(k) + qcd(k)*delt &
+    & - dtz(k)*rhoinv(k)*s_awqv(k+1)                  &
+    & + dtz(k)*rhoinv(k)*sd_awqv(k+1)                 &
+    & + sub_sqv(k)*delt + det_sqv(k)*delt
+
+    do k=kts+1,kte-1
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)               &
+       & + 0.5*dtz(k)*rhoinv(k)*s_aw(k)               &
+       & + 0.5*dtz(k)*rhoinv(k)*sd_aw(k)
+       b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))*rhoinv(k)   &
+       & + 0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))   &
+       & + 0.5*dtz(k)*rhoinv(k)*(sd_aw(k)-sd_aw(k+1))
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)             &
+       & - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)             &
+       & - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+       d(k)=sqv(k) + qcd(k)*delt                      &
+       & + dtz(k)*rhoinv(k)*(s_awqv(k)-s_awqv(k+1))   &
+       & - dtz(k)*rhoinv(k)*(sd_awqv(k)-sd_awqv(k+1)) &
+       & + sub_sqv(k)*delt + det_sqv(k)*delt
+    enddo
+
+! no flux at the top
+!    a(kte)=-1.
+!    b(kte)=1.
+!    c(kte)=0.
+!    d(kte)=0.
+
+! specified gradient at the top
+! assume gradqw_top=gradqv_top
+!    a(kte)=-1.
+!    b(kte)=1.
+!    c(kte)=0.
+!    d(kte)=gradqv_top*dztop
+
+! prescribed value
+    a(kte)=0.
+    b(kte)=1.
+    c(kte)=0.
+    d(kte)=sqv(kte)
+
+!    CALL tridiag(kte,a,b,c,d)
+    CALL tridiag2(kte,a,b,c,d,sqv2)
+!    CALL tridiag3(kte,a,b,c,d,sqv2)
+
+!    DO k=kts,kte
+!       sqv2(k)=d(k-kts+1)
+!    ENDDO
+ELSE
+    sqv2=sqv
+ENDIF
+
+!============================================
+! MIX CLOUD ICE ( sqi )                      
+!============================================
+IF (bl_mynn_cloudmix > 0 .AND. FLAG_QI) THEN
+
+    k=kts
+
+    a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
+    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k)      &
+!    &  - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)               &
+    &  - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)                &
+!    &  - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)               &
+    &  - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+    d(k)=sqi(k)                                       &
+!    &  - dtz(k)*rhoinv(k)*s_awqi(k+1)                 &
+    &  + dtz(k)*rhoinv(k)*sd_awqi(k+1)
+
+    do k=kts+1,kte-1
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)               &
+!       & + 0.5*dtz(k)*rhoinv(k)*s_aw(k)               &
+       & + 0.5*dtz(k)*rhoinv(k)*sd_aw(k)
+       b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))*rhoinv(k)   &
+!       & + 0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))   &
+       & + 0.5*dtz(k)*rhoinv(k)*(sd_aw(k)-sd_aw(k+1))
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)             &
+!       & - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)             &
+       & - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+       d(k)=sqi(k)                                    &
+!       & + dtz(k)*rhoinv(k)*(s_awqi(k)-s_awqi(k+1))   &
+       & - dtz(k)*rhoinv(k)*(sd_awqi(k)-sd_awqi(k+1))
+    enddo
 
 !! no flux at the top
-!    a(nz)=-1.       
-!    b(nz)=1.        
-!    c(nz)=0.        
-!    d(nz)=0.        
+!    a(kte)=-1.       
+!    b(kte)=1.        
+!    c(kte)=0.        
+!    d(kte)=0.        
 
 !! specified gradient at the top
 !assume gradqw_top=gradqv_top
-!    a(nz)=-1.                                                                                          
-!    b(nz)=1.                                                                                           
-!    c(nz)=0.                                                                                           
-!    d(nz)=gradqv_top*dztop                                                                             
+!    a(kte)=-1.
+!    b(kte)=1.
+!    c(kte)=0.
+!    d(kte)=gradqv_top*dztop
 
-!! prescribed value                                                                                     
-    a(nz)=0.
-    b(nz)=1.
-    c(nz)=0.
-    d(nz)=sqi(kte)
+!! prescribed value
+    a(kte)=0.
+    b(kte)=1.
+    c(kte)=0.
+    d(kte)=sqi(kte)
 
-    CALL tridiag(nz,a,b,c,d)
+!    CALL tridiag(kte,a,b,c,d)
+    CALL tridiag2(kte,a,b,c,d,sqi2)
+!    CALL tridiag3(kte,a,b,c,d,sqi2)
 
-    DO k=kts,kte
-       sqi(k)=d(k-kts+1)
-    ENDDO
-
+!    DO k=kts,kte
+!       sqi2(k)=d(k-kts+1)
+!    ENDDO
+ELSE
+   sqi2=sqi
 ENDIF
 
-!!============================================
-!! ice water number concentration (qni)       
-!!============================================
-IF (Cloudmix > 0.5 .AND. FLAG_QNI) THEN
+!============================================
+! MIX SNOW ( sqs )
+!============================================
+!hard-code to not mix snow
+IF (bl_mynn_cloudmix > 0 .AND. .false.) THEN
 
     k=kts
-
-    a(1)=0.
-    b(1)=1.+dtz(k)*dfh(k+1)
-    c(1)=-dtz(k)*dfh(k+1)
-
-    rhs = qcd(k)               
-
-    d(1)=qni(k) !+ dtz(k)*flqc + rhs*delt
+!rho-weighted:
+    a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
+    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k)
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)
+    d(k)=sqs(k)
 
     DO k=kts+1,kte-1
-       kk=k-kts+1
-       a(kk)=-dtz(k)*dfh(k)
-       b(kk)=1.+dtz(k)*(dfh(k)+dfh(k+1))
-       c(kk)=-dtz(k)*dfh(k+1)
-
-       rhs = qcd(k)
-       d(kk)=qni(k) + rhs*delt
-
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
+       b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))*rhoinv(k)
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)
+       d(k)=sqs(k)
     ENDDO
 
 !! prescribed value
-    a(nz)=0.
-    b(nz)=1.
-    c(nz)=0.
-    d(nz)=qni(kte)
+    a(kte)=0.
+    b(kte)=1.
+    c(kte)=0.
+    d(kte)=sqs(kte)
 
-    CALL tridiag(nz,a,b,c,d)
+!    CALL tridiag(kte,a,b,c,d)
+    CALL tridiag2(kte,a,b,c,d,sqs2)
+!    CALL tridiag3(kte,a,b,c,d,sqs2)
+
+!    DO k=kts,kte
+!       sqs2(k)=d(k-kts+1)
+!    ENDDO
+ELSE
+   sqs2=sqs
+ENDIF
+
+!!============================================
+!! cloud ice number concentration (qni)
+!!============================================
+IF (bl_mynn_cloudmix > 0 .AND. FLAG_QNI .AND. &
+      bl_mynn_mixscalars > 0) THEN
+
+    k=kts
+
+    a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
+    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k)      &
+    &  - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)               &
+    &  - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)                &
+    &  - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)               &
+    &  - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+    d(k)=qni(k)                                       &
+    &  - dtz(k)*rhoinv(k)*s_awqni(k+1)                &
+    &  + dtz(k)*rhoinv(k)*sd_awqni(k+1)
+
+    do k=kts+1,kte-1
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)               &
+       & + 0.5*dtz(k)*rhoinv(k)*s_aw(k)               &
+       & + 0.5*dtz(k)*rhoinv(k)*sd_aw(k)
+       b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))*rhoinv(k)   &
+       & + 0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))   &
+       & + 0.5*dtz(k)*rhoinv(k)*(sd_aw(k)-sd_aw(k+1))
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)             &
+       & - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)             &
+       & - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+       d(k)=qni(k)                                    &
+       & + dtz(k)*rhoinv(k)*(s_awqni(k)-s_awqni(k+1)) &
+       & - dtz(k)*rhoinv(k)*(sd_awqni(k)-sd_awqni(k+1))
+    enddo
+
+!! prescribed value
+    a(kte)=0.
+    b(kte)=1.
+    c(kte)=0.
+    d(kte)=qni(kte)
+
+!    CALL tridiag(kte,a,b,c,d)
+    CALL tridiag2(kte,a,b,c,d,x)
+!    CALL tridiag3(kte,a,b,c,d,x)
 
     DO k=kts,kte
-       qni2(k)=d(k-kts+1)
+       !qni2(k)=d(k-kts+1)
+       qni2(k)=x(k)
     ENDDO
+
 ELSE
     qni2=qni
 ENDIF
 
 !!============================================
-!! convert to mixing ratios for wrf
+!! cloud water number concentration (qnc)     
+!! include non-local transport                
 !!============================================
-!!NOTE: added number conc tendencies for double moment schemes
+  IF (bl_mynn_cloudmix > 0 .AND. FLAG_QNC .AND. &
+      bl_mynn_mixscalars > 0) THEN
+
+    k=kts
+
+    a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
+    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k)      &
+    &  - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)               &
+    &  - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)                &
+    &  - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)               &
+    &  - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+    d(k)=qnc(k)                                       &
+    &  - dtz(k)*rhoinv(k)*s_awqnc(k+1)                &
+    &  + dtz(k)*rhoinv(k)*sd_awqnc(k+1)
+
+    do k=kts+1,kte-1
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)               &
+       & + 0.5*dtz(k)*rhoinv(k)*s_aw(k)               &
+       & + 0.5*dtz(k)*rhoinv(k)*sd_aw(k)
+       b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))*rhoinv(k)   &
+       & + 0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))   &
+       & + 0.5*dtz(k)*rhoinv(k)*(sd_aw(k)-sd_aw(k+1))
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)             &
+       & - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)             &
+       & - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+       d(k)=qnc(k)                                    &
+       & + dtz(k)*rhoinv(k)*(s_awqnc(k)-s_awqnc(k+1)) &
+       & - dtz(k)*rhoinv(k)*(sd_awqnc(k)-sd_awqnc(k+1))
+    enddo
+
+!! prescribed value
+    a(kte)=0.
+    b(kte)=1.
+    c(kte)=0.
+    d(kte)=qnc(kte)
+
+!    CALL tridiag(kte,a,b,c,d)
+    CALL tridiag2(kte,a,b,c,d,x)
+!    CALL tridiag3(kte,a,b,c,d,x)
 
     DO k=kts,kte
-       !sqw(k)=d(k-kts+1)
-       Dqv(k)=(sqv(k)/(1.-sqv(k))-qv(k))/delt
-       !qc settling tendency is now computed in module_bl_fogdes.F, so
-       !sqc should only be changed by turbulent mixing.
-       Dqc(k)=(sqc(k)/(1.-sqc(k))-qc(k))/delt
-       Dqi(k)=(sqi(k)/(1.-sqi(k))-qi(k))/delt
- !      Dqnc(k)=(qnc2(k)-qnc(k))/delt
-       Dqni(k)=(qni2(k)-qni(k))/delt
-       Dth(k)=(thl(k) + xlvcp/exner(k)*sqc(k) &
-         &            + xlscp/exner(k)*sqi(k) &
-         &            - th(k))/delt
-       !Dth(k)=(thl(k)+xlvcp/exner(k)*sqc(k)-th(k))/delt
+       !qnc2(k)=d(k-kts+1)
+       qnc2(k)=x(k)
     ENDDO
+
+ELSE
+    qnc2=qnc
+ENDIF
+
+!============================================
+! Water-friendly aerosols ( qnwfa ).
+!============================================
+IF (bl_mynn_cloudmix > 0 .AND. FLAG_QNWFA .AND. &
+      bl_mynn_mixscalars > 0) THEN
+
+    k=kts
+
+    a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
+    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k)      &
+    &  - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)               &
+    &  - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)                &
+    &  - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)               &
+    &  - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+    d(k)=qnwfa(k)                                     &
+    &  - dtz(k)*rhoinv(k)*s_awqnwfa(k+1)              &
+    &  + dtz(k)*rhoinv(k)*sd_awqnwfa(k+1)
+
+    do k=kts+1,kte-1
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)               &
+       & + 0.5*dtz(k)*rhoinv(k)*s_aw(k)               &
+       & + 0.5*dtz(k)*rhoinv(k)*sd_aw(k)
+       b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))*rhoinv(k)   &
+       & + 0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))   &
+       & + 0.5*dtz(k)*rhoinv(k)*(sd_aw(k)-sd_aw(k+1))
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)             &
+       & - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)             &
+       & - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+       d(k)=qnwfa(k)                                  &
+       & + dtz(k)*rhoinv(k)*(s_awqnwfa(k)-s_awqnwfa(k+1)) &
+       & - dtz(k)*rhoinv(k)*(sd_awqnwfa(k)-sd_awqnwfa(k+1))
+    enddo
+
+! prescribed value
+    a(kte)=0.
+    b(kte)=1.
+    c(kte)=0.
+    d(kte)=qnwfa(kte)
+
+!    CALL tridiag(kte,a,b,c,d)
+    CALL tridiag2(kte,a,b,c,d,x)
+!    CALL tridiag3(kte,a,b,c,d,x)
+
+    DO k=kts,kte
+       !qnwfa2(k)=d(k)
+       qnwfa2(k)=x(k)
+    ENDDO
+
+ELSE
+    !If not mixing aerosols, set "updated" array equal to original array
+    qnwfa2=qnwfa
+ENDIF
+
+!============================================
+! Ice-friendly aerosols ( qnifa ).
+!============================================
+IF (bl_mynn_cloudmix > 0 .AND. FLAG_QNIFA .AND. &
+      bl_mynn_mixscalars > 0) THEN
+
+   k=kts
+
+    a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
+    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k)      &
+    &  - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)               &
+    &  - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)                &
+    &  - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)               &
+    &  - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+    d(k)=qnifa(k)                                     &
+    &  - dtz(k)*rhoinv(k)*s_awqnifa(k+1)              &
+    &  + dtz(k)*rhoinv(k)*sd_awqnifa(k+1)
+
+    do k=kts+1,kte-1
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)               &
+       & + 0.5*dtz(k)*rhoinv(k)*s_aw(k)               &
+       & + 0.5*dtz(k)*rhoinv(k)*sd_aw(k)
+       b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))*rhoinv(k)   &
+       & + 0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))   &
+       & + 0.5*dtz(k)*rhoinv(k)*(sd_aw(k)-sd_aw(k+1))
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)             &
+       & - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)             &
+       & - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
+       d(k)=qnifa(k)                                  &
+       & + dtz(k)*rhoinv(k)*(s_awqnifa(k)-s_awqnifa(k+1)) &
+       & - dtz(k)*rhoinv(k)*(sd_awqnifa(k)-sd_awqnifa(k+1))
+    enddo
+
+! prescribed value
+    a(kte)=0.
+    b(kte)=1.
+    c(kte)=0.
+    d(kte)=qnifa(kte)
+
+!    CALL tridiag(kte,a,b,c,d)
+    CALL tridiag2(kte,a,b,c,d,x)
+!    CALL tridiag3(kte,a,b,c,d,x)
+
+    DO k=kts,kte
+       !qnifa2(k)=d(k-kts+1)
+       qnifa2(k)=x(k)
+    ENDDO
+
+ELSE
+    !If not mixing aerosols, set "updated" array equal to original array
+    qnifa2=qnifa
+ENDIF
+
+!============================================
+! Black-carbon aerosols ( qnbca ).           
+!============================================
+IF (bl_mynn_cloudmix > 0 .AND. FLAG_QNBCA .AND. &
+      bl_mynn_mixscalars > 0) THEN
+
+   k=kts
+
+    a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
+    b(k)=1.+dtz(k)*(khdz(k) + khdz(k+1))*rhoinv(k)   &
+    & - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*nonloc
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)               &
+    & - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*nonloc
+    d(k)=qnbca(k)  - dtz(k)*rhoinv(k)*s_awqnbca(k+1)*nonloc
+
+    do k=kts+1,kte-1
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)              &
+       & + 0.5*dtz(k)*rhoinv(k)*s_aw(k)*nonloc
+       b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))*rhoinv(k)  &
+       & + 0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))*nonloc
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)            &
+       & - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*nonloc
+       d(k)=qnbca(k) + dtz(k)*rhoinv(k)*(s_awqnbca(k)-s_awqnbca(k+1))*nonloc
+    enddo
+
+! prescribed value
+    a(kte)=0.
+    b(kte)=1.
+    c(kte)=0.
+    d(kte)=qnbca(kte)
+
+!    CALL tridiag(kte,a,b,c,d)
+   CALL tridiag2(kte,a,b,c,d,x)
+!    CALL tridiag3(kte,a,b,c,d,x)
+
+    DO k=kts,kte
+       !qnbca2(k)=d(k-kts+1)
+       qnbca2(k)=x(k)
+    ENDDO
+
+ELSE
+    !If not mixing aerosols, set "updated" array equal to original array
+    qnbca2=qnbca
+ENDIF
+
+!============================================
+! Ozone - local mixing only
+!============================================
+IF (FLAG_OZONE) THEN
+    k=kts
+
+!rho-weighted:
+    a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
+    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k)
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)
+    d(k)=ozone(k)
+
+    DO k=kts+1,kte-1
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
+       b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))*rhoinv(k)
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)
+       d(k)=ozone(k)
+    ENDDO
+
+! prescribed value                                                                                                           
+    a(kte)=0.
+    b(kte)=1.
+    c(kte)=0.
+    d(kte)=ozone(kte)
+
+!    CALL tridiag(kte,a,b,c,d)
+    CALL tridiag2(kte,a,b,c,d,x)
+!    CALL tridiag3(kte,a,b,c,d,x)
+
+    DO k=kts,kte
+       !ozone2(k)=d(k-kts+1)
+       dozone(k)=(x(k)-ozone(k))/delt
+    ENDDO
+ELSE
+    dozone(:)=0.0
+ENDIF
+
+!!============================================
+!! Compute tendencies and convert to mixing ratios for WRF.
+!! Note that the momentum tendencies are calculated above.
+!!============================================
+
+   IF (bl_mynn_mixqt > 0) THEN 
+      DO k=kts,kte
+         !compute updated theta using updated thl and old condensate
+         th_new = thl(k) + xlvcp/exner(k)*sqc(k) &
+           &             + xlscp/exner(k)*sqi(k)
+
+         t  = th_new*exner(k)
+         qsat = qsat_blend(t,p(k)) 
+         !SATURATED VAPOR PRESSURE
+         !esat=esat_blend(t)
+         !SATURATED SPECIFIC HUMIDITY
+         !qsl=ep_2*esat/(p(k)-ep_3*esat)
+         !qsl=ep_2*esat/max(1.e-4,(p(k)-ep_3*esat))
+
+         IF (sqc(k) > 0.0 .or. sqi(k) > 0.0) THEN !initially saturated
+            sqv2(k) = MIN(sqw2(k),qsat)
+            portion_qc = sqc(k)/(sqc(k) + sqi(k))
+            portion_qi = sqi(k)/(sqc(k) + sqi(k))
+            condensate = MAX(sqw2(k) - qsat, 0.0)
+            sqc2(k) = condensate*portion_qc
+            sqi2(k) = condensate*portion_qi
+         ELSE                     ! initially unsaturated -----
+            sqv2(k) = sqw2(k)     ! let microphys decide what to do
+            sqi2(k) = 0.0         ! if sqw2 > qsat 
+            sqc2(k) = 0.0
+         ENDIF
+      ENDDO
+   ENDIF
+
+
+    !=====================
+    ! WATER VAPOR TENDENCY
+    !=====================
+    DO k=kts,kte
+       Dqv(k)=(sqv2(k) - sqv(k))/delt
+       !if (sqv2(k) < 0.0)print*,"neg qv:",sqv2(k),k
+    ENDDO
+
+    IF (bl_mynn_cloudmix > 0) THEN
+      !=====================
+      ! CLOUD WATER TENDENCY
+      !=====================
+      !print*,"FLAG_QC:",FLAG_QC
+      IF (FLAG_QC) THEN
+         DO k=kts,kte
+            Dqc(k)=(sqc2(k) - sqc(k))/delt
+            !if (sqc2(k) < 0.0)print*,"neg qc:",sqc2(k),k
+         ENDDO
+      ELSE
+         DO k=kts,kte
+           Dqc(k) = 0.
+         ENDDO
+      ENDIF
+
+      !===================
+      ! CLOUD WATER NUM CONC TENDENCY
+      !===================
+      IF (FLAG_QNC .AND. bl_mynn_mixscalars > 0) THEN
+         DO k=kts,kte
+           Dqnc(k) = (qnc2(k)-qnc(k))/delt
+           !IF(Dqnc(k)*delt + qnc(k) < 0.)Dqnc(k)=-qnc(k)/delt
+         ENDDO 
+      ELSE
+         DO k=kts,kte
+           Dqnc(k) = 0.
+         ENDDO
+      ENDIF
+
+      !===================
+      ! CLOUD ICE TENDENCY
+      !===================
+      IF (FLAG_QI) THEN
+         DO k=kts,kte
+           Dqi(k)=(sqi2(k) - sqi(k))/delt
+           !if (sqi2(k) < 0.0)print*,"neg qi:",sqi2(k),k
+         ENDDO
+      ELSE
+         DO k=kts,kte
+           Dqi(k) = 0.
+         ENDDO
+      ENDIF
+
+      !===================
+      ! CLOUD SNOW TENDENCY
+      !===================
+      IF (.false.) THEN !disabled
+         DO k=kts,kte
+           Dqs(k)=(sqs2(k) - sqs(k))/delt
+         ENDDO
+      ELSE
+         DO k=kts,kte
+           Dqs(k) = 0.
+         ENDDO
+      ENDIF
+
+      !===================
+      ! CLOUD ICE NUM CONC TENDENCY
+      !===================
+      IF (FLAG_QNI .AND. bl_mynn_mixscalars > 0) THEN
+         DO k=kts,kte
+           Dqni(k)=(qni2(k)-qni(k))/delt
+           !IF(Dqni(k)*delt + qni(k) < 0.)Dqni(k)=-qni(k)/delt
+         ENDDO
+      ELSE
+         DO k=kts,kte
+           Dqni(k)=0.
+         ENDDO
+      ENDIF
+    ELSE !-MIX CLOUD SPECIES?
+      !CLOUDS ARE NOT NIXED (when bl_mynn_cloudmix == 0)
+      DO k=kts,kte
+         Dqc(k) =0.
+         Dqnc(k)=0.
+         Dqi(k) =0.
+         Dqni(k)=0.
+         Dqs(k) =0.
+      ENDDO
+    ENDIF
+
+    !ensure non-negative moist species
+    CALL moisture_check(kte, delt, delp, exner,        &
+                        sqv2, sqc2, sqi2, sqs2, thl,   &
+                        dqv, dqc, dqi, dqs, dth        )
+
+    !=====================
+    ! OZONE TENDENCY CHECK
+    !=====================
+    DO k=kts,kte
+       IF(Dozone(k)*delt + ozone(k) < 0.) THEN
+         Dozone(k)=-ozone(k)*0.99/delt
+       ENDIF
+    ENDDO
+
+    !===================
+    ! THETA TENDENCY
+    !===================
+    IF (FLAG_QI) THEN
+      DO k=kts,kte
+         Dth(k)=(thl(k) + xlvcp/exner(k)*sqc2(k)          &
+           &            + xlscp/exner(k)*(sqi2(k))        & !+sqs2(k)) &
+           &            - th(k))/delt
+         !Use form from Tripoli and Cotton (1981) with their
+         !suggested min temperature to improve accuracy:
+         !Dth(k)=(thl(k)*(1.+ xlvcp/MAX(tk(k),TKmin)*sqc(k)  &
+         !  &               + xlscp/MAX(tk(k),TKmin)*sqi(k)) &
+         !  &               - th(k))/delt
+      ENDDO
+    ELSE
+      DO k=kts,kte
+         Dth(k)=(thl(k)+xlvcp/exner(k)*sqc2(k) - th(k))/delt
+         !Use form from Tripoli and Cotton (1981) with their
+         !suggested min temperature to improve accuracy.
+         !Dth(k)=(thl(k)*(1.+ xlvcp/MAX(tk(k),TKmin)*sqc(k))  &
+         !&               - th(k))/delt
+      ENDDO
+    ENDIF
+
+    !===================
+    ! AEROSOL TENDENCIES
+    !===================
+    IF (FLAG_QNWFA .AND. FLAG_QNIFA .AND. &
+        bl_mynn_mixscalars > 0) THEN
+       DO k=kts,kte
+          !=====================
+          ! WATER-friendly aerosols
+          !=====================
+          Dqnwfa(k)=(qnwfa2(k) - qnwfa(k))/delt
+          !=====================
+          ! Ice-friendly aerosols
+          !=====================
+          Dqnifa(k)=(qnifa2(k) - qnifa(k))/delt
+       ENDDO
+    ELSE
+       DO k=kts,kte
+          Dqnwfa(k)=0.
+          Dqnifa(k)=0.
+       ENDDO
+    ENDIF
+
+    !========================
+    ! BLACK-CARBON TENDENCIES
+    !========================
+    IF (FLAG_QNBCA .AND. bl_mynn_mixscalars > 0) THEN
+       DO k=kts,kte
+          Dqnbca(k)=(qnbca2(k) - qnbca(k))/delt
+       ENDDO
+    ELSE
+       DO k=kts,kte
+          Dqnbca(k)=0.
+       ENDDO
+    ENDIF
+
+    !ensure non-negative moist species
+    !note: if called down here, dth needs to be updated, but
+    !      if called before the theta-tendency calculation, do not compute dth
+    !CALL moisture_check(kte, delt, delp, exner,     &
+    !                    sqv, sqc, sqi, thl,         &
+    !                    dqv, dqc, dqi, dth )
+
+    if (debug_code) then
+       problem = .false.
+       do k=kts,kte
+          wsp  = sqrt(u(k)**2 + v(k)**2)
+          wsp2 = sqrt((u(k)+du(k)*delt)**2 + (v(k)+du(k)*delt)**2)
+          th2  = th(k) + Dth(k)*delt
+          tk2  = th2*exner(k)
+          if (wsp2 > 200. .or. tk2 > 360. .or. tk2 < 160.) then
+             problem = .true.
+             print*,"Outgoing problem at: i=",i," k=",k
+             print*," incoming wsp=",wsp," outgoing wsp=",wsp2
+             print*," incoming T=",th(k)*exner(k),"outgoing T:",tk2
+             print*," du=",du(k)*delt," dv=",dv(k)*delt," dth=",dth(k)*delt
+             print*," km=",kmdz(k)*dz(k)," kh=",khdz(k)*dz(k)
+             print*," u*=",ust," wspd=",wspd,"rhosfc=",rhosfc
+             print*," LH=",flq*rhosfc*1004.," HFX=",flt*rhosfc*1004.
+             print*," drag term=",ust**2/wspd*dtz(k)*rhosfc/rho(kts)
+             kproblem = k
+          endif
+       enddo
+       if (problem) then
+          print*,"==thl:",thl(max(kproblem-3,1):min(kproblem+3,kte))
+          print*,"===qv:",sqv2(max(kproblem-3,1):min(kproblem+3,kte))
+          print*,"===qc:",sqc2(max(kproblem-3,1):min(kproblem+3,kte))
+          print*,"===qi:",sqi2(max(kproblem-3,1):min(kproblem+3,kte))
+          print*,"====u:",u(max(kproblem-3,1):min(kproblem+3,kte))
+          print*,"====v:",v(max(kproblem-3,1):min(kproblem+3,kte))
+       endif
+    endif
+
+#ifdef HARDCODE_VERTICAL
+# undef kts
+# undef kte
+#endif
 
   END SUBROUTINE mynn_tendencies
 
 ! ==================================================================
-  SUBROUTINE retrieve_exchange_coeffs(kts,kte,&
-       &dfm,dfh,dfq,dz,&
-       &K_m,K_h,K_q)
+  SUBROUTINE moisture_check(kte, delt, dp, exner,   &
+                            qv, qc, qi, qs, th,     &
+                            dqv, dqc, dqi, dqs, dth )
+
+  ! This subroutine was adopted from the CAM-UW ShCu scheme and 
+  ! adapted for use here.
+  !
+  ! If qc < qcmin, qi < qimin, or qv < qvmin happens in any layer,
+  ! force them to be larger than minimum value by (1) condensating 
+  ! water vapor into liquid or ice, and (2) by transporting water vapor 
+  ! from the very lower layer.
+  ! 
+  ! We then update the final state variables and tendencies associated
+  ! with this correction. If any condensation happens, update theta too.
+  ! Note that (qv,qc,qi,th) are the final state variables after
+  ! applying corresponding input tendencies and corrective tendencies.
+
+    implicit none
+    integer,         intent(in)     :: kte
+    real(kind_phys), intent(in)     :: delt
+    real(kind_phys), dimension(kte), intent(in)     :: dp, exner
+    real(kind_phys), dimension(kte), intent(inout)  :: qv, qc, qi, qs, th
+    real(kind_phys), dimension(kte), intent(inout)  :: dqv, dqc, dqi, dqs, dth
+    integer   k
+    real(kind_phys)::  dqc2, dqi2, dqs2, dqv2, sum, aa, dum
+    real(kind_phys), parameter :: qvmin = 1e-20,       &
+                                  qcmin = 0.0,         &
+                                  qimin = 0.0
+
+    do k = kte, 1, -1  ! From the top to the surface
+       dqc2 = max(0.0, qcmin-qc(k)) !qc deficit (>=0)
+       dqi2 = max(0.0, qimin-qi(k)) !qi deficit (>=0)
+       dqs2 = max(0.0, qimin-qs(k)) !qs deficit (>=0)
+
+       !fix tendencies
+       dqc(k) = dqc(k) +  dqc2/delt
+       dqi(k) = dqi(k) +  dqi2/delt
+       dqs(k) = dqs(k) +  dqs2/delt
+       dqv(k) = dqv(k) - (dqc2+dqi2+dqs2)/delt
+       dth(k) = dth(k) + xlvcp/exner(k)*(dqc2/delt) + &
+                         xlscp/exner(k)*((dqi2+dqs2)/delt)
+       !update species
+       qc(k)  = qc(k)  +  dqc2
+       qi(k)  = qi(k)  +  dqi2
+       qs(k)  = qs(k)  +  dqs2
+       qv(k)  = qv(k)  -  dqc2 - dqi2 - dqs2
+       th(k)  = th(k)  +  xlvcp/exner(k)*dqc2 + &
+                          xlscp/exner(k)*(dqi2+dqs2)
+
+       !then fix qv
+       dqv2   = max(0.0, qvmin-qv(k)) !qv deficit (>=0)
+       dqv(k) = dqv(k) + dqv2/delt
+       qv(k)  = qv(k)  + dqv2
+       if( k .ne. 1 ) then
+           qv(k-1)   = qv(k-1)  - dqv2*dp(k)/dp(k-1)
+           dqv(k-1)  = dqv(k-1) - dqv2*dp(k)/dp(k-1)/delt
+       endif
+       qv(k) = max(qv(k),qvmin)
+       qc(k) = max(qc(k),qcmin)
+       qi(k) = max(qi(k),qimin)
+       qs(k) = max(qs(k),qimin)
+    end do
+    ! Extra moisture used to satisfy 'qv(1)>=qvmin' is proportionally
+    ! extracted from all the layers that has 'qv > 2*qvmin'. This fully
+    ! preserves column moisture.
+    if( dqv2 .gt. 1.e-20 ) then
+        sum = 0.0
+        do k = 1, kte
+           if( qv(k) .gt. 2.0*qvmin ) sum = sum + qv(k)*dp(k)
+        enddo
+        aa = dqv2*dp(1)/max(1.e-20,sum)
+        if( aa .lt. 0.5 ) then
+            do k = 1, kte
+               if( qv(k) .gt. 2.0*qvmin ) then
+                   dum    = aa*qv(k)
+                   qv(k)  = qv(k) - dum
+                   dqv(k) = dqv(k) - dum/delt
+               endif
+            enddo
+        else
+        ! For testing purposes only (not yet found in any output):
+        !    write(*,*) 'Full moisture conservation is impossible'
+        endif
+    endif
+
+    return
+
+  END SUBROUTINE moisture_check
+
+! ==================================================================
+
+  SUBROUTINE mynn_mix_chem(kts,kte,i,     &
+       delt,dz,pblh,                      &
+       nchem, kdvel, ndvel,               &
+       chem1, vd1,                        &
+       rho,                               &
+       flt, tcd, qcd,                     &
+       dfh,                               &
+       s_aw, s_awchem,                    &
+       emis_ant_no, frp, rrfs_sd,         &
+       enh_mix, smoke_dbg                 )
+
+!-------------------------------------------------------------------
+    integer, intent(in) :: kts,kte,i
+    real(kind_phys), dimension(kts:kte), intent(in) :: dfh,dz,tcd,qcd
+    real(kind_phys), dimension(kts:kte), intent(in) :: rho
+    real(kind_phys), intent(in)    :: flt
+    real(kind_phys), intent(in)    :: delt,pblh
+    integer, intent(in) :: nchem, kdvel, ndvel
+    real(kind_phys), dimension( kts:kte+1), intent(in) :: s_aw
+    real(kind_phys), dimension( kts:kte, nchem ), intent(inout) :: chem1
+    real(kind_phys), dimension( kts:kte+1,nchem), intent(in) :: s_awchem
+    real(kind_phys), dimension( ndvel ), intent(in) :: vd1
+    real(kind_phys), intent(in) :: emis_ant_no,frp
+    logical, intent(in) :: rrfs_sd,enh_mix,smoke_dbg
+!local vars
+
+    real(kind_phys), dimension(kts:kte)     :: dtz
+    real(kind_phys), dimension(kts:kte) :: a,b,c,d,x
+    real(kind_phys):: rhs,dztop
+    real(kind_phys):: t,dzk
+    real(kind_phys):: hght 
+    real(kind_phys):: khdz_old, khdz_back
+    integer :: k,kk,kmaxfire                         ! JLS 12/21/21
+    integer :: ic  ! Chemical array loop index
+    
+    integer, SAVE :: icall
+
+    real(kind_phys), dimension(kts:kte) :: rhoinv
+    real(kind_phys), dimension(kts:kte+1) :: rhoz,khdz
+    real(kind_phys), parameter :: NO_threshold    = 10.0     ! For anthropogenic sources
+    real(kind_phys), parameter :: frp_threshold   = 10.0     ! RAR 02/11/22: I increased the frp threshold to enhance mixing over big fires
+    real(kind_phys), parameter :: pblh_threshold  = 100.0
+
+    dztop=.5*(dz(kte)+dz(kte-1))
+
+    DO k=kts,kte
+       dtz(k)=delt/dz(k)
+    ENDDO
+
+    !Prepare "constants" for diffusion equation.
+    !khdz = rho*Kh/dz = rho*dfh
+    rhoz(kts)  =rho(kts)
+    rhoinv(kts)=1./rho(kts)
+    khdz(kts)  =rhoz(kts)*dfh(kts)
+
+    DO k=kts+1,kte
+       rhoz(k)  =(rho(k)*dz(k-1) + rho(k-1)*dz(k))/(dz(k-1)+dz(k))
+       rhoz(k)  =  MAX(rhoz(k),1E-4)
+       rhoinv(k)=1./MAX(rho(k),1E-4)
+       dzk      = 0.5  *( dz(k)+dz(k-1) )
+       khdz(k)  = rhoz(k)*dfh(k)
+    ENDDO
+    rhoz(kte+1)=rhoz(kte)
+    khdz(kte+1)=rhoz(kte+1)*dfh(kte)
+
+    !stability criteria for mf
+    DO k=kts+1,kte-1
+       khdz(k) = MAX(khdz(k),  0.5*s_aw(k))
+       khdz(k) = MAX(khdz(k), -0.5*(s_aw(k)-s_aw(k+1)))
+    ENDDO
+
+    !Enhanced mixing over fires
+    IF ( rrfs_sd .and. enh_mix ) THEN
+       DO k=kts+1,kte-1
+          khdz_old  = khdz(k)
+          khdz_back = pblh * 0.15 / dz(k)
+          !Modify based on anthropogenic emissions of NO and FRP
+          IF ( pblh < pblh_threshold ) THEN
+             IF ( emis_ant_no > NO_threshold ) THEN
+                khdz(k) = MAX(1.1*khdz(k),sqrt((emis_ant_no / NO_threshold)) / dz(k) * rhoz(k)) ! JLS 12/21/21
+!                khdz(k) = MAX(khdz(k),khdz_back)
+             ENDIF
+             IF ( frp > frp_threshold ) THEN
+                kmaxfire = ceiling(log(frp))
+                khdz(k) = MAX(1.1*khdz(k), (1. - k/(kmaxfire*2.)) * ((log(frp))**2.- 2.*log(frp)) / dz(k)*rhoz(k)) ! JLS 12/21/21
+!                khdz(k) = MAX(khdz(k),khdz_back)
+             ENDIF
+          ENDIF
+       ENDDO
+    ENDIF
+
+  !============================================
+  ! Patterned after mixing of water vapor in mynn_tendencies.
+  !============================================
+
+    DO ic = 1,nchem
+       k=kts
+
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
+       b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)           - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)
+       d(k)=chem1(k,ic) & !dtz(k)*flt  !neglecting surface sources 
+            & - dtz(k)*vd1(ic)*chem1(k,ic) &
+            & - dtz(k)*rhoinv(k)*s_awchem(k+1,ic)
+
+       DO k=kts+1,kte-1
+          a(k)=  -dtz(k)*khdz(k)*rhoinv(k)     + 0.5*dtz(k)*rhoinv(k)*s_aw(k)
+          b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))*rhoinv(k) + &
+             &    0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))
+          c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)
+          d(k)=chem1(k,ic) + dtz(k)*rhoinv(k)*(s_awchem(k,ic)-s_awchem(k+1,ic))
+       ENDDO
+
+      ! prescribed value at top
+       a(kte)=0.
+       b(kte)=1.
+       c(kte)=0.
+       d(kte)=chem1(kte,ic)
+
+       CALL tridiag3(kte,a,b,c,d,x)
+
+       DO k=kts,kte
+          chem1(k,ic)=x(k)
+       ENDDO
+    ENDDO
+
+  END SUBROUTINE mynn_mix_chem
+
+! ==================================================================
+!>\ingroup gsd_mynn_edmf
+  SUBROUTINE retrieve_exchange_coeffs(kts,kte,dfm,dfh,dz,km1,kh1)
 
 !-------------------------------------------------------------------
 
-    INTEGER , INTENT(in) :: kts,kte
+    integer , intent(in) :: kts,kte
 
-    REAL, DIMENSION(KtS:KtE), INTENT(in) :: dz,dfm,dfh,dfq
-
-    REAL, DIMENSION(KtS:KtE), INTENT(out) :: &
-         &K_m, K_h, K_q
+    real(kind_phys), dimension(kts:kte), intent(in)  :: dz,dfm,dfh
+    real(kind_phys), dimension(kts:kte), intent(out) :: km1, kh1
 
 
-    INTEGER :: k
-    REAL :: dzk
+    integer :: k
+    real(kind_phys):: dzk
 
-    K_m(kts)=0.
-    K_h(kts)=0.
-    K_q(kts)=0.
+    km1(kts)=0.
+    kh1(kts)=0.
 
-    DO k=kts+1,kte
-       dzk = 0.5  *( dz(k)+dz(k-1) )
-       K_m(k)=dfm(k)*dzk
-       K_h(k)=dfh(k)*dzk
-       K_q(k)=dfq(k)*dzk
-    ENDDO
+    do k=kts+1,kte
+       dzk   = 0.5 *( dz(k)+dz(k-1) )
+       km1(k)=dfm(k)*dzk
+       kh1(k)=dfh(k)*dzk
+    enddo
+
+!    km1(kte+1)=0.
+!    kh1(kte+1)=0.
 
   END SUBROUTINE retrieve_exchange_coeffs
 
 ! ==================================================================
+!>\ingroup gsd_mynn_edmf
   SUBROUTINE tridiag(n,a,b,c,d)
 
 !! to solve system of linear eqs on tridiagonal matrix n times n
@@ -2391,13 +5245,13 @@ ENDIF
     
 !-------------------------------------------------------------------
 
-    INTEGER, INTENT(in):: n
-    REAL, DIMENSION(n), INTENT(in) :: a,b
-    REAL, DIMENSION(n), INTENT(inout) :: c,d
+    integer, intent(in):: n
+    real(kind_phys), dimension(n), intent(in) :: a,b
+    real(kind_phys), dimension(n), intent(inout) :: c,d
     
-    INTEGER :: i
-    REAL :: p
-    REAL, DIMENSION(n) :: q
+    integer :: i
+    real(kind_phys):: p
+    real(kind_phys), dimension(n) :: q
     
     c(n)=0.
     q(1)=-c(1)/b(1)
@@ -2416,527 +5270,100 @@ ENDIF
   END SUBROUTINE tridiag
 
 ! ==================================================================
-  SUBROUTINE mynn_bl_driver(&
-       &initflag,&
-       &grav_settling,&
-       &delt,&
-       &dz,&
-       &u,v,th,qv,qc,qi,qni,&! qnc&       !JOE: ice & num conc mixing
-       &p,exner,rho,&
-       &xland,ts,qsfc,qcg,ps,&
-       &ust,ch,hfx,qfx,rmol,wspd,&
-       &uoce,voce,&                     !ocean current
-       &vdfg,&                          !Katata-added for fog dep
-       &Qke,tke_pbl,&                   !JOE: add TKE for coupling
-       &qke_adv,bl_mynn_tkeadvect,&     !ACF for QKE advection
-       &Tsq,Qsq,Cov,&
-       &Du,Dv,Dth,&
-       &Dqv,Dqc,Dqi,Dqni,& !Dqnc,&         !JOE: ice & nim conc mixing
-       &K_m,K_h,K_q,&
-!      &K_h,k_m,&
-       &Pblh,kpbl&                      !JOE-added kpbl for coupling
-       &,el_pbl&
-       &,dqke,qWT,qSHEAR,qBUOY,qDISS    & !JOE-TKE BUDGET
-       &,wstar,delta                    & !JOE-added for grims
-       &,bl_mynn_tkebudget              & !JOE-TKE BUDGET
-       &,bl_mynn_cloudpdf,Sh3D          & !JOE-cloudPDF testing
-       ! optional arguments
-       &,FLAG_QI,FLAG_QNI,FLAG_QC,FLAG_QNC &
-       &,IDS,IDE,JDS,JDE,KDS,KDE        &
-       &,IMS,IME,JMS,JME,KMS,KME        &
-       &,ITS,ITE,JTS,JTE,KTS,KTE)
-    
-!-------------------------------------------------------------------
+!>\ingroup gsd_mynn_edmf
+      subroutine tridiag2(kte,a,b,c,d,x)
+      implicit none
+!      a - sub-diagonal (means it is the diagonal below the main diagonal)
+!      b - the main diagonal
+!      c - sup-diagonal (means it is the diagonal above the main diagonal)
+!      d - right part
+!      x - the answer
+!      kte - number of unknowns (levels)
 
-    INTEGER, INTENT(in) :: initflag
-    !INPUT NAMELIST OPTIONS:
-    INTEGER, INTENT(in) :: grav_settling
-    INTEGER, INTENT(in) :: bl_mynn_tkebudget
-    INTEGER, INTENT(in) :: bl_mynn_cloudpdf
-    LOGICAL, INTENT(IN) :: bl_mynn_tkeadvect
+        integer,intent(in) :: kte
+        real(kind_phys), dimension(kte), intent(in) :: a,b,c,d
+        real(kind_phys), dimension(kte), intent(out):: x
+        real(kind_phys), dimension(kte)  :: cp,dp
+        real(kind_phys):: m
+        integer :: k
 
-    LOGICAL, INTENT(IN) :: FLAG_QI,FLAG_QNI,FLAG_QC,FLAG_QNC
-    
-    INTEGER,INTENT(IN) :: &
-         & IDS,IDE,JDS,JDE,KDS,KDE &
-         &,IMS,IME,JMS,JME,KMS,KME &
-         &,ITS,ITE,JTS,JTE,KTS,KTE
-    
+        ! initialize c-prime and d-prime
+        cp(1) = c(1)/b(1)
+        dp(1) = d(1)/b(1)
+        ! solve for vectors c-prime and d-prime
+        do k = 2,kte
+           m = b(k)-cp(k-1)*a(k)
+           cp(k) = c(k)/m
+           dp(k) = (d(k)-dp(k-1)*a(k))/m
+        enddo
+        ! initialize x
+        x(kte) = dp(kte)
+        ! solve for x from the vectors c-prime and d-prime
+        do k = kte-1, 1, -1
+           x(k) = dp(k)-cp(k)*x(k+1)
+        end do
 
-! initflag > 0  for TRUE
-! else        for FALSE
-!       levflag         : <>3;  Level 2.5
-!                         = 3;  Level 3
-! grav_settling = 1 when gravitational settling accounted for
-! grav_settling = 0 when gravitational settling NOT accounted for
-    
-    REAL, INTENT(in) :: delt
-    REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), INTENT(in) :: dz,&
-         &u,v,th,qv,qc,p,exner,rho
-    REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), OPTIONAL, INTENT(in)::&
-         &qi,qni! ,qnc
-    REAL, DIMENSION(IMS:IME,JMS:JME), INTENT(in) :: xland,ust,&
-!         &ch,rmol,ts,qsfc,qcg,ps,hfx,qfx, wspd,uoce,voce
-!Katata-added for extra in-output
-         &ch,rmol,ts,qsfc,qcg,ps,hfx,qfx, wspd,uoce,voce, vdfg
-!Katata-end
-
-    REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), INTENT(inout) :: &
-         &Qke,Tsq,Qsq,Cov, &
-         &tke_pbl, & !JOE-added for coupling (TKE_PBL = QKE/2)
-         &qke_adv    !ACF for QKE advection
-
-    REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), INTENT(inout) :: &
-         &Du,Dv,Dth,Dqv,Dqc,Dqi,Dqni!,Dqnc
-
-    REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), INTENT(out) :: &
-         &K_h,K_m
-
-    REAL, DIMENSION(IMS:IME,JMS:JME), INTENT(inout) :: &
-         &Pblh,wstar,delta  !JOE-added for GRIMS
-    INTEGER,DIMENSION(IMS:IME,JMS:JME),INTENT(INOUT) :: & 
-         &KPBL
-    
-    REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), INTENT(inout) :: &
-         &el_pbl
-
-!JOE-TKE BUDGET
-    REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), INTENT(out) :: &
-         &qWT,qSHEAR,qBUOY,qDISS,dqke
-    ! 3D budget arrays are not allocated when bl_mynn_tkebudget == 0.
-    ! 1D (local) budget arrays are used for passing between subroutines.
-    REAL, DIMENSION(KTS:KTE) :: qWT1,qSHEAR1,qBUOY1,qDISS1,dqke1
-!JOE-end
-    REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME) :: K_q,Sh3D
-
-!local vars
-    INTEGER :: ITF,JTF,KTF, IMD,JMD
-    INTEGER :: i,j,k
-    REAL, DIMENSION(KTS:KTE) :: thl,sqv,sqc,sqi,sqw,&
-         &El, Dfm, Dfh, Dfq, Tcd, Qcd, Pdk, Pdt, Pdq, Pdc, Vt, Vq
-
-    REAL, DIMENSION(KTS:KTE) :: thetav,sh,u1,v1,p1,ex1,dz1,th1,qke1, &
-           & tsq1,qsq1,cov1,qv1,qi1,qc1,du1,dv1,dth1,dqv1,dqc1,dqi1, &
-           & k_m1,k_h1,k_q1,qni1,dqni1!,qnc1,dqnc1
-
-    REAL, DIMENSION(KTS:KTE+1) :: zw
-    
-      REAL :: cpm,sqcg,flt,flq,flqv,flqc,pmz,phh,exnerg,zet,& 
-              &afk,abk
-!JOE-add GRIMS parameters & variables
-   real,parameter    ::  d1 = 0.02, d2 = 0.05, d3 = 0.001
-   real,parameter    ::  h1 = 0.33333335, h2 = 0.6666667
-   REAL :: govrth, sflux, bfx0, wstar3, wm2, wm3, delb
-!JOE-end GRIMS
-    INTEGER, SAVE :: levflag
-
-!***  Begin debugging
-    IMD=(IMS+IME)/2
-    JMD=(JMS+JME)/2
-!***  End debugging 
-
-    JTF=MIN0(JTE,JDE-1)
-    ITF=MIN0(ITE,IDE-1)
-    KTF=MIN0(KTE,KDE-1)
-
-    levflag=mynn_level
-
-    IF (initflag > 0) THEN
-!      write(0,*)
-!      write(0,*) '--- bl_mynn initflag = ', initflag
-!      write(0,*) '--- bl_mynn mynn_level = ', levflag
-!      write(0,*) '--- initialize sh3d, el_pbl, tsq, qsq, cov'
-!      write(0,*)
-       Sh3D(its:ite,kts:kte,jts:jte)=0.
-       el_pbl(its:ite,kts:kte,jts:jte)=0.
-       tsq(its:ite,kts:kte,jts:jte)=0.
-       qsq(its:ite,kts:kte,jts:jte)=0.
-       cov(its:ite,kts:kte,jts:jte)=0.
-
-       DO j=JTS,JTF
-          DO i=ITS,ITF
-             DO k=KTS,KTF
-                dz1(k)=dz(i,k,j)
-                u1(k) = u(i,k,j)
-                v1(k) = v(i,k,j)
-                th1(k)=th(i,k,j)
-                sqc(k)=qc(i,k,j)/(1.+qc(i,k,j))
-                sqv(k)=qv(i,k,j)/(1.+qv(i,k,j))
-                thetav(k)=th(i,k,j)*(1.+0.61*sqv(k))
-                IF (PRESENT(qi) .AND. FLAG_QI ) THEN
-                   sqi(k)=qi(i,k,j)/(1.+qi(i,k,j))
-                   sqw(k)=sqv(k)+sqc(k)+sqi(k)
-                   thl(k)=th(i,k,j)- xlvcp/exner(i,k,j)*sqc(k) &
-                       &           - xlscp/exner(i,k,j)*sqi(k)
-                ELSE
-                   sqi(k)=0.0
-                   sqw(k)=sqv(k)+sqc(k)
-                   thl(k)=th(i,k,j)-xlvcp/exner(i,k,j)*sqc(k)
-                ENDIF
-
-                IF (k==kts) THEN
-                   zw(k)=0.
-                ELSE
-                   zw(k)=zw(k-1)+dz(i,k-1,j)
-                ENDIF
-
-                k_m(i,k,j)=0.
-                k_h(i,k,j)=0.
-                k_q(i,k,j)=0.
-                qke(i,k,j)=0.1-MIN(zw(k)*0.001, 0.0)
-                qke1(k)=qke(i,k,j)
-                el(k)=el_pbl(i,k,j)
-                sh(k)=Sh3D(i,k,j)
-                tsq1(k)=tsq(i,k,j)
-                qsq1(k)=qsq(i,k,j)
-                cov1(k)=cov(i,k,j)
-
-                IF ( bl_mynn_tkebudget == 1) THEN
-                   !TKE BUDGET VARIABLES
-                   qWT(i,k,j)=0.
-                   qSHEAR(i,k,j)=0.
-                   qBUOY(i,k,j)=0.
-                   qDISS(i,k,j)=0.
-                   dqke(i,k,j)=0.
-                ENDIF
-             ENDDO
-
-             zw(kte+1)=zw(kte)+dz(i,kte,j)
-             
-             CALL GET_PBLH(KTS,KTE,PBLH(i,j),thetav,&
-               &  Qke1,zw,dz1,xland(i,j),KPBL(i,j))
-
-             CALL mym_initialize ( kts,kte,&
-                  &dz1, zw, u1, v1, thl, sqv,&
-                  &PBLH(i,j),th1,&                      !JOE-BouLac mod
-                  &sh,&                                 !JOE-cloudPDF mod
-                  &ust(i,j), rmol(i,j),&
-                  &el, Qke1, Tsq1, Qsq1, Cov1)
-
-             !UPDATE 3D VARIABLES
-             DO k=KTS,KTE !KTF
-                el_pbl(i,k,j)=el(k)
-                sh3d(i,k,j)=sh(k)
-                qke(i,k,j)=qke1(k)
-                tsq(i,k,j)=tsq1(k)
-                qsq(i,k,j)=qsq1(k)
-                cov(i,k,j)=cov1(k)
-!ACF,JOE- initialize qke_adv array if using advection
-                IF (bl_mynn_tkeadvect) THEN
-                   qke_adv(i,k,j)=qke1(k)
-                ENDIF
-!ACF,JOE-end                
-             ENDDO
-
-!***  Begin debugging
-!             k=kdebug
-!             IF(I==IMD .AND. J==JMD)THEN
-!               PRINT*,"MYNN DRIVER INIT: k=",1," sh=",sh(k)
-!               PRINT*," sqw=",sqw(k)," thl=",thl(k)," k_m=",k_m(i,k,j)
-!               PRINT*," xland=",xland(i,j)," rmol=",rmol(i,j)," ust=",ust(i,j)
-!               PRINT*," qke=",qke(i,k,j)," el=",el_pbl(i,k,j)," tsq=",Tsq(i,k,j)
-!               PRINT*," PBLH=",PBLH(i,j)," u=",u(i,k,j)," v=",v(i,k,j)
-!             ENDIF
-!***  End debugging
-
-          ENDDO
-       ENDDO
-
-    ENDIF ! end initflag
-
-!ACF copy qke_adv array into qke if using advection
-    IF (bl_mynn_tkeadvect) THEN
-       qke=qke_adv
-    ENDIF
-!ACF-end
-
-    DO j=JTS,JTF
-       DO i=ITS,ITF
-          DO k=KTS,KTF
-             !JOE-TKE BUDGET
-             IF ( bl_mynn_tkebudget == 1) THEN
-                dqke(i,k,j)=qke(i,k,j)
-             END IF
-             dz1(k)= dz(i,k,j)
-             u1(k) = u(i,k,j)
-             v1(k) = v(i,k,j)
-             th1(k)= th(i,k,j)
-             qv1(k)= qv(i,k,j)
-             qc1(k)= qc(i,k,j)
-             sqv(k)= qv(i,k,j)/(1.+qv(i,k,j))
-             sqc(k)= qc(i,k,j)/(1.+qc(i,k,j))
-             IF(PRESENT(qi) .AND. FLAG_QI)THEN
-                qi1(k)= qi(i,k,j)
-                sqi(k)= qi(i,k,j)/(1.+qi(i,k,j))
-                sqw(k)= sqv(k)+sqc(k)+sqi(k)
-                thl(k)= th(i,k,j) - xlvcp/exner(i,k,j)*sqc(k) &
-                     &            - xlscp/exner(i,k,j)*sqi(k)
-                !print*,"MYNN: Flag_qi=",FLAG_QI,qi(i,k,j)
-             ELSE
-                qi1(k)=0.0
-                sqi(k)=0.0
-                sqw(k)= sqv(k)+sqc(k)
-                thl(k)= th(i,k,j)-xlvcp/exner(i,k,j)*sqc(k)
-             ENDIF
-             IF (PRESENT(qni) .AND. FLAG_QNI ) THEN
-                qni1(k)=qni(i,k,j)
-                !print*,"MYNN: Flag_qni=",FLAG_QNI,qni(i,k,j)
-             ELSE
-                qni1(k)=0.0
-             ENDIF
-             !IF (PRESENT(qnc) .AND. FLAG_QNC ) THEN
-             !   qnc1(k)=qnc(i,k,j)
-             !   !print*,"MYNN: Flag_qnc=",FLAG_QNC,qnc(i,k,j)
-             !ELSE
-             !   qnc1(k)=0.0
-             !ENDIF
-             thetav(k)=th(i,k,j)*(1.+0.608*sqv(k))
-             p1(k) = p(i,k,j)
-             ex1(k)= exner(i,k,j)
-             el(k) = el_pbl(i,k,j)
-             qke1(k)=qke(i,k,j)
-             sh(k) = sh3d(i,k,j)
-             tsq1(k)=tsq(i,k,j)
-             qsq1(k)=qsq(i,k,j)
-             cov1(k)=cov(i,k,j)
-
-             IF (k==kts) THEN
-                zw(k)=0.
-             ELSE
-                zw(k)=zw(k-1)+dz(i,k-1,j)
-             ENDIF
-          ENDDO
-
-          zw(kte+1)=zw(kte)+dz(i,kte,j)          
-          
-          CALL GET_PBLH(KTS,KTE,PBLH(i,j),thetav,&
-          & Qke1,zw,dz1,xland(i,j),KPBL(i,j))
-          
-          sqcg= 0.0   !JOE, it was: qcg(i,j)/(1.+qcg(i,j))
-          cpm=cp*(1.+0.84*qv(i,kts,j))
-          exnerg=(ps(i,j)/p1000mb)**rcp
-
-          !-----------------------------------------------------
-          !ORIGINAL CODE
-          !flt = hfx(i,j)/( rho(i,kts,j)*cpm ) &
-          ! +xlvcp*ch(i,j)*(sqc(kts)/exner(i,kts,j) -sqcg/exnerg)
-          !flq = qfx(i,j)/  rho(i,kts,j)       &
-          !    -ch(i,j)*(sqc(kts)   -sqcg )
-          !-----------------------------------------------------
-          ! Katata-added - The deposition velocity of cloud (fog) 
-          ! water is used instead of CH.
-          flt = hfx(i,j)/( rho(i,kts,j)*cpm ) &
-            & +xlvcp*vdfg(i,j)*(sqc(kts)/exner(i,kts,j)- sqcg/exnerg)
-          flq = qfx(i,j)/  rho(i,kts,j)       &
-            & -vdfg(i,j)*(sqc(kts) - sqcg )
-          flqv = qfx(i,j)/rho(i,kts,j)
-          flqc = -vdfg(i,j)*(sqc(kts) - sqcg )
-
-          zet = 0.5*dz(i,kts,j)*rmol(i,j)
-          if ( zet >= 0.0 ) then
-            pmz = 1.0 + (cphm_st-1.0) * zet
-            phh = 1.0 +  cphh_st      * zet
-          else
-            pmz = 1.0/    (1.0-cphm_unst*zet)**0.25 - zet
-            phh = 1.0/SQRT(1.0-cphh_unst*zet)
-          end if
-
-!!!!! estimate wstar & delta for GRIMS shallow-cu
-          govrth = g/th1(kts)
-          sflux = hfx(i,j)/rho(i,kts,j)/cpm + &
-                  qfx(i,j)/rho(i,kts,j)*ep_1*th1(kts)
-          bfx0 = max(sflux,0.)
-          wstar3     = (govrth*bfx0*pblh(i,j))
-          wstar(i,j) = wstar3**h1
-          wm3        = wstar3 + 5.*ust(i,j)**3.
-          wm2        = wm3**h2
-          delb       = govrth*d3*pblh(i,j)
-          delta(i,j) = min(d1*pblh(i,j) + d2*wm2/delb, 100.)
-!!!!! end GRIMS
-
-          CALL  mym_condensation ( kts,kte,&
-               &dz1,thl,sqw,p1,ex1, &
-               &tsq1, qsq1, cov1, &
-               &Sh,el,bl_mynn_cloudpdf, & !JOE-added for cloud PDF testing (from Kuwano-Yoshida et al. 2010)
-               &Vt, Vq)
-
-          CALL mym_turbulence ( kts,kte,levflag, &
-               &dz1, zw, u1, v1, thl, sqc, sqw, &
-               &qke1, tsq1, qsq1, cov1, &
-               &vt, vq,&
-               &rmol(i,j), flt, flq, &
-               &PBLH(i,j),th1,&                  !JOE-BouLac mod
-               &Sh,&                             !JOE-cloudPDF mod
-               &el,&  
-               &Dfm,Dfh,Dfq, &
-               &Tcd,Qcd,Pdk, &
-               &Pdt,Pdq,Pdc &
-               &,qWT1,qSHEAR1,qBUOY1,qDISS1  &   !JOE-TKE BUDGET
-               &,bl_mynn_tkebudget           &   !JOE-TKE BUDGET
-               &)
-
-          CALL mym_predict (kts,kte,levflag,  &
-               &delt, dz1, &
-               &ust(i,j), flt, flq, pmz, phh, &
-               &el, dfq, pdk, pdt, pdq, pdc, &
-               &Qke1, Tsq1, Qsq1, Cov1)
-
-          CALL mynn_tendencies(kts,kte,&
-               &levflag,grav_settling,&
-               &delt, dz1,&
-               &u1, v1, th1, qv1, qc1, qi1, qni1,&! qnc1,&
-               &p1, ex1, thl, sqv, sqc, sqi, sqw,&
-               &ust(i,j),flt,flq,flqv,flqc,wspd(i,j),qcg(i,j),&
-               &uoce(i,j),voce(i,j),&
-               &tsq1, qsq1, cov1,&
-               &tcd, qcd, &
-               &dfm, dfh, dfq,&
-               &Du1, Dv1, Dth1, Dqv1, Dqc1, Dqi1, Dqni1& !, Dqnc1&
-               &,vdfg(i,j)&                 !JOE/Katata- fog deposition
-               &,FLAG_QI,FLAG_QNI,FLAG_QC,FLAG_QNC &
-               &)
-
-                !print*,"MYNN: qi_ten, qni_ten=",Dqi1(4),Dqni1(4)
-                !print*,"MYNN: qc_ten, qnc_ten=",Dqc1(4),Dqnc1(4)
-
-          CALL retrieve_exchange_coeffs(kts,kte,&
-               &dfm, dfh, dfq, dz1,&
-               &K_m1, K_h1, K_q1)
-
-          !UPDATE 3D ARRAYS
-          DO k=KTS,KTF
-             K_m(i,k,j)=K_m1(k)
-             K_h(i,k,j)=K_h1(k)
-             K_q(i,k,j)=K_q1(k)
-             du(i,k,j)=du1(k)
-             dv(i,k,j)=dv1(k)
-             dth(i,k,j)=dth1(k)
-             dqv(i,k,j)=dqv1(k)
-             dqc(i,k,j)=dqc1(k)
-             IF (PRESENT(qi) .AND. FLAG_QI) dqi(i,k,j)=dqi1(k)
-             !IF (PRESENT(qnc) .AND. FLAG_QNC) dqnc(i,k,j)=dqnc1(k)
-             IF (PRESENT(qni) .AND. FLAG_QNI) dqni(i,k,j)=dqni1(k)
-             el_pbl(i,k,j)=el(k)
-             qke(i,k,j)=qke1(k)
-             tsq(i,k,j)=tsq1(k)
-             qsq(i,k,j)=qsq1(k)
-             cov(i,k,j)=cov1(k)
-             sh3d(i,k,j)=sh(k)
-             IF ( bl_mynn_tkebudget == 1) THEN
-                dqke(i,k,j)  = (qke1(k)-dqke(i,k,j))*0.5  !qke->tke
-                qWT(i,k,j)   = qWT1(k)*delt
-                qSHEAR(i,k,j)= qSHEAR1(k)*delt
-                qBUOY(i,k,j) = qBUOY1(k)*delt
-                qDISS(i,k,j) = qDISS1(k)*delt
-             ENDIF
-             !***  Begin debugging
-!             IF ( sh(k) < 0. .OR. sh(k)> 200. .OR. &
-!                & qke(i,k,j) < -5. .OR. qke(i,k,j)> 200. .OR. &
-!                & el_pbl(i,k,j) < 0. .OR. el_pbl(i,k,j)> 2000. .OR. &
-!                & ABS(vt(k)) > 0.8 .OR. ABS(vq(k)) > 1100. .OR. &
-!                & k_m(i,k,j) < 0. .OR. k_m(i,k,j)> 2000. .OR. &
-!                & vdfg(i,j) < 0. .OR. vdfg(i,j)>5. ) THEN
-!                  PRINT*,"SUSPICIOUS VALUES AT: k=",k," sh=",sh(k)
-!                  PRINT*," sqw=",sqw(k)," thl=",thl(k)," k_m=",k_m(i,k,j)
-!                  PRINT*," xland=",xland(i,j)," rmol=",rmol(i,j)," ust=",ust(i,j)
-!                  PRINT*," qke=",qke(i,k,j)," el=",el_pbl(i,k,j)," tsq=",tsq(i,k,j)
-!                  PRINT*," PBLH=",PBLH(i,j)," u=",u(i,k,j)," v=",v(i,k,j)
-!                  PRINT*," vq=",vq(k)," vt=",vt(k)," vdfg=",vdfg(i,j)
-!             ENDIF
-             !***  End debugging
-          ENDDO
-!JOE-add tke_pbl for coupling w/shallow-cu schemes (TKE_PBL = QKE/2.)
-!    TKE_PBL is defined on interfaces, while QKE is at middle of layer.
-          tke_pbl(i,kts,j) = 0.5*MAX(qke(i,kts,j),1.0e-10)
-          DO k = kts+1,kte
-             afk = dz1(k)/( dz1(k)+dz1(k-1) )
-             abk = 1.0 -afk
-             tke_pbl(i,k,j) = 0.5*MAX(qke(i,k,j)*abk+qke(i,k-1,j)*afk,1.0e-3)
-          ENDDO
-!JOE-end tke_pbl
-!JOE-end addition
-
-!***  Begin debugging
-!          IF(I==IMD .AND. J==JMD)THEN
-!             k=kdebug
-!             PRINT*,"MYNN DRIVER END: k=",1," sh=",sh(k)
-!             PRINT*," sqw=",sqw(k)," thl=",thl(k)," k_m=",k_m(i,k,j)
-!             PRINT*," xland=",xland(i,j)," rmol=",rmol(i,j)," ust=",ust(i,j)
-!             PRINT*," qke=",qke(i,k,j)," el=",el_pbl(i,k,j)," tsq=",tsq(i,k,j)
-!             PRINT*," PBLH=",PBLH(i,j)," u=",u(i,k,j)," v=",v(i,k,j)
-!             PRINT*," vq=",vq(k)," vt=",vt(k)," vdfg=",vdfg(i,j)
-!          ENDIF
-!***  End debugging
-
-       ENDDO
-    ENDDO
-
-!ACF copy qke into qke_adv if using advection
-    IF (bl_mynn_tkeadvect) THEN
-       qke_adv=qke
-    ENDIF
-!ACF-end
-    
-  END SUBROUTINE mynn_bl_driver
-
-#if !defined(mpas)
+    end subroutine tridiag2
 ! ==================================================================
-  SUBROUTINE mynn_bl_init_driver(&
-       &Du,Dv,Dth,Dqv,Dqc,Dqi                       &
-       !&,Dqnc,Dqni                                  &
-       &,QKE,TKE_PBL,EXCH_H                         &
-       &,RESTART,ALLOWED_TO_READ,LEVEL              &
-       &,IDS,IDE,JDS,JDE,KDS,KDE                    &
-       &,IMS,IME,JMS,JME,KMS,KME                    &
-       &,ITS,ITE,JTS,JTE,KTS,KTE)
+!>\ingroup gsd_mynn_edmf
+       subroutine tridiag3(kte,a,b,c,d,x)
 
-    !---------------------------------------------------------------
-    LOGICAL,INTENT(IN) :: ALLOWED_TO_READ,RESTART
-    INTEGER,INTENT(IN) :: LEVEL
+!ccccccccccccccccccccccccccccccc                                                                   
+! Aim: Inversion and resolution of a tridiagonal matrix                                            
+!          A X = D                                                                                 
+! Input:                                                                                           
+!  a(*) lower diagonal (Ai,i-1)                                                                  
+!  b(*) principal diagonal (Ai,i)                                                                
+!  c(*) upper diagonal (Ai,i+1)                                                                  
+!  d                                                                                               
+! Output                                                                                           
+!  x     results                                                                                   
+!ccccccccccccccccccccccccccccccc                                                                   
 
-    INTEGER,INTENT(IN) :: IDS,IDE,JDS,JDE,KDS,KDE,                    &
-         &                IMS,IME,JMS,JME,KMS,KME,                    &
-         &                ITS,ITE,JTS,JTE,KTS,KTE
-    
-    
-    REAL,DIMENSION(IMS:IME,KMS:KME,JMS:JME),INTENT(INOUT) :: &
-         &Du,Dv,Dth,Dqv,Dqc,Dqi, & !Dqnc,Dqni,
-         &QKE,TKE_PBL,EXCH_H
+       implicit none
+        integer,intent(in)   :: kte
+        integer, parameter   :: kts=1
+        real(kind_phys), dimension(kte) :: a,b,c,d
+        real(kind_phys), dimension(kte), intent(out) :: x
+        integer :: k
 
-    INTEGER :: I,J,K,ITF,JTF,KTF
-    
-    JTF=MIN0(JTE,JDE-1)
-    KTF=MIN0(KTE,KDE-1)
-    ITF=MIN0(ITE,IDE-1)
-    
-    IF(.NOT.RESTART)THEN
-       DO J=JTS,JTF
-          DO K=KTS,KTF
-             DO I=ITS,ITF
-                Du(i,k,j)=0.
-                Dv(i,k,j)=0.
-                Dth(i,k,j)=0.
-                Dqv(i,k,j)=0.
-                if( p_qc >= param_first_scalar ) Dqc(i,k,j)=0.
-                if( p_qi >= param_first_scalar ) Dqi(i,k,j)=0.
-                !if( p_qnc >= param_first_scalar ) Dqnc(i,k,j)=0.
-                !if( p_qni >= param_first_scalar ) Dqni(i,k,j)=0.
-                QKE(i,k,j)=0.
-                TKE_PBL(i,k,j)=0.
-                EXCH_H(i,k,j)=0.
-             ENDDO
-          ENDDO
-       ENDDO
-    ENDIF
+        do k=kte-1,kts,-1
+           d(k)=d(k)-c(k)*d(k+1)/b(k+1)
+           b(k)=b(k)-c(k)*a(k+1)/b(k+1)
+        enddo
 
-    mynn_level=level
+        do k=kts+1,kte
+           d(k)=d(k)-a(k)*d(k-1)/b(k-1)
+        enddo
 
-  END SUBROUTINE mynn_bl_init_driver
+        do k=kts,kte
+           x(k)=d(k)/b(k)
+        enddo
 
-#endif
+        return
+        end subroutine tridiag3
+
 ! ==================================================================
-
-  SUBROUTINE GET_PBLH(KTS,KTE,zi,thetav1D,qke1D,zw1D,dz1D,landsea,kzi)
+!>\ingroup gsd_mynn_edmf
+!! This subroutine calculates hybrid diagnotic boundary-layer height (PBLH).
+!!
+!! NOTES ON THE PBLH FORMULATION: The 1.5-theta-increase method defines
+!!PBL heights as the level at.
+!!which the potential temperature first exceeds the minimum potential.
+!!temperature within the boundary layer by 1.5 K. When applied to.
+!!observed temperatures, this method has been shown to produce PBL-
+!!height estimates that are unbiased relative to profiler-based.
+!!estimates (Nielsen-Gammon et al. 2008 \cite Nielsen_Gammon_2008). 
+!! However, their study did not
+!!include LLJs. Banta and Pichugina (2008) \cite Pichugina_2008  show that a TKE-based.
+!!threshold is a good estimate of the PBL height in LLJs. Therefore,
+!!a hybrid definition is implemented that uses both methods, weighting
+!!the TKE-method more during stable conditions (PBLH < 400 m).
+!!A variable tke threshold (TKEeps) is used since no hard-wired
+!!value could be found to work best in all conditions.
+!>\section gen_get_pblh  GSD get_pblh General Algorithm
+!> @{
+  SUBROUTINE GET_PBLH(KTS,KTE,pblh,thv1,qke1,zw1,dz1,landsea,kpbl)
 
     !---------------------------------------------------------------
     !             NOTES ON THE PBLH FORMULATION
@@ -2955,110 +5382,2410 @@ ENDIF
     !value could be found to work best in all conditions.
     !---------------------------------------------------------------
 
-    INTEGER,INTENT(IN) :: KTS,KTE
-    REAL, INTENT(OUT) :: zi
-    REAL, INTENT(IN) :: landsea
-    REAL, DIMENSION(KTS:KTE), INTENT(IN) :: thetav1D, qke1D, dz1D
-    REAL, DIMENSION(KTS:KTE+1), INTENT(IN) :: zw1D
+    integer,intent(in) :: KTS,KTE
+
+#ifdef HARDCODE_VERTICAL
+# define kts 1
+# define kte HARDCODE_VERTICAL
+#endif
+
+    real(kind_phys), intent(out) :: pblh
+    real(kind_phys), intent(in) :: landsea
+    real(kind_phys), dimension(kts:kte), intent(in) :: thv1, qke1, dz1
+    real(kind_phys), dimension(kts:kte+1), intent(in) :: zw1
     !LOCAL VARS
-    REAL ::  PBLH_TKE,qtke,qtkem1,wt,maxqke,TKEeps,minthv
-    REAL :: delt_thv   !delta theta-v; dependent on land/sea point
-    REAL, PARAMETER :: sbl_lim  = 200. !typical scale of stable BL (m).
-    REAL, PARAMETER :: sbl_damp = 400. !transition length for blending (m).
-    INTEGER :: I,J,K,kthv,ktke,kzi,kzi2
+    real(kind_phys)::  PBLH_TKE,qtke,qtkem1,wt,maxqke,TKEeps,minthv
+    real(kind_phys):: delt_thv   !delta theta-v; dependent on land/sea point
+    real(kind_phys), parameter :: sbl_lim  = 200. !upper limit of stable BL height (m).
+    real(kind_phys), parameter :: sbl_damp = 400. !transition length for blending (m).
+    integer :: I,J,K,kthv,ktke,kpbl
 
-    !ADD KPBL (kzi) for coupling to some Cu schemes, initialize at k=2                                  
-    !kzi2 is the TKE-based part of the hybrid KPBL                                                      
-    kzi = 1
-    kzi2= 1
+    !Initialize kpbl
+    kpbl = 2
 
-    !FIND MAX TKE AND MIN THETAV IN THE LOWEST 500 M
+    !> - FIND MIN THETAV IN THE LOWEST 200 M AGL
     k = kts+1
     kthv = 1
-    ktke = 1
-    maxqke = 0.
     minthv = 9.E9
-    DO WHILE (zw1D(k) .LE. 500.)
-       qtke  =MAX(Qke1D(k),0.)   ! maximum QKE
-       IF (maxqke < qtke) then
-           maxqke = qtke
-           ktke = k
-       ENDIF
-       IF (minthv > thetav1D(k)) then
-           minthv = thetav1D(k)
+    DO WHILE (zw1(k) .LE. 200.)
+    !DO k=kts+1,kte-1
+       IF (minthv > thv1(k)) then
+           minthv = thv1(k)
            kthv = k
        ENDIF
        k = k+1
+       !IF (zw1(k) .GT. sbl_lim) exit
     ENDDO
-    !TKEeps = maxtke/20. = maxqke/40.
-    TKEeps = maxqke/40. 
-    TKEeps = MAX(TKEeps,0.025)
 
-    !FIND THETAV-BASED PBLH (BEST FOR DAYTIME).
-    zi=0.
+    !> - FIND THETAV-BASED PBLH (BEST FOR DAYTIME).
+    pblh=0.
     k = kthv+1
-    IF((landsea-1.5).GE.0)THEN                                            
+    IF((landsea-1.5).GE.0)THEN
         ! WATER
-        delt_thv = 0.75
-    ELSE         
-        ! LAND     
+        delt_thv = 1.0
+    ELSE
+        ! LAND
         delt_thv = 1.25
     ENDIF
 
-    zi=0.
+    pblh=0.
     k = kthv+1
-    DO WHILE (zi .EQ. 0.) 
-       IF (thetav1D(k) .GE. (minthv + delt_thv))THEN
-          kzi = MAX(k-1,1)
-          zi = zw1D(k) - dz1D(k-1)* &
-             & MIN((thetav1D(k)-(minthv + delt_thv))/ &
-             & MAX(thetav1D(k)-thetav1D(k-1),1E-6),1.0)
+!    DO WHILE (pblh .EQ. 0.) 
+    DO k=kts+1,kte-1
+       IF (thv1(k) .GE. (minthv + delt_thv))THEN
+          pblh = zw1(k) - dz1(k-1)* &
+             & MIN((thv1(k)-(minthv + delt_thv))/ &
+             & MAX(thv1(k)-thv1(k-1),1E-6),1.0)
        ENDIF
-       k = k+1
-       IF (k .EQ. kte-1) zi = zw1D(kts+1) !EXIT SAFEGUARD
+       !k = k+1
+       IF (k .EQ. kte-1) pblh = zw1(kts+1) !EXIT SAFEGUARD
+       IF (pblh .NE. 0.0) exit
     ENDDO
-    !print*,"IN GET_PBLH:",thsfc,zi
+    !print*,"IN GET_PBLH:",thsfc,pblh
 
-    !FOR STABLE BOUNDARY LAYERS, USE TKE METHOD TO COMPLEMENT THE
-    !THETAV-BASED DEFINITION (WHEN THE THETA-V BASED PBLH IS BELOW ~0.5 KM).
-    !THE TANH WEIGHTING FUNCTION WILL MAKE THE TKE-BASED DEFINITION NEGLIGIBLE 
-    !WHEN THE THETA-V-BASED DEFINITION IS ABOVE ~1 KM.
-
+    !> - FOR STABLE BOUNDARY LAYERS, USE TKE METHOD TO COMPLEMENT THE
+    !! THETAV-BASED DEFINITION (WHEN THE THETA-V BASED PBLH IS BELOW ~0.5 KM).
+    !!THE TANH WEIGHTING FUNCTION WILL MAKE THE TKE-BASED DEFINITION NEGLIGIBLE 
+    !!WHEN THE THETA-V-BASED DEFINITION IS ABOVE ~1 KM.
+    ktke   = 1
+    maxqke = MAX(qke1(kts),0.)
+    !Use 5% of tke max (Kosovic and Curry, 2000; JAS)
+    !TKEeps = maxtke/20. = maxqke/40.
+    TKEeps = maxqke/40.
+    TKEeps = MAX(TKEeps,0.01) !0.025) 
     PBLH_TKE=0.
+
     k = ktke+1
-    DO WHILE (PBLH_TKE .EQ. 0.) 
+!    DO WHILE (PBLH_TKE .EQ. 0.) 
+    DO k=kts+1,kte-1
        !QKE CAN BE NEGATIVE (IF CKmod == 0)... MAKE TKE NON-NEGATIVE.
-       qtke  =MAX(Qke1D(k)/2.,0.)      ! maximum TKE
-       qtkem1=MAX(Qke1D(k-1)/2.,0.)
+       qtke  =MAX(0.5*qke1(k)  ,0.)      ! maximum TKE
+       qtkem1=MAX(0.5*qke1(k-1),0.)
        IF (qtke .LE. TKEeps) THEN
-           kzi2 = MAX(k-1,1)
-           PBLH_TKE = zw1D(k) - dz1D(k-1)* &
+           PBLH_TKE = zw1(k) - dz1(k-1)* &
              & MIN((TKEeps-qtke)/MAX(qtkem1-qtke, 1E-6), 1.0)
            !IN CASE OF NEAR ZERO TKE, SET PBLH = LOWEST LEVEL.
-           PBLH_TKE = MAX(PBLH_TKE,zw1D(kts+1))
-           !print *,"PBLH_TKE:",i,j,PBLH_TKE, Qke1D(k)/2., zw1D(kts+1)
+           PBLH_TKE = MAX(PBLH_TKE,zw1(kts+1))
+           !print *,"PBLH_TKE:",i,PBLH_TKE, Qke1(k)/2., zw1(kts+1)
        ENDIF
-       k = k+1
-       IF (k .EQ. kte-1) PBLH_TKE = zw1D(kts+1) !EXIT SAFEGUARD
+       !k = k+1
+       IF (k .EQ. kte-1) PBLH_TKE = zw1(kts+1) !EXIT SAFEGUARD
+       IF (PBLH_TKE .NE. 0.) exit
     ENDDO
 
-    !With TKE advection turned on, the TKE-based PBLH can be very large 
-    !in grid points with convective precipitation (> 8 km!),
-    !so an artificial limit is imposed to not let PBLH_TKE exceed 4km.
-    !This has no impact on 98-99% of the domain, but is the simplest patch
-    !that adequately addresses these extremely large PBLHs.
-    !PBLH_TKE = MIN(PBLH_TKE,4000.)
-    PBLH_TKE = MIN(PBLH_TKE,zi+500.)
+    !> - The TKE-based PBLH can (rarely) become very large 
+    !! in grid points with deep convection (> 8 km!),
+    !! so a limit is imposed to not let PBLH_TKE exceed the
+    !! theta_v-based PBL height +/- 350 m.
+    !! This has no impact on 99% of the domain.
+    PBLH_TKE = MIN(PBLH_TKE,pblh+350.)
+    PBLH_TKE = MAX(PBLH_TKE,MAX(pblh-350.,10.))
 
-    !BLEND THE TWO PBLH TYPES HERE: 
-    wt=.5*TANH((zi - sbl_lim)/sbl_damp) + .5
-    zi=PBLH_TKE*(1.-wt) + zi*wt
+    wt=.5*TANH((pblh - sbl_lim)/sbl_damp) + .5
+    IF (maxqke <= TKEeps) THEN
+       !Cold pool situation - default to theta_v-based def
+    ELSE
+       !BLEND THE TWO PBLH TYPES HERE: 
+       pblh=PBLH_TKE*(1.-wt) + pblh*wt
+    ENDIF
 
-    !ADD KPBL (kzi) for coupling to some Cu schemes
-     kzi = INT(kzi2*(1.-wt) + kzi*wt)
+    !Compute kpbl
+    DO k=kts+1,kte-1
+       IF ( zw1(k) >= pblh) THEN
+          kpbl = k-1
+          exit
+       ENDIF
+    ENDDO
+
+#ifdef HARDCODE_VERTICAL
+# undef kts
+# undef kte
+#endif
 
   END SUBROUTINE GET_PBLH
+!> @}
   
 ! ==================================================================
+!>\ingroup gsd_mynn_edmf
+!! This subroutine is the Dynamic Multi-Plume (DMP) Mass-Flux Scheme.
+!! 
+!! dmp_mf() calculates the nonlocal turbulent transport from the dynamic
+!! multiplume mass-flux scheme as well as the shallow-cumulus component of 
+!! the subgrid clouds. Note that this mass-flux scheme is called when the
+!! namelist paramter \p bl_mynn_edmf is set to 1 (recommended).
+!!
+!! Much thanks to Kay Suslj of NASA-JPL for contributing the original version
+!! of this mass-flux scheme. Considerable changes have been made from it's
+!! original form. Some additions include:
+!!  -# scale-aware tapering as dx -> 0
+!!  -# transport of TKE (extra namelist option)
+!!  -# Chaboureau-Bechtold cloud fraction & coupling to radiation (when icloud_bl > 0)
+!!  -# some extra limits for numerical stability
+!!
+!! This scheme remains under development, so consider it experimental code. 
+!!
+  SUBROUTINE DMP_mf(                               &
+                 & kts,kte,dt,zw1,dz1,p1,rho1,     &
+                 & momentum_opt,                   &
+                 & tke_opt,                        &
+                 & scalar_opt,                     &
+                 & u1,v1,w1,th1,thl1,thv1,tk1,     &
+                 & qt1,qv1,qc1,qke1,               &
+                 & qnc1,qni1,qnwfa1,qnifa1,qnbca1, &
+                 & ex1,vt1,vq1,sgm1,               &
+                 & ust,flt,fltv,flq,flqv,          &
+                 & pblh,kpbl,dx,landsea,ts,        &
+            ! outputs - updraft properties   
+                 & edmf_a1,edmf_w1,                &
+                 & edmf_qt1,edmf_thl1,             &
+                 & edmf_ent1,edmf_qc1,             &
+            ! outputs - variables needed for solver 
+                 & s_aw1,s_awthl1,s_awqt1,         &
+                 & s_awqv1,s_awqc1,                &
+                 & s_awu1,s_awv1,s_awqke1,         &
+                 & s_awqnc1,s_awqni1,              &
+                 & s_awqnwfa1,s_awqnifa1,          &
+                 & s_awqnbca1,                     &
+                 & sub_thl1,sub_sqv1,              &
+                 & sub_u1,sub_v1,                  &
+                 & det_thl1,det_sqv1,det_sqc1,     &
+                 & det_u1,det_v1,                  &
+            ! chem/smoke
+                 & nchem,chem1,s_awchem1,          &
+                 & mix_chem,                       &
+            ! in/outputs - subgrid scale clouds
+                 & qc_bl1,cldfra_bl1,              &
+                 & qc_bl1_old,cldfra_bl1_old,      &
+            ! inputs - flags for moist arrays
+                 & F_QC,F_QI,                      &
+                 & F_QNC,F_QNI,                    &
+                 & F_QNWFA,F_QNIFA,F_QNBCA,        &
+                 & Psig_shcu,                      &
+            ! output info
+                 & maxwidth,ktop,maxmf,ztop,       &
+            ! inputs for stochastic perturbations
+                 & spp_pbl,pattern_spp_pbl1,       &
+                 & tkeprod_up,el1                  )
+
+#ifdef HARDCODE_VERTICAL
+# define kts 1
+# define kte HARDCODE_VERTICAL
+#endif
+
+! inputs:
+  integer, intent(in) :: kts,kte,kpbl,momentum_opt,tke_opt,scalar_opt
+! stochastic 
+  integer,  intent(in)                             :: spp_pbl
+  real(kind_phys), dimension(kts:kte), intent(in)  :: pattern_spp_pbl1
+! state variables
+  real(kind_phys), dimension(kts:kte), intent(in)  ::                  &
+        &u1,v1,w1,th1,thl1,tk1,qt1,qv1,qc1,                            &
+        &ex1,dz1,thv1,p1,rho1,qke1,qnc1,qni1,                          &
+        &qnwfa1,qnifa1,qnbca1,el1
+  real(kind_phys),dimension(kts:kte+1), intent(in) ::                  &
+        &zw1
+  real(kind_phys), intent(in)                      ::                  &
+        &flt,fltv,flq,flqv,Psig_shcu,                                  &
+        &landsea,ts,dx,dt,ust,pblh
+  logical, optional :: F_QC,F_QI,F_QNC,F_QNI,F_QNWFA,F_QNIFA,F_QNBCA
+
+! outputs - updraft properties
+  real(kind_phys),dimension(kts:kte), intent(out) ::                   &
+        &edmf_a1,edmf_w1,edmf_qt1,edmf_thl1,edmf_ent1,edmf_qc1
+!add one local edmf variable:
+  real(kind_phys),dimension(kts:kte) :: edmf_th1
+! output
+  integer,         intent(inout) :: ktop
+  real(kind_phys), intent(out) :: maxmf,ztop,maxwidth
+! outputs - variables needed for solver
+     real(kind_phys),dimension(kts:kte+1), intent(out) ::              & !sum ai*rho*wis_awphi
+          &s_aw1,s_awthl1,s_awqt1,s_awqv1,s_awqc1,s_awqnc1,s_awqni1,   &
+          &s_awqnwfa1,s_awqnifa1,s_awqnbca1,s_awu1,s_awv1,             &
+          &s_awqke1
+     real(kind_phys),dimension(kts:kte+1) :: s_aw2
+
+     real(kind_phys),dimension(kts:kte), intent(inout) ::              &
+          &qc_bl1,cldfra_bl1,qc_bl1_old,cldfra_bl1_old,tkeprod_up
+
+    integer, parameter :: nup=8, debug_mf=0
+    real(kind_phys)    :: nup2
+
+  !------------- local variables -------------------
+  ! updraft properties defined on interfaces (k=1 is the top of the
+  ! first model layer
+     real(kind_phys),dimension(kts:kte+1,1:NUP) ::                     &
+          &UPW,UPTHL,UPQT,UPQC,UPQV,                                   &
+          &UPA,UPU,UPV,UPTHV,UPQKE,UPQNC,                              &
+          &UPQNI,UPQNWFA,UPQNIFA,UPQNBCA
+  ! entrainment variables
+     real(kind_phys),dimension(kts:kte,1:NUP) :: ENT,ENTf
+     integer,dimension(kts:kte,1:NUP)         :: ENTi
+  ! internal variables
+     integer :: k,i,k50
+     real(kind_phys):: fltv2,wstar,qstar,thstar,sigmaW,sigmaQT,        &
+          &sigmaTH,z0,pwmin,pwmax,wmin,wmax,wlv,Psig_w,maxw,maxqc,wpbl
+     real(kind_phys):: B,QTn,THLn,THVn,QCn,Un,Vn,QKEn,QNCn,QNIn,       &
+          &  QNWFAn,QNIFAn,QNBCAn,                                     &
+          &  Wn2,Wn,EntEXP,EntEXM,EntW,BCOEFF,THVkm1,THVk,Pk,rho_int
+
+  ! w parameters
+     real(kind_phys), parameter ::                                     &
+          &Wa=2./3.,                                                   &
+          &Wb=0.002,                                                   &
+          &Wc=1.5 
+        
+  ! Lateral entrainment parameters ( L0=100 and ENT0=0.1) were taken from
+  ! Suselj et al (2013, jas). Note that Suselj et al (2014,waf) use L0=200 and ENT0=0.2.
+     real(kind_phys),parameter ::                                      &
+          & L0=100.,                                                   &
+          & ENT0=0.1
+
+  ! Parameters/variables for regulating plumes:
+     real(kind_phys), parameter :: Atot = 0.10 ! Maximum total fractional area of all updrafts
+     real(kind_phys), parameter :: lmax = 1000.! diameter of largest plume (absolute maximum, can be smaller)
+     real(kind_phys), parameter :: lmin = 300. ! diameter of smallest plume (absolute minimum, can be larger)
+     real(kind_phys), parameter :: dlmin = 0.  ! delta increase in the diameter of smallest plume (large fltv) 
+     real(kind_phys)            :: minwidth    ! actual width of smallest plume
+     real(kind_phys)            :: dl          ! variable increment of plume size
+     real(kind_phys), parameter :: dcut = 1.2  ! max diameter of plume to parameterize relative to dx (km)
+     real(kind_phys)::  d     != -2.3 to -1.7  ;=-1.9 in Neggers paper; power law exponent for number density (N=Cl^d).
+          ! Note that changing d to -2.0 makes each size plume equally contribute to the total coverage of all plumes.
+          ! Note that changing d to -1.7 doubles the area coverage of the largest plumes relative to the smallest plumes.
+     real(kind_phys):: cn,c,l,n,an2,hux,wspd_pbl,cloud_base,width_flx
+
+  ! chem/smoke
+     integer, intent(in) :: nchem
+     real(kind_phys),dimension(kts:kte,   nchem) :: chem1
+     real(kind_phys),dimension(kts:kte+1, nchem) :: s_awchem1
+     real(kind_phys),dimension(nchem)            :: chemn
+     real(kind_phys),dimension(kts:kte+1,1:NUP, nchem) :: UPCHEM
+     integer :: ic
+     real(kind_phys),dimension(kts:kte,   nchem) :: edmf_chem
+     logical, intent(in) :: mix_chem
+
+  !JOE: add declaration of ERF
+   real(kind_phys):: ERF
+
+   logical :: superadiabatic
+
+  ! VARIABLES FOR CHABOUREAU-BECHTOLD CLOUD FRACTION
+   real(kind_phys),dimension(kts:kte), intent(inout) :: vt1, vq1, sgm1
+   real(kind_phys):: sigq,xl,rsl,cpm,a,qmq,mf_cf,Aup,Q1,diffqt,qsat_tk,&
+           Fng,qww,alpha,beta,bb,f,pt,t,q2p,b9,satvp,rhgrid,           &
+           Ac_mf,Ac_strat,qc_mf
+   real(kind_phys), parameter :: cf_thresh = 0.5 ! only overwrite stratus CF less than this value
+
+  ! Variables for plume interpolation/saturation check
+   real(kind_phys),dimension(kts:kte) :: exneri,dzi,rhoz
+   real(kind_phys):: THp, QTp, QCp, QCs, esat, qsl
+   real(kind_phys):: csigma,acfac,ac_wsp
+
+   !plume overshoot
+   integer :: overshoot
+   real(kind_phys):: bvf, Frz, dzp
+
+   !Flux limiter: not let mass-flux of heat between k=1&2 exceed (fluxportion)*(surface heat flux).
+   !This limiter makes adjustments to the entire column.
+   real(kind_phys):: adjustment, flx1, flt2
+   real(kind_phys), parameter :: fluxportion=0.75 ! set liberally, so has minimal impact. Note that
+                                       ! 0.5 starts to have a noticeable impact
+                                       ! over land (decrease maxMF by 10-20%), but no impact over water.
+
+   !Subsidence
+      real(kind_phys),dimension(kts:kte) :: sub_thl1,sub_sqv1,         &
+              sub_u1,sub_v1,det_thl1,det_sqv1,det_sqc1,det_u1,det_v1,  &  !tendencied due to detrainment
+              envm_a,envm_w,envm_thl,envm_sqv,envm_sqc,                &
+              envm_u,envm_v                  !environmental variables defined at middle of layer
+   real(kind_phys),dimension(kts:kte+1) ::  envi_a,envi_w        !environmental variables defined at model interface
+   real(kind_phys):: temp,sublim,qc_ent,qv_ent,qt_ent,thl_ent,detrate, &
+           detrateUV,oow,exc_fac,aratio,detturb,qc_grid,qc_sgs,        &
+           qc_plume,exc_heat,exc_moist,tk_int,tvs
+   real(kind_phys), parameter :: Cdet   = 1./45.
+   real(kind_phys), parameter :: dzpmax = 300. !limit dz used in detrainment - can be excessing in thick layers
+   !parameter "Csub" determines the propotion of upward vertical velocity that contributes to
+   !environmenatal subsidence. Some portion is expected to be compensated by downdrafts instead of
+   !gentle environmental subsidence. 1.0 assumes all upward vertical velocity in the mass-flux scheme
+   !is compensated by "gentle" environmental subsidence. 
+   real(kind_phys), parameter :: Csub=0.25
+
+   !Factor for the pressure gradient effects on momentum transport
+   real(kind_phys), parameter :: pgfac = 0.00  ! Zhang and Wu showed 0.4 is more appropriate for lower troposphere
+   real(kind_phys):: Uk,Ukm1,Vk,Vkm1,dxsa
+
+! Inititialize 2d ouput
+ ktop      =0    !integer
+ ztop      =0.
+ maxmf     =0.
+ maxwidth  =0. 
+ ! Initialize individual updraft properties
+ UPW       =0.
+ UPTHL     =0.
+ UPTHV     =0.
+ UPQT      =0.
+ UPA       =0.
+ UPU       =0.
+ UPV       =0.
+ UPQC      =0.
+ UPQV      =0.
+ UPQKE     =0.
+ UPQNC     =0.
+ UPQNI     =0.
+ UPQNWFA   =0.
+ UPQNIFA   =0.
+ UPQNBCA   =0.
+ if ( mix_chem ) then
+    UPCHEM(kts:kte+1,1:NUP,1:nchem)=0.0
+ endif
+ ENT       =0.001
+ ! Initialize mean updraft properties
+ edmf_a1   =0.
+ edmf_w1   =0.
+ edmf_qt1  =0.
+ edmf_thl1 =0.
+ edmf_ent1 =0.
+ edmf_qc1  =0.
+ if ( mix_chem ) then
+    edmf_chem(kts:kte,1:nchem) = 0.0
+ endif
+ ! Initialize the variables needed for implicit solver
+ s_aw1     =0.
+ s_awthl1  =0.
+ s_awqt1   =0.
+ s_awqv1   =0.
+ s_awqc1   =0.
+ s_awu1    =0.
+ s_awv1    =0.
+ s_awqke1  =0.
+ s_awqnc1  =0.
+ s_awqni1  =0.
+ s_awqnwfa1=0.
+ s_awqnifa1=0.
+ s_awqnbca1=0.
+ if ( mix_chem ) then
+    s_awchem1(kts:kte+1,1:nchem) = 0.0
+ endif
+
+ ! Initialize explicit tendencies for subsidence & detrainment
+ sub_thl1 = 0.
+ sub_sqv1 = 0.
+ sub_u1   = 0.
+ sub_v1   = 0.
+ det_thl1 = 0.
+ det_sqv1 = 0.
+ det_sqc1 = 0.
+ det_u1   = 0.
+ det_v1   = 0.
+ nup2     = nup !start with nup, but set to zero if activation criteria fails
+ tkeprod_up = 0.0
+      
+ ! Taper off MF scheme when significant resolved-scale motions
+ ! are present This function needs to be asymetric...
+ maxw    = 0.0
+ cloud_base  = 9000.0
+ do k=1,kte-1
+    if (zw1(k) > pblh + 500.) exit
+
+    wpbl = w1(k)
+    if (w1(k) < 0.)wpbl = 2.*w1(k)
+    maxw = max(maxw,abs(wpbl))
+
+    !Find highest k-level below 50m AGL
+    if (zw1(k)<=50.)k50=k
+
+    !Search for cloud base
+    qc_sgs = max(qc1(k), qc_bl1(k))
+    if (qc_sgs> 1E-5 .and. (cldfra_bl1(k) .ge. 0.5) .and. cloud_base == 9000.0) then
+      cloud_base = 0.5*(zw1(k)+zw1(k+1))
+    endif
+ enddo
+
+ !do nothing for small w (< 1 m/s), but linearly taper off for w > 1.0 m/s
+ maxw = max(0.,maxw - 1.0)
+ Psig_w = max(0.0, 1.0 - maxw)
+ Psig_w = min(Psig_w, Psig_shcu)
+
+ !Completely shut off MF scheme for strong resolved-scale vertical velocities.
+ fltv2 = fltv
+ if(Psig_w == 0.0 .and. fltv > 0.0) fltv2 = -1.*fltv
+
+ ! If surface buoyancy is positive we do integration, otherwise no.
+ ! Also, ensure that it is at least slightly superadiabatic up through 50 m
+ superadiabatic = .false.
+ if ((landsea-1.5).ge.0) then
+    hux = -0.001   ! WATER  ! dT/dz must be < - 0.1 K per 100 m.
+ else
+    hux = -0.005  ! LAND    ! dT/dz must be < - 0.5 K per 100 m.
+ endif
+ tvs = ts*(1.0+p608*qv1(kts))
+ do k=1,max(1,k50-1) !use "-1" because k50 used interface heights (zw). 
+    if (k == 1) then
+       if ((thv1(k)-tvs)/(0.5*dz1(k)) < hux) then
+          superadiabatic = .true.
+       else
+          superadiabatic = .false.
+          exit
+       endif
+    else
+       if ((thv1(k)-thv1(k-1))/(0.5*(dz1(k)+dz1(k-1))) < hux) then
+          superadiabatic = .true.
+       else
+          superadiabatic = .false.
+          exit
+       endif
+    endif
+ enddo
+
+ ! Determine the numer of updrafts/plumes in the grid column:
+ ! Some of these criteria may be a little redundant but useful for bullet-proofing.
+ !   (1) largest plume = 1.2 * dx.
+ !   (2) Apply a scale-break, assuming no plumes with diameter larger than 1.1*PBLH can exist.
+ !   (3) max plume size beneath clouds deck approx = 0.5 * cloud_base.
+ !   (4) add wspd-dependent limit, when plume model breaks down. (hurricanes)
+ !   (5) limit to reduce max plume sizes in weakly forced conditions. This is only
+ !       meant to "soften" the activation of the mass-flux scheme.
+ ! Criteria (1)
+ maxwidth = min(dx*dcut, lmax)
+ !Criteria (2)
+ maxwidth = min(maxwidth, 1.1_kind_phys*pblh) 
+ ! Criteria (3)
+ if ((landsea-1.5) .lt. 0) then  !land
+    maxwidth = MIN(maxwidth, 0.5_kind_phys*cloud_base)
+ else                            !water
+    maxwidth = MIN(maxwidth, 0.9_kind_phys*cloud_base)
+ endif
+ ! Criteria (4)
+ wspd_pbl=sqrt(max(u1(kts)**2 + v1(kts)**2, 0.01_kind_phys))
+ !Note: area fraction (acfac) is modified below
+ ! Criteria (5) - only a function of flt (not fltv)
+ if ((landsea-1.5).LT.0) then  !land
+    width_flx = MAX(MIN(1000.*(0.6*tanh((fltv - 0.040)/0.04) + .5),1000._kind_phys), 0._kind_phys)
+ else                          !water
+    width_flx = MAX(MIN(1000.*(0.6*tanh((fltv - 0.007)/0.02) + .5),1000._kind_phys), 0._kind_phys)
+ endif
+ maxwidth = MIN(maxwidth, width_flx)
+ minwidth = lmin
+ !allow min plume size to increase in large flux conditions (eddy diffusivity should be
+ !large enough to handle the representation of small plumes).
+ if (maxwidth .ge. (lmax - 1.0) .and. fltv .gt. 0.2)minwidth = lmin + dlmin*min((fltv-0.2)/0.3, 1._kind_phys) 
+
+ if (maxwidth .le. minwidth) then ! deactivate MF component
+    nup2 = 0
+    maxwidth = 0.0
+ endif
+
+ ! Initialize values for 2d output fields:
+ ktop = 0
+ ztop = 0.0
+ maxmf= 0.0
+
+ !Begin plume processing if passes criteria
+ if ( fltv2 > 0.002 .AND. (maxwidth > minwidth) .AND. superadiabatic) then
+
+    ! Find coef C for number size density N
+    cn = 0.
+    d  =-1.9  !set d to value suggested by Neggers 2015 (JAMES).
+    dl = (maxwidth - minwidth)/real(nup-1,kind=kind_phys)
+    do i=1,NUP
+       ! diameter of plume
+       l = minwidth + dl*real(i-1,kind=kind_phys)
+       cn = cn + l**d * (l*l)/(dx*dx) * dl  ! sum fractional area of each plume
+    enddo
+    C = Atot/cn   !Normalize C according to the defined total fraction (Atot)
+
+    ! Make updraft area (UPA) a function of the buoyancy flux
+    acfac = .5*tanh((fltv2 - 0.02)/0.05) + .5
+
+    !add a windspeed-dependent adjustment to acfac that tapers off
+    !the mass-flux scheme linearly above sfc wind speeds of 10 m/s.
+    !Note: this effect may be better represented by an increase in
+    !entrainment rate for high wind consitions (more ambient turbulence).
+    if (wspd_pbl .le. 10.) then
+       ac_wsp = 1.0
+    else
+       ac_wsp = 1.0 - min((wspd_pbl - 10.0)/15., 1.0)
+    endif
+    acfac  = acfac * ac_wsp
+
+    ! Find the portion of the total fraction (Atot) of each plume size:
+    An2 = 0.
+    do i=1,nup
+       ! diameter of plume
+       l  = minwidth + dl*real(i-1,kind=kind_phys)
+       N  = C*l**d                          ! number density of plume n
+       UPA(1,i) = N*l*l/(dx*dx) * dl        ! fractional area of plume n
+
+       UPA(1,i) = UPA(1,i)*acfac
+       An2 = An2 + UPA(1,i)                 ! total fractional area of all plumes
+       !if (upa(i,i)<0.0)print*,"Neg plume area: plume size=",l," dl=",dl,&
+       !    " area=",UPA(1,I),"; total=",An2," acfac=",acfac," N=",N
+    end do
+
+    ! set initial conditions for updrafts
+    z0=50.
+    pwmin=0.1       ! was 0.5
+    pwmax=0.4       ! was 3.0
+
+    wstar=max(1.E-2,(gtr*fltv2*pblh)**(onethird))
+    qstar=max(flq,1.0E-5)/wstar
+    thstar=flt/wstar
+
+    if ((landsea-1.5) .ge. 0) then
+       csigma = 1.34   ! WATER
+    else
+       csigma = 1.34   ! LAND
+    endif
+
+    if (env_subs) then
+       exc_fac = 0.0
+    else
+       if ((landsea-1.5).GE.0) then
+          !water: increase factor to compensate for decreased pwmin/pwmax
+          exc_fac = 0.58*4.0
+       else
+          !land: no need to increase factor - already sufficiently large superadiabatic layers
+          exc_fac = 0.58
+       endif
+    endif
+    !decrease excess for large wind speeds
+    exc_fac = exc_fac * ac_wsp
+
+    !Note: sigmaW is typically about 0.5*wstar
+    sigmaW =csigma*wstar*(z0/pblh)**(onethird)*(1. - 0.8*z0/pblh)
+    sigmaQT=csigma*qstar*(z0/pblh)**(onethird)
+    sigmaTH=csigma*thstar*(z0/pblh)**(onethird)
+
+    !Note: Given the pwmin & pwmax set above, these max/mins are
+    !      rarely exceeded. 
+    wmin=MIN(sigmaW*pwmin,0.1)
+    wmax=MIN(sigmaW*pwmax,0.5)
+
+    !SPECIFY SURFACE UPDRAFT PROPERTIES AT MODEL INTERFACE BETWEEN K = 1 & 2
+    do i=1,NUP
+       wlv=wmin+(wmax-wmin)/NUP2*(i-1)
+
+       !SURFACE UPDRAFT VERTICAL VELOCITY
+       UPW(1,I)    =wmin + real(i)/real(NUP)*(wmax-wmin)
+       UPU(1,I)    =(u1(kts)    *dz1(kts+1)+u1(kts+1)    *dz1(kts))/(dz1(kts)+dz1(kts+1))
+       UPV(1,I)    =(v1(kts)    *dz1(kts+1)+v1(kts+1)    *dz1(kts))/(dz1(kts)+dz1(kts+1))
+       UPQC(1,I)   =0.0
+       !UPQC(1,I)  =(qc1(kts)*dz1(kts+1)+qc1(kts+1)*dz1(kts))/(dz1(kts)+dz1(kts+1))
+
+       exc_heat    =exc_fac*UPW(1,I)*sigmaTH/sigmaW
+       UPTHV(1,I)  =(thv1(kts)  *dz1(kts+1)+thv1(kts+1)  *dz1(kts))/(dz1(kts)+dz1(kts+1)) &
+           &       + exc_heat
+       UPTHL(1,I)  =(thl1(kts)  *dz1(kts+1)+thl1(kts+1)  *dz1(kts))/(dz1(kts)+dz1(kts+1)) &
+           &       + exc_heat
+       !calculate exc_moist by use of surface fluxes
+       exc_moist=exc_fac*UPW(1,I)*sigmaQT/sigmaW
+       UPQT(1,I)   =(qt1(kts)   *dz1(kts+1)+qt1(kts+1)   *dz1(kts))/(dz1(kts)+dz1(kts+1))&
+            &      + exc_moist
+       UPQKE(1,I)  =(qke1(kts)  *dz1(kts+1)+qke1(kts+1)  *dz1(kts))/(dz1(kts)+dz1(kts+1))
+       UPQNC(1,I)  =(qnc1(kts)  *dz1(kts+1)+qnc1(kts+1)  *dz1(kts))/(dz1(kts)+dz1(kts+1))
+       UPQNI(1,I)  =(qni1(kts)  *dz1(kts+1)+qni1(kts+1)  *dz1(kts))/(dz1(kts)+dz1(kts+1))
+       UPQNWFA(1,I)=(qnwfa1(kts)*dz1(kts+1)+qnwfa1(kts+1)*dz1(kts))/(dz1(kts)+dz1(kts+1))
+       UPQNIFA(1,I)=(qnifa1(kts)*dz1(kts+1)+qnifa1(kts+1)*dz1(kts))/(dz1(kts)+dz1(kts+1))
+       UPQNBCA(1,I)=(qnbca1(kts)*dz1(kts+1)+qnbca1(kts+1)*dz1(kts))/(dz1(kts)+dz1(kts+1))
+    enddo
+
+    if ( mix_chem ) then
+      do i=1,NUP
+        do ic = 1,nchem
+          UPCHEM(1,i,ic)=(chem1(kts,ic)*dz1(kts+1)+chem1(kts+1,ic)*dz1(kts))/(dz1(kts)+dz1(kts+1))
+        enddo
+      enddo
+    endif
+
+    !Initialize environmental variables which can be modified by detrainment
+    envm_thl(kts:kte)=thl1(kts:kte)
+    envm_sqv(kts:kte)=qv1(kts:kte)
+    envm_sqc(kts:kte)=qc1(kts:kte)
+    envm_u(kts:kte)  =u1(kts:kte)
+    envm_v(kts:kte)  =v1(kts:kte)
+    do k=kts,kte-1
+       rhoz(k)  = (rho1(k)*dz1(k+1)+rho1(k+1)*dz1(k))/(dz1(k+1)+dz1(k))
+    enddo
+    rhoz(kte) = rho1(kte)
+
+    !dxsa is scale-adaptive factor governing the pressure-gradient term of the momentum transport
+    dxsa = 1. - MIN(MAX((12000.0-dx)/(12000.0-3000.0), 0.), 1.)
+
+    ! do integration  updraft
+    do i=1,NUP
+       QCn = 0.
+       overshoot = 0
+       l  = minwidth + dl*real(i-1)            ! diameter of plume
+       do k=kts+1,kte-1
+          !Entrainment from Tian and Kuang (2016)
+          !ENT(k,i) = 0.35/(MIN(MAX(UPW(K-1,I),0.75),1.9)*l)
+          wmin = 0.3 + l*0.0005 !* MAX(pblh-zw1(k+1), 0.0)/pblh
+          ENT(k,i) = 0.33/(MIN(MAX(UPW(K-1,I),wmin),0.9)*l)
+
+          !Entrainment from Negggers (2015, JAMES)
+          !ENT(k,i) = 0.02*l**-0.35 - 0.0009
+          !ENT(k,i) = 0.04*l**-0.50 - 0.0009   !more plume diversity
+          !ENT(k,i) = 0.04*l**-0.495 - 0.0009  !"neg1+"
+
+          !Minimum background entrainment 
+          ENT(k,i) = max(ENT(k,i),0.0003)
+          !ENT(k,i) = max(ENT(k,i),0.05/zw1(k))  !not needed for Tian and Kuang
+
+          !increase entrainment for plumes extending very high.
+          IF(zw1(k) >= MIN(pblh+1500., 4000.))THEN
+            ENT(k,i)=ENT(k,i) + (zw1(k)-MIN(pblh+1500.,4000.))*5.0E-6
+          ENDIF
+
+          !SPP
+          ENT(k,i) = ENT(k,i) * (1.0 - pattern_spp_pbl1(k))
+
+          ENT(k,i) = min(ENT(k,i),0.9/(zw1(k+1)-zw1(k)))
+
+          ! Define environment U & V at the model interface levels
+          Uk     =(u1(k)*dz1(k+1)+u1(k+1)*dz1(k))/(dz1(k+1)+dz1(k))
+          Ukm1   =(u1(k-1)*dz1(k)+u1(k)*dz1(k-1))/(dz1(k-1)+dz1(k))
+          Vk     =(v1(k)*dz1(k+1)+v1(k+1)*dz1(k))/(dz1(k+1)+dz1(k))
+          Vkm1   =(v1(k-1)*dz1(k)+v1(k)*dz1(k-1))/(dz1(k-1)+dz1(k))
+
+          ! Linear entrainment:
+          EntExp =ENT(K,I)*(zw1(k+1)-zw1(k))
+          EntExm =EntExp*0.3333    !reduce entrainment for momentum
+          QTn    =UPQT(k-1,I)   *(1.-EntExp) + qt1(k)*EntExp
+          THLn   =UPTHL(k-1,I)  *(1.-EntExp) + thl1(k)*EntExp
+          Un     =UPU(k-1,I)    *(1.-EntExm) + u1(k)*EntExm + dxsa*pgfac*(Uk - Ukm1)
+          Vn     =UPV(k-1,I)    *(1.-EntExm) + v1(k)*EntExm + dxsa*pgfac*(Vk - Vkm1)
+          QKEn   =UPQKE(k-1,I)  *(1.-EntExp) + qke1(k)*EntExp
+          QNCn   =UPQNC(k-1,I)  *(1.-EntExp) + qnc1(k)*EntExp
+          QNIn   =UPQNI(k-1,I)  *(1.-EntExp) + qni1(k)*EntExp
+          QNWFAn =UPQNWFA(k-1,I)*(1.-EntExp) + qnwfa1(k)*EntExp
+          QNIFAn =UPQNIFA(k-1,I)*(1.-EntExp) + qnifa1(k)*EntExp
+          QNBCAn =UPQNBCA(k-1,I)*(1.-EntExp) + qnbca1(k)*EntExp
+
+          !capture the updated qc, qt & thl modified by entranment alone,
+          !since they will be modified later if condensation occurs.
+          qc_ent =QCn
+          qt_ent =QTn
+          thl_ent=THLn
+
+          ! Exponential Entrainment:
+          !EntExp= exp(-ENT(K,I)*(zw1(k)-zw1(k-1)))
+          !QTn =qt1(K) *(1-EntExp)+UPQT(K-1,I)*EntExp
+          !THLn=thl1(K)*(1-EntExp)+UPTHL(K-1,I)*EntExp
+          !Un  =u1(K)  *(1-EntExp)+UPU(K-1,I)*EntExp
+          !Vn  =v1(K)  *(1-EntExp)+UPV(K-1,I)*EntExp
+          !QKEn=qke1(k)*(1-EntExp)+UPQKE(K-1,I)*EntExp
+
+          if ( mix_chem ) then
+            do ic = 1,nchem
+              ! Exponential Entrainment:
+              !chemn(ic) = chem(k,ic)*(1-EntExp)+UPCHEM(K-1,I,ic)*EntExp
+              ! Linear entrainment:
+              chemn(ic)=UPCHEM(k-1,i,ic)*(1.-EntExp) + chem1(k,ic)*EntExp
+            enddo
+          endif
+
+          ! Define pressure at model interface
+          Pk    =(p1(k)*dz1(k+1)+p1(k+1)*dz1(k))/(dz1(k+1)+dz1(k))
+          ! Compute plume properties thvn and qcn
+          call condensation_edmf(QTn,THLn,Pk,zw1(k+1),THVn,QCn)
+
+          ! Define environment THV at the model interface levels
+          THVk  =(thv1(k)*dz1(k+1)+thv1(k+1)*dz1(k))/(dz1(k+1)+dz1(k))
+          THVkm1=(thv1(k-1)*dz1(k)+thv1(k)*dz1(k-1))/(dz1(k-1)+dz1(k))
+
+!          B=g*(0.5*(THVn+UPTHV(k-1,I))/thv1(k-1) - 1.0)
+          B=grav*(THVn/THVk - 1.0)
+          IF(B>0.)THEN
+            BCOEFF = 0.15        !w typically stays < 2.5, so doesnt hit the limits nearly as much
+          ELSE
+            BCOEFF = 0.2 !0.33
+          ENDIF
+
+          ! Original StEM with exponential entrainment
+          !EntW=exp(-2.*(Wb+Wc*ENT(K,I))*(zw1(k)-zw1(k-1)))
+          !Wn2=UPW(K-1,I)**2*EntW + (1.-EntW)*0.5*Wa*B/(Wb+Wc*ENT(K,I))
+          ! Original StEM with linear entrainment
+          !Wn2=UPW(K-1,I)**2*(1.-EntExp) + EntExp*0.5*Wa*B/(Wb+Wc*ENT(K,I))
+          !Wn2=MAX(Wn2,0.0)
+          !WA: TEMF form
+          !IF (B>0.0 .AND. UPW(K-1,I) < 0.2 ) THEN
+          IF (UPW(K-1,I) < 0.2 ) THEN
+             Wn = UPW(K-1,I) + (-2. * ENT(K,I) * UPW(K-1,I) + BCOEFF*B / MAX(UPW(K-1,I),0.2)) * MIN(zw1(k)-zw1(k-1), 250.)
+          ELSE
+             Wn = UPW(K-1,I) + (-2. * ENT(K,I) * UPW(K-1,I) + BCOEFF*B / UPW(K-1,I)) * MIN(zw1(k)-zw1(k-1), 250.)
+          ENDIF
+          !Do not allow a parcel to accelerate more than 1.25 m/s over 200 m.
+          !Add max increase of 2.0 m/s for coarse vertical resolution.
+          IF(Wn > UPW(K-1,I) + MIN(1.25*(zw1(k)-zw1(k-1))/200., 2.0) ) THEN
+             Wn = UPW(K-1,I) + MIN(1.25*(zw1(k)-zw1(k-1))/200., 2.0)
+          ENDIF
+          !Add symmetrical max decrease in w
+          IF(Wn < UPW(K-1,I) - MIN(1.25*(zw1(k)-zw1(k-1))/200., 2.0) ) THEN
+             Wn = UPW(K-1,I) - MIN(1.25*(zw1(k)-zw1(k-1))/200., 2.0)
+          ENDIF
+          Wn = MIN(MAX(Wn,0.0), 3.0)
+
+          !Check to make sure that the plume made it up at least one level.
+          !if it failed, then set nup2=0 and exit the mass-flux portion.
+          IF (k==kts+1 .AND. Wn == 0.) THEN
+             NUP2=0
+             exit
+          ENDIF
+
+          IF (debug_mf == 1) THEN
+            IF (Wn .GE. 3.0) THEN
+              ! surface values
+              print *," **** SUSPICIOUSLY LARGE W:"
+              print *,' QCn:',QCn,' ENT=',ENT(k,i),' Nup2=',Nup2
+              print *,'pblh:',pblh,' Wn:',Wn,' UPW(k-1)=',UPW(K-1,I)
+              print *,'K=',k,' B=',B,' dz=',zw1(k)-zw1(k-1)
+            ENDIF
+          ENDIF
+
+          !Allow strongly forced plumes to overshoot if KE is sufficient
+          IF (Wn <= 0.0 .AND. overshoot == 0) THEN
+             overshoot = 1
+             IF ( THVk-THVkm1 .GT. 0.0 ) THEN
+                bvf = SQRT( gtr*(THVk-THVkm1)/dz1(k) )
+                !vertical Froude number
+                Frz = UPW(K-1,I)/(bvf*dz1(k))
+                !IF ( Frz >= 0.5 ) Wn =  MIN(Frz,1.0)*UPW(K-1,I)
+                dzp = dz1(k)*MAX(MIN(Frz,1.0),0.0) ! portion of highest layer the plume penetrates
+             ENDIF
+          ELSE
+             dzp = dz1(k)
+          ENDIF
+
+          !minimize the plume penetratration in stratocu-topped PBL
+          !IF (fltv2 < 0.06) THEN
+          !   IF(ZW(k+1) >= pblh-200. .AND. qc1(k) > 1e-5 .AND. I > 4) Wn=0.
+          !ENDIF
+
+          !Modify environment variables (representative of the model layer - envm*)
+          !following the updraft dynamical detrainment of Asai and Kasahara (1967, JAS).
+          !Reminder: w is limited to be non-negative (above)
+          aratio   = MIN(UPA(K-1,I)/(1.-UPA(K-1,I)), 0.5) !limit should never get hit
+          detturb  = 0.00008
+          oow      = -0.060/MAX(1.0,(0.5*(Wn+UPW(K-1,I))))   !coef for dynamical detrainment rate
+          detrate  = MIN(MAX(oow*(Wn-UPW(K-1,I))/dz1(k), detturb), .0002) ! dynamical detrainment rate (m^-1)
+          detrateUV= MIN(MAX(oow*(Wn-UPW(K-1,I))/dz1(k), detturb), .0001) ! dynamical detrainment rate (m^-1) 
+          envm_thl(k)=envm_thl(k) + (0.5*(thl_ent + UPTHL(K-1,I)) - thl1(k))*detrate*aratio*MIN(dzp,dzpmax)
+          qv_ent = 0.5*(MAX(qt_ent-qc_ent,0.) + MAX(UPQT(K-1,I)-UPQC(K-1,I),0.))
+          envm_sqv(k)=envm_sqv(k) + (qv_ent-qv1(K))*detrate*aratio*MIN(dzp,dzpmax)
+          IF (UPQC(K-1,I) > 1E-8) THEN
+             IF (qc1(k) > 1E-6) THEN
+                qc_grid = qc1(k)
+             ELSE
+                qc_grid = qc_bl1(K)
+             ENDIF
+             envm_sqc(k)=envm_sqc(k) + MAX(UPA(K-1,I)*0.5*(QCn + UPQC(K-1,I)) - qc_grid, 0.0)*detrate*aratio*MIN(dzp,dzpmax)
+          ENDIF
+          envm_u(k)  =envm_u(k)   + (0.5*(Un + UPU(K-1,I)) - u1(K))*detrateUV*aratio*MIN(dzp,dzpmax)
+          envm_v(k)  =envm_v(k)   + (0.5*(Vn + UPV(K-1,I)) - v1(K))*detrateUV*aratio*MIN(dzp,dzpmax)
+
+          IF (Wn > 0.) THEN
+             !Update plume variables at current k index
+             UPW(K,I)=Wn  !sqrt(Wn2)
+             UPTHV(K,I)=THVn
+             UPTHL(K,I)=THLn
+             UPQT(K,I)=QTn
+             UPQC(K,I)=QCn
+             UPU(K,I)=Un
+             UPV(K,I)=Vn
+             UPQKE(K,I)=QKEn
+             UPQNC(K,I)=QNCn
+             UPQNI(K,I)=QNIn
+             UPQNWFA(K,I)=QNWFAn
+             UPQNIFA(K,I)=QNIFAn
+             UPQNBCA(K,I)=QNBCAn
+             UPA(K,I)=UPA(K-1,I)
+             IF ( mix_chem ) THEN
+               do ic = 1,nchem
+                 UPCHEM(k,I,ic) = chemn(ic)
+               enddo
+             ENDIF
+             ktop = MAX(ktop,k)
+          ELSE
+             exit  !exit k-loop
+          END IF
+       ENDDO
+
+       IF (debug_mf == 1) THEN
+          IF (MAXVAL(UPW(:,I)) > 10.0 .OR. MINVAL(UPA(:,I)) < 0.0 .OR. &
+              MAXVAL(UPA(:,I)) > Atot .OR. NUP2 > 10) THEN
+             ! surface values
+             print *,'flq:',flq,' fltv:',fltv2,' Nup2=',Nup2
+             print *,'pblh:',pblh,' wstar:',wstar,' ktop=',ktop
+             print *,'sigmaW=',sigmaW,' sigmaTH=',sigmaTH,' sigmaQT=',sigmaQT
+             ! means
+             print *,'u:',u1
+             print *,'v:',v1
+             print *,'thl:',thl1
+             print *,'UPA:',UPA(:,I)
+             print *,'UPW:',UPW(:,I)
+             print *,'UPTHL:',UPTHL(:,I)
+             print *,'UPQT:',UPQT(:,I)
+             print *,'ENT:',ENT(:,I)
+          ENDIF
+       ENDIF
+    ENDDO
+ ELSE
+    !At least one of the conditions was not met for activating the MF scheme.
+    NUP2=0.
+ END IF !end criteria check for mass-flux scheme
+
+ ktop=MIN(ktop,KTE-1)
+ IF (ktop == 0) THEN
+    ztop = 0.0
+ ELSE
+    ztop=zw1(ktop)
+ ENDIF
+
+ IF (nup2 > 0) THEN
+    !Calculate the fluxes for each variable
+    !All s_aw* variable are == 0 at k=1
+    DO i=1,NUP
+       DO k=kts,kte-1
+          s_aw1(k+1)   = s_aw1(k+1)    + rhoz(k)*UPA(K,i)*UPW(K,i)*Psig_w
+          s_awthl1(k+1)= s_awthl1(k+1) + rhoz(k)*UPA(K,i)*UPW(K,i)*UPTHL(K,i)*Psig_w
+          s_awqt1(k+1) = s_awqt1(k+1)  + rhoz(k)*UPA(K,i)*UPW(K,i)*UPQT(K,i)*Psig_w
+          !to conform to grid mean properties, move qc to qv in grid mean
+          !saturated layers, so total water fluxes are preserved but 
+          !negative qc fluxes in unsaturated layers is reduced.
+!         if (qc1(k) > 1e-12 .or. qc1(k+1) > 1e-12) then
+             qc_plume = UPQC(K,i)
+!         else
+!            qc_plume = 0.0
+!         endif
+          s_awqc1(k+1) = s_awqc1(k+1)  + rhoz(k)*UPA(K,i)*UPW(K,i)*qc_plume*Psig_w
+          s_awqv1(k+1) = s_awqt1(k+1)  - s_awqc1(k+1)
+       ENDDO
+    ENDDO
+    !momentum
+    if (momentum_opt > 0) then
+       do i=1,nup
+          do k=kts,kte-1
+             s_awu1(k+1) = s_awu1(k+1)   + rhoz(k)*UPA(K,i)*UPW(K,i)*UPU(K,i)*Psig_w
+             s_awv1(k+1) = s_awv1(k+1)   + rhoz(k)*UPA(K,i)*UPW(K,i)*UPV(K,i)*Psig_w
+          enddo
+       enddo
+    endif
+    !tke
+    if (tke_opt > 0) then
+       do i=1,nup
+          do k=kts,kte-1
+             s_awqke1(k+1)= s_awqke1(k+1) + rhoz(k)*UPA(K,i)*UPW(K,i)*UPQKE(K,i)*Psig_w
+          enddo
+       enddo
+    endif
+    !chem
+    if ( mix_chem ) then
+       do k=kts,kte-1
+          do i=1,nup
+             do ic = 1,nchem
+                s_awchem1(k+1,ic) = s_awchem1(k+1,ic) + rhoz(k)*UPA(K,i)*UPW(K,i)*UPCHEM(K,i,ic)*Psig_w
+             enddo
+          enddo
+       enddo
+    endif
+
+    if (scalar_opt > 0) then
+       do i=1,nup
+          do k=kts,kte-1
+             s_awqnc1(k+1)  = s_awqnc1(K+1)   + rhoz(k)*UPA(K,i)*UPW(K,i)*UPQNC(K,i)*Psig_w
+             s_awqni1(k+1)  = s_awqni1(K+1)   + rhoz(k)*UPA(K,i)*UPW(K,i)*UPQNI(K,i)*Psig_w
+             s_awqnwfa1(k+1)= s_awqnwfa1(K+1) + rhoz(k)*UPA(K,i)*UPW(K,i)*UPQNWFA(K,i)*Psig_w
+             s_awqnifa1(k+1)= s_awqnifa1(K+1) + rhoz(k)*UPA(K,i)*UPW(K,i)*UPQNIFA(K,i)*Psig_w
+             s_awqnbca1(k+1)= s_awqnbca1(K+1) + rhoz(k)*UPA(K,i)*UPW(K,i)*UPQNBCA(K,i)*Psig_w
+          enddo
+       enddo
+    endif
+
+   !Flux limiter: Check ratio of heat flux at top of first model layer
+   !and at the surface. Make sure estimated flux out of the top of the
+   !layer is < fluxportion*surface_heat_flux
+   IF (s_aw1(kts+1) /= 0.) THEN
+      dzi(kts) = 0.5*(dz1(kts)+dz1(kts+1)) !dz centered at model interface
+      flx1   = MAX(s_aw1(kts+1)*(th1(kts)-th1(kts+1))/dzi(kts),1.0e-5)
+   ELSE
+      flx1 = 0.0
+      !print*,"ERROR: s_aw(kts+1) == 0, NUP=",NUP," NUP2=",NUP2,&
+      !       " superadiabatic=",superadiabatic," KTOP=",KTOP
+   ENDIF
+   adjustment=1.0
+   flt2=max(flt,0.0) !need because activation is now based on fltv, not flt
+   !Print*,"Flux limiter in MYNN-EDMF, adjustment=",fluxportion*flt/dz(kts)/flx1
+   !Print*,"flt/dz=",flt/dz(kts)," flx1=",flx1," s_aw(kts+1)=",s_aw(kts+1)
+   IF (flx1 > fluxportion*flt2/dz1(kts) .AND. flx1>0.0) THEN
+      adjustment= fluxportion*flt2/dz1(kts)/flx1
+      s_aw1      = s_aw1*adjustment
+      s_awthl1   = s_awthl1*adjustment
+      s_awqt1    = s_awqt1*adjustment
+      s_awqc1    = s_awqc1*adjustment
+      s_awqv1    = s_awqv1*adjustment
+      s_awqnc1   = s_awqnc1*adjustment
+      s_awqni1   = s_awqni1*adjustment
+      s_awqnwfa1 = s_awqnwfa1*adjustment
+      s_awqnifa1 = s_awqnifa1*adjustment
+      s_awqnbca1 = s_awqnbca1*adjustment
+      IF (momentum_opt > 0) THEN
+         s_awu1  = s_awu1*adjustment
+         s_awv1  = s_awv1*adjustment
+      ENDIF
+      IF (tke_opt > 0) THEN
+         s_awqke1= s_awqke1*adjustment
+      ENDIF
+      IF ( mix_chem ) THEN
+         s_awchem1 = s_awchem1*adjustment
+      ENDIF
+      UPA = UPA*adjustment
+   ENDIF
+   !Print*,"adjustment=",adjustment," fluxportion=",fluxportion," flt=",flt
+
+   !Calculate mean updraft properties for output:
+   !all edmf_* variables at k=1 correspond to the interface at top of first model layer
+   do i=1,nup
+      do k=kts,kte-1
+         edmf_a1(k)  =edmf_a1(k)  +UPA(k,i)
+         edmf_w1(k)  =edmf_w1(k)  +UPA(k,i)*UPW(k,i)
+         edmf_qt1(k) =edmf_qt1(k) +UPA(k,i)*UPQT(k,i)
+         edmf_thl1(k)=edmf_thl1(k)+UPA(k,i)*UPTHL(k,i)
+         edmf_ent1(k)=edmf_ent1(k)+UPA(k,i)*ENT(k,i)
+         edmf_qc1(k) =edmf_qc1(k) +UPA(k,i)*UPQC(k,i)
+      enddo
+   enddo
+   do k=kts,kte-1
+      !Note that only edmf_a1 is multiplied by Psig_w. This takes care of the
+      !scale-awareness of the subsidence below:
+      if (edmf_a1(k)>0.) then
+         edmf_w1(k)  =edmf_w1(k)/edmf_a1(k)
+         edmf_qt1(k) =edmf_qt1(k)/edmf_a1(k)
+         edmf_thl1(k)=edmf_thl1(k)/edmf_a1(k)
+         edmf_ent1(k)=edmf_ent1(k)/edmf_a1(k)
+         edmf_qc1(k) =edmf_qc1(k)/edmf_a1(k)
+         edmf_a1(k)  =edmf_a1(k)*Psig_w
+         !FIND MAXIMUM MASS-FLUX IN THE COLUMN:
+         if(edmf_a1(k)*edmf_w1(k) > maxmf) maxmf = edmf_a1(k)*edmf_w1(k)
+      endif
+      !instead of dTKE/dt = 1/2 w^3, multiply by 2 for QKE.
+      tkeprod_up(k)=(abs(edmf_w1(k))**3)*edmf_a1(k)/(b1*max(el1(k),0.1)) 
+   enddo ! end k
+
+   !smoke/chem
+   if ( mix_chem ) then
+      do k=kts,kte-1
+        do I=1,nup
+          do ic = 1,nchem
+            edmf_chem(k,ic) = edmf_chem(k,ic) + UPA(K,I)*UPCHEM(k,i,ic)
+          enddo
+        enddo
+      enddo
+      do k=kts,kte-1
+        if (edmf_a1(k)>0.) then
+          do ic = 1,nchem
+            edmf_chem(k,ic) = edmf_chem(k,ic)/edmf_a1(k)
+          enddo
+        endif
+      enddo ! end k
+   endif
+
+   !Calculate the effects environmental subsidence.
+   !All envi_*variables are valid at the interfaces, like the edmf_* variables
+   IF (env_subs) THEN
+      DO k=kts+1,kte-1
+         !First, smooth the profiles of w & a, since sharp vertical gradients
+         !in plume variables are not likely extended to env variables
+         !Note1: w is treated as negative further below
+         !Note2: both w & a will be transformed into env variables further below
+         envi_w(k) = onethird*(edmf_w1(k-1)+edmf_w1(k)+edmf_w1(k+1))
+         envi_a(k) = onethird*(edmf_a1(k-1)+edmf_a1(k)+edmf_a1(k+1))*adjustment
+      ENDDO
+      !define env variables at k=1 (top of first model layer)
+      envi_w(kts) = edmf_w1(kts)
+      envi_a(kts) = edmf_a1(kts)
+      !define env variables at k=kte
+      envi_w(kte) = 0.0
+      envi_a(kte) = edmf_a1(kte)
+      !define env variables at k=kte+1
+      envi_w(kte+1) = 0.0
+      envi_a(kte+1) = edmf_a1(kte)
+      !Add limiter for very long time steps (i.e. dt > 300 s)
+      !Note that this is not a robust check - only for violations in
+      !   the first model level.
+      IF (envi_w(kts) > 0.9*dz1(kts)/dt) THEN
+         sublim = 0.9*dz1(kts)/dt/envi_w(kts)
+      ELSE
+         sublim = 1.0
+      ENDIF
+      !Transform w & a into env variables
+      DO k=kts,kte
+         temp=envi_a(k)
+         envi_a(k)=1.0-temp
+         envi_w(k)=csub*sublim*envi_w(k)*temp/(1.-temp)
+      ENDDO
+      !calculate tendencies from subsidence and detrainment valid at the middle of
+      !each model layer. The lowest model layer uses an assumes w=0 at the surface.
+      dzi(kts)     = 0.5*(dz1(kts)+dz1(kts+1))
+      sub_thl1(kts)= 0.5*envi_w(kts)*envi_a(kts)*                               &
+                     (rho1(kts+1)*thl1(kts+1)-rho1(kts)*thl1(kts))/dzi(kts)/rhoz(kts)
+      sub_sqv1(kts)= 0.5*envi_w(kts)*envi_a(kts)*                               &
+                     (rho1(kts+1)*qv1(kts+1)-rho1(kts)*qv1(kts))/dzi(kts)/rhoz(kts)
+      DO k=kts+1,kte-1
+         dzi(k)     = 0.5*(dz1(k)+dz1(k+1))
+         sub_thl1(k)= 0.5*(envi_w(k)+envi_w(k-1))*0.5*(envi_a(k)+envi_a(k-1)) * &
+                      (rho1(k+1)*thl1(k+1)-rho1(k)*thl1(k))/dzi(k)/rhoz(k)
+         sub_sqv1(k)= 0.5*(envi_w(k)+envi_w(k-1))*0.5*(envi_a(k)+envi_a(k-1)) * &
+                      (rho1(k+1)*qv1(k+1)-rho1(k)*qv1(k))/dzi(k)/rhoz(k)
+      ENDDO
+
+      DO k=kts,KTE-1
+         det_thl1(k)=Cdet*(envm_thl(k)-thl1(k))*envi_a(k)*Psig_w
+         det_sqv1(k)=Cdet*(envm_sqv(k)-qv1(k))*envi_a(k)*Psig_w
+         det_sqc1(k)=Cdet*(envm_sqc(k)-qc1(k))*envi_a(k)*Psig_w
+      ENDDO
+
+      IF (momentum_opt > 0) THEN
+         sub_u1(kts)=0.5*envi_w(kts)*envi_a(kts)*                               &
+                     (rho1(kts+1)*u1(kts+1)-rho1(kts)*u1(kts))/dzi(kts)/rhoz(kts)
+         sub_v1(kts)=0.5*envi_w(kts)*envi_a(kts)*                               &
+                     (rho1(kts+1)*v1(kts+1)-rho1(kts)*v1(kts))/dzi(kts)/rhoz(kts)
+         DO k=kts+1,kte-1
+            sub_u1(k)=0.5*(envi_w(k)+envi_w(k-1))*0.5*(envi_a(k)+envi_a(k-1)) * &
+                       (rho1(k+1)*u1(k+1)-rho1(k)*u1(k))/dzi(k)/rhoz(k)
+            sub_v1(k)=0.5*(envi_w(k)+envi_w(k-1))*0.5*(envi_a(k)+envi_a(k-1)) * &
+                       (rho1(k+1)*v1(k+1)-rho1(k)*v1(k))/dzi(k)/rhoz(k)
+         ENDDO
+
+         DO k=kts,KTE-1
+           det_u1(k) = Cdet*(envm_u(k)-u1(k))*envi_a(k)*Psig_w
+           det_v1(k) = Cdet*(envm_v(k)-v1(k))*envi_a(k)*Psig_w
+         ENDDO
+       ENDIF
+   ENDIF !end subsidence/env detranment
+
+   !First, compute exner, plume theta, and dz centered at interface
+   !Here, k=1 is the top of the first model layer. These values do not 
+   !need to be defined at k=kte (unused level).
+   DO k=kts,kte-1
+      exneri(k)  = (ex1(k)*dz1(k+1)+ex1(k+1)*dz1(k))/(dz1(k+1)+dz1(k))
+      edmf_th1(k)= edmf_thl1(k) + xlvcp/ex1(k)*edmf_qc1(K)
+      dzi(k)     = 0.5*(dz1(k)+dz1(k+1))
+   ENDDO
+
+!JOE: ADD CLDFRA_bl1, qc_bl1. Note that they have already been defined in
+!     mym_condensation. Here, a shallow-cu component is added, but no cumulus
+!     clouds can be added at k=1 (start loop at k=2).
+   do k=kts+1,kte-2
+      if (k > KTOP) exit
+         if(0.5*(edmf_qc1(k)+edmf_qc1(k-1))>0.0 .and. (cldfra_bl1(k) < cf_thresh))THEN
+            !interpolate plume quantities to mass levels
+            Aup = (edmf_a1(k)*dzi(k-1)+edmf_a1(k-1)*dzi(k))/(dzi(k-1)+dzi(k))
+            THp = (edmf_th1(k)*dzi(k-1)+edmf_th1(k-1)*dzi(k))/(dzi(k-1)+dzi(k))
+            QTp = (edmf_qt1(k)*dzi(k-1)+edmf_qt1(k-1)*dzi(k))/(dzi(k-1)+dzi(k))
+            !convert TH to T
+!            t = THp*exner(k)
+            !SATURATED VAPOR PRESSURE
+            esat = esat_blend(tk1(k))
+            !SATURATED SPECIFIC HUMIDITY
+            qsl=ep_2*esat/max(1.e-7,(p1(k)-ep_3*esat)) 
+
+            !condensed liquid in the plume on mass levels
+            if (edmf_qc1(k)>0.0 .and. edmf_qc1(k-1)>0.0) then
+              QCp = (edmf_qc1(k)*dzi(k-1)+edmf_qc1(k-1)*dzi(k))/(dzi(k-1)+dzi(k))
+            else
+              QCp = max(edmf_qc1(k),edmf_qc1(k-1))
+            endif
+
+            !COMPUTE CLDFRA & QC_BL FROM MASS-FLUX SCHEME and recompute vt & vq
+            xl = xl_blend(tk1(k))               ! obtain blended heat capacity
+            qsat_tk = qsat_blend(tk1(k),p1(k))  ! get saturation water vapor mixing ratio
+                                                !   at t and p
+            rsl = xl*qsat_tk / (r_v*tk1(k)**2)  ! slope of C-C curve at t (abs temp)
+                                                ! CB02, Eqn. 4
+            cpm = cp + qt1(k)*cpv               ! CB02, sec. 2, para. 1
+            a   = 1./(1. + xl*rsl/cpm)          ! CB02 variable "a"
+            b9  = a*rsl                         ! CB02 variable "b" 
+
+            q2p  = xlvcp/ex1(k)
+            pt = thl1(k) +q2p*QCp*Aup ! potential temp (env + plume)
+            bb = b9*tk1(k)/pt ! bb is "b9" in BCMT95.  Their "b9" differs from
+                           ! "b9" in CB02 by a factor
+                           ! of T/theta.  Strictly, b9 above is formulated in
+                           ! terms of sat. mixing ratio, but bb in BCMT95 is
+                           ! cast in terms of sat. specific humidity.  The
+                           ! conversion is neglected here.
+            qww   = 1.+0.61*qt1(k)
+            alpha = 0.61*pt
+            beta  = pt*xl/(tk1(k)*cp) - 1.61*pt
+            !Buoyancy flux terms have been moved to the end of this section...
+
+            !Now calculate convective component of the cloud fraction:
+            if (a > 0.0) then
+               f = MIN(1.0/a, 4.0)              ! f is vertical profile scaling function (CB2005)
+            else
+               f = 1.0
+            endif
+
+            !CB form:
+            !sigq = 3.5E-3 * Aup * 0.5*(edmf_w1(k)+edmf_w1(k-1)) * f  ! convective component of sigma (CB2005)
+            !sigq = SQRT(sigq**2 + sgm1(k)**2)    ! combined conv + stratus components
+            !Per S.DeRoode 2009?
+            !sigq = 5. * Aup * (QTp - qt1(k))
+            sigq = 10. * Aup * (QTp - qt1(k)) 
+            !constrain sigq wrt saturation:
+            sigq = max(sigq, qsat_tk*0.02 )
+            sigq = min(sigq, qsat_tk*0.25 )
+
+            qmq = a * (qt1(k) - qsat_tk)          ! saturation deficit/excess;
+            Q1  = qmq/sigq                        !   the numerator of Q1
+
+            if ((landsea-1.5).GE.0) then      ! WATER
+               !modified form from LES
+               !mf_cf = min(max(0.5 + 0.36 * atan(1.20*(Q1+0.2)),0.01),0.6)
+               !Original CB
+               mf_cf = min(max(0.5 + 0.36 * atan(1.55*Q1),0.01),0.6)
+               mf_cf = max(mf_cf, 1.2 * Aup)
+               mf_cf = min(mf_cf, 5.0 * Aup)
+            else                              ! LAND
+               !LES form
+               !mf_cf = min(max(0.5 + 0.36 * atan(1.20*(Q1+0.4)),0.01),0.6)
+               !Original CB
+               mf_cf = min(max(0.5 + 0.36 * atan(1.55*Q1),0.01),0.6)
+               mf_cf = max(mf_cf, 1.8 * Aup)
+               mf_cf = min(mf_cf, 5.0 * Aup)
+            endif
+
+            !IF ( debug_code ) THEN
+            !   print*,"In MYNN, StEM edmf"
+            !   print*,"  CB: env qt=",qt1(k)," qsat=",qsat_tk
+            !   print*,"  k=",k," satdef=",QTp - qsat_tk," sgm=",sgm1(k)
+            !   print*,"  CB: sigq=",sigq," qmq=",qmq," tk=",tk1(k)
+            !   print*,"  CB: mf_cf=",mf_cf," cldfra_bl=",cldfra_bl1(k)," edmf_a1=",edmf_a1(k)
+            !ENDIF
+
+            ! Update cloud fractions and specific humidities in grid cells
+            ! where the mass-flux scheme is active. The specific humidities
+            ! are converted to grid means (not in-cloud quantities).
+            if ((landsea-1.5).GE.0) then     ! water
+               if (QCp * Aup > 5e-5) then
+                  qc_bl1(k) = 1.86 * (QCp * Aup) - 2.2e-5
+               else
+                  qc_bl1(k) = 1.18 * (QCp * Aup)
+               endif
+               cldfra_bl1(k)= mf_cf
+               Ac_mf        = mf_cf
+            else                             ! land
+               if (QCp * Aup > 5e-5) then
+                  qc_bl1(k) = 1.86 * (QCp * Aup) - 2.2e-5
+               else
+                  qc_bl1(k) = 1.18 * (QCp * Aup)
+               endif
+               cldfra_bl1(k)= mf_cf
+               Ac_mf        = mf_cf
+            endif
+
+            !Now recalculate the terms for the buoyancy flux for mass-flux clouds:
+            !See mym_condensation for details on these formulations.
+            !Use Bechtold and Siebesma (1998) piecewise estimation of Fng with 
+            !limits ,since they really should be recalculated after all the other changes...:
+            !Only overwrite vt & vq in non-stratus condition
+            !if ((landsea-1.5).GE.0) then      ! WATER
+               Q1=max(Q1,-2.25)
+            !else
+            !   Q1=max(Q1,-2.0)
+            !endif
+
+            if (Q1 .ge. 1.0) then
+               Fng = 1.0
+            elseif (Q1 .ge. -1.7 .and. Q1 .lt. 1.0) then
+               Fng = EXP(-0.4*(Q1-1.0))
+            elseif (Q1 .ge. -2.5 .and. Q1 .lt. -1.7) then
+               Fng = 3.0 + EXP(-3.8*(Q1+1.7))
+            else
+               Fng = min(23.9 + EXP(-1.6*(Q1+2.5)), 60.)
+            endif
+
+            !link the buoyancy flux function to active clouds only (c*Aup):
+            vt1(k) = qww   - (1.5*Aup)*beta*bb*Fng - 1.
+            vq1(k) = alpha + (1.5*Aup)*beta*a*Fng  - tv0
+         endif !check for (qc in plume) .and. (cldfra_bl < threshold)
+      enddo !k-loop
+
+ENDIF  !end nup2 > 0
+
+!modify output (negative: dry plume, positive: moist plume)
+if (ktop > 0) then
+   maxqc = maxval(edmf_qc1(1:ktop)) 
+   if ( maxqc < 1.E-8) maxmf = -1.0*maxmf
+endif
+
+!
+! debugging
+!
+if (edmf_w1(1) > 4.0) then
+! surface values
+    print *,'flq:',flq,' fltv:',fltv2
+    print *,'pblh:',pblh,' wstar:',wstar
+    print *,'sigmaW=',sigmaW,' sigmaTH=',sigmaTH,' sigmaQT=',sigmaQT
+! means
+!   print *,'u:',u1
+!   print *,'v:',v1
+!   print *,'thl:',thl1
+!   print *,'thv:',thv1
+!   print *,'qt:',qt1
+!   print *,'p:',p1
+ 
+! updrafts
+! DO I=1,NUP2
+!   print *,'up:A',i
+!   print *,UPA(:,i)
+!   print *,'up:W',i
+!   print*,UPW(:,i)
+!   print *,'up:thv',i
+!   print *,UPTHV(:,i)
+!   print *,'up:thl',i 
+!   print *,UPTHL(:,i)
+!   print *,'up:qt',i
+!   print *,UPQT(:,i)
+!   print *,'up:tQC',i
+!   print *,UPQC(:,i)
+!   print *,'up:ent',i
+!   print *,ENT(:,i)   
+! ENDDO
+ 
+! mean updrafts
+   print *,' edmf_a1',edmf_a1(1:14)
+   print *,' edmf_w1',edmf_w1(1:14)
+   print *,' edmf_qt1:',edmf_qt1(1:14)
+   print *,' edmf_thl1:',edmf_thl1(1:14)
+ 
+ENDIF !END Debugging
+
+
+#ifdef HARDCODE_VERTICAL
+# undef kts
+# undef kte
+#endif
+
+END SUBROUTINE DMP_MF
+!=================================================================
+!>\ingroup gsd_mynn_edmf
+!! This subroutine 
+subroutine condensation_edmf(QT,THL,P,zagl,THV,QC)
+!
+! zero or one condensation for edmf: calculates THV and QC
+!
+real(kind_phys),intent(in)   :: QT,THL,P,zagl
+real(kind_phys),intent(inout):: THV
+real(kind_phys),intent(inout):: QC
+
+integer :: niter,i
+real(kind_phys):: diff,exn,t,th,qs,qcold
+
+! constants used from module_model_constants.F
+! p1000mb
+! rcp ... Rd/cp
+! xlv ... latent heat for water (2.5e6)
+! cp
+! rvord .. r_v/r_d  (1.6) 
+
+! number of iterations
+  niter=50
+! minimum difference (usually converges in < 8 iterations with diff = 2e-5)
+  diff=1.e-6
+
+  EXN=(P/p1000mb)**rcp
+  !QC=0.  !better first guess QC is incoming from lower level, do not set to zero
+  do i=1,NITER
+     T=EXN*THL + xlvcp*QC
+     QS=qsat_blend(T,P)
+     QCOLD=QC
+     QC=0.5*QC + 0.5*MAX((QT-QS),0.)
+     if (abs(QC-QCOLD)<Diff) exit
+  enddo
+
+  T=EXN*THL + xlvcp*QC
+  QS=qsat_blend(T,P)
+  QC=max(QT-QS,0.)
+
+  !Do not allow saturation below 100 m
+  if(zagl < 100.)QC=0.
+
+  !THV=(THL+xlv/cp*QC).*(1+(1-rvovrd)*(QT-QC)-QC);
+  THV=(THL+xlvcp*QC)*(1.+QT*(rvovrd-1.)-rvovrd*QC)
+
+!  IF (QC > 0.0) THEN
+!    PRINT*,"EDMF SAT, p:",p," iterations:",i
+!    PRINT*," T=",T," THL=",THL," THV=",THV
+!    PRINT*," QS=",QS," QT=",QT," QC=",QC,"ratio=",qc/qs
+!  ENDIF
+
+  !THIS BASICALLY GIVE THE SAME RESULT AS THE PREVIOUS LINE
+  !TH = THL + xlv/cp/EXN*QC
+  !THV= TH*(1. + p608*QT)
+
+  !print *,'t,p,qt,qs,qc'
+  !print *,t,p,qt,qs,qc 
+
+
+end subroutine condensation_edmf
+
+!===============================================================
+subroutine condensation_ddmf(qt,thl,p,zagl,thv,qc,qi,debug_dd)
+!
+! zero or one condensation for edmf: calculates thv, qc, and qi
+!
+real(kind_phys),intent(in)   :: qt,thl,p,zagl
+real(kind_phys),intent(inout):: thv,qc,qi
+
+integer :: niter,i,debug_dd
+real(kind_phys):: diff,exn,t,th,qs,qx,qxold,frac_ice,frac_liq,thvin
+
+! number of iterations
+  niter=50
+! minimum difference (usually converges in < 8 iterations with diff = 2e-5)
+  diff=1.e-6
+
+  if ((qi+qc) .gt. 0.0) then
+     frac_ice = qi/(qi+qc)
+     frac_liq = 1.0 - frac_ice
+  else
+     frac_ice = 0.0
+     frac_liq = 0.0
+  endif
+
+  if (debug_dd == 1) then
+     thvin = thv
+     print*,"------- in consensation_ddmf-------------"
+     print*,"input qc=",qc," qi=",qi," frac_liq=",frac_liq
+  endif
+
+  exn=(p/p1000mb)**rcp
+  do i=1,niter
+     t=exn*thl + xlvcp*qc + xlscp*qi
+     qs=qsat_blend(t,p)
+     qxold=qc+qi
+     qx=qc+qi
+     qx=0.5*qx + 0.5*max((qt-qs),0.)
+     qc=frac_liq*qx
+     qi=frac_ice*qx
+     if (abs(qx-qxold)<diff) exit
+  enddo
+
+  t=exn*thl + xlvcp*qc + xlscp*qi
+  qs=qsat_blend(t,p)
+  qx=max(qt-qs,0.)
+  qc=frac_liq*qx
+  qi=frac_ice*qx
+
+  !thv=(thl+xlv/cp*qc).*(1+(1-rvovrd)*(qt-qc)-qc)
+!was this: thv=(thl+xlvcp*qc)*(1.+qt*(rvovrd-1.)-rvovrd*qc)
+  !thv=(thl + xlvcp*qc + xlscp*qi)*(1. + qt*(rvovrd-1.)-rvovrd*qc)
+  thv=(thl + xlvcp*qc + xlscp*qi)*(1. + p608*(qt-qx))
+
+!  if (qc > 0.0) then
+!    print*,"edmf sat, p:",p," iterations:",i
+!    print*," t=",t," thl=",thl," thv=",thv
+!    print*," qs=",qs," qt=",qt," qc=",qc,"ratio=",qc/qs
+!  endif
+
+  !this basically give the same result as the previous line
+  !th = thl + xlv/cp/exn*qc
+  !thv= th*(1. + p608*qt)
+
+  !print *,'t,p,qt,qs,qc'
+  !print *,t,p,qt,qs,qc
+
+  if (debug_dd == 1) then
+     print*,"output qc=",qc," qi=",qi," frac_liq=",frac_liq
+     print*,"input thv=",thvin," out thv=",thv," diff=",thv-thvin
+     print*,"------- exiting consensation_ddmf----------"
+  endif
+
+end subroutine condensation_ddmf
+
+!===============================================================
+
+subroutine condensation_edmf_r(QT,THL,P,zagl,THV,QC)
+!                                                                                                
+! zero or one condensation for edmf: calculates THL and QC                                       
+! similar to condensation_edmf but with different inputs                                         
+!                                                                                                
+real(kind_phys),intent(in)   :: QT,THV,P,zagl
+real(kind_phys),intent(inout):: THL, QC
+
+integer :: niter,i
+real(kind_phys):: diff,exn,t,th,qs,qcold
+
+! number of iterations                                                                           
+  niter=50
+! minimum difference                                                                             
+  diff=2.e-5
+
+  EXN=(P/p1000mb)**rcp
+  ! assume first that th = thv                                                                   
+  T = THV*EXN
+  !QS = qsat_blend(T,P)                                                                          
+  !QC = QS - QT                                                                                  
+
+  QC=0.
+
+  do i=1,NITER
+     QCOLD = QC
+     T = EXN*THV/(1.+QT*(rvovrd-1.)-rvovrd*QC)
+     QS=qsat_blend(T,P)
+     QC= MAX((QT-QS),0.)
+     if (abs(QC-QCOLD)<Diff) exit
+  enddo
+  THL = (T - xlv/cp*QC)/EXN
+
+end subroutine condensation_edmf_r
+
+!===============================================================
+! ddmp_mf is a downdraft mass flux scheme - analogous to the updrafts but
+! flipped upsidedown and revised to be more specific for turbulence
+! driven by radiative cooling at cloud tops. this scheme has been primarily
+! designed for stratocumulus cloud conditions. This is based off of a
+! combination of the original scheme [Wu et al. (2020, MWR)] but several
+! modifications were made to better fit it in the MYNN-EDMF and to
+! help the coupling to the Thompson microphysics scheme. Some of the
+! primary design changes include:
+!                                                                                                                                                                      
+! 1) the spectral plume design, similar to the MYNNs updraft scheme
+! 2) generalized to any cloud, not just PBL-topped clouds
+! 3) always initialized at the cloud top
+! 4) can penetrate all the way to the surface
+! 5) generalized for mixed-phase clouds
+! 6) mixes number concentration for double moment schemes
+! 7) mixes aerosols
+! 8) revised the conection to the solver
+
+subroutine ddmp_mf(kts,kte,dt,dx,zw,dz,p,            &
+              &u,v,th,thl,thv,tk,qt,qv,qc,qi,        &
+              &qnc,qni,qnwfa,qnifa,                  &
+              &qke,rho,exner,                        &
+              &qc_bl1,qi_bl1,cldfra_bl1,             &
+              &ust,flt,flq,fltv,pblh,kpbl,           &
+              &edmf_a_dd,edmf_w_dd, edmf_qt_dd,      &
+              &edmf_thl_dd,edmf_ent_dd,edmf_qc_dd,   &
+              &sd_aw,sd_awthl,sd_awqt,               &
+              &sd_awqv,sd_awqc,sd_awqi,              &
+              &sd_awqnc,sd_awqni,                    &
+              &sd_awqnwfa,sd_awqnifa,                &
+              &sd_awu,sd_awv,sd_awqke,               &
+              &tkeprod_dn,el,                        &
+              &rthraten                              )
+
+        integer, intent(in) :: kts,kte,kpbl
+        real(kind_phys), dimension(kts:kte), intent(in) ::            &
+            u,v,th,thl,tk,qt,qv,qc,qi,thv,p,qke,rho,exner,            &
+            qnc,qni,qnwfa,qnifa,dz,qc_bl1,qi_bl1,cldfra_bl1,el
+        real(kind_phys), dimension(kts:kte), intent(in) :: rthraten
+        ! zw .. heights of the downdraft levels (edges of boxes)
+        real(kind_phys), dimension(kts:kte+1), intent(in) :: zw
+        real(kind_phys), intent(in)  :: flt,flq,fltv
+        real(kind_phys), intent(in)  :: dt,dx,ust,pblh
+  ! outputs - downdraft properties
+        real(kind_phys), dimension(kts:kte), intent(out) ::           &
+        edmf_a_dd,   edmf_w_dd,   edmf_qt_dd,  edmf_thl_dd,       &
+        edmf_ent_dd, edmf_qc_dd,  tkeprod_dn
+
+  ! outputs - variables needed for solver (sd_aw - sum ai*wi, sd_awphi - sum ai*wi*phii)
+        real(kind_phys), dimension(kts:kte+1) ::                      &
+            sd_aw, sd_awthl, sd_awu, sd_awv,                          &
+            sd_awqt, sd_awqc, sd_awqv, sd_awqi, sd_awqnc, sd_awqni,   &
+            sd_awqnwfa, sd_awqnifa, sd_awqke, sd_aw2
+
+   !downdraft properties
+        integer, parameter::                                          &
+            & ndd    = 5,               &  !number of downdrafts
+            & kmin   = 3                   !lowest k-level where downdrafts can start
+        real(kind_phys),parameter ::                                  &
+            & minddd = 400.,            &  !min downdraft diameter (m)
+            & maxddd = 1000,            &  !max downdraft diameter (m)
+            & zmin   = 50.                 !lowest height where downdrafts can start
+        real(kind_phys)::                                             &
+            & maxdd2,                   &  !variable max downdraft diameter (m)
+            &    ddd,                   &  !downdraft diameter
+            &     dl,                   &  !diameter increment
+            &    add,                   &  !total area of downdrafts
+            & minexc,                   &  !minimum init downdraft temp pert
+            & maxexc                       !maximum init downdraft temp pert
+  ! k-index of downdraft starting height
+        integer,         dimension(1:ndd) :: dd_initk
+  ! downdraft column properties
+        real(kind_phys), dimension(kts:kte+1,1:ndd) ::                &
+            downw,downthl,downqt,downqc,downa,downu,downv,downthv,    &
+            downqi,downqnc,downqni,downqnwfa,downqnifa
+  ! entrainment variables
+        real(kind_phys), dimension(kts:kte+1,1:ndd) :: ent
+  ! internal variables
+        integer :: k,i,ki,qltop,qlbase
+        real(kind_phys):: qstar,thstar,sigmaw,sigmaqt,                &
+            sigmath,z0,pwmin,pwmax,wmin,wmax,went,mindownw
+        real(kind_phys):: qtn,thln,thvn,qcn,un,vn,qken,wn2,wn,        &
+            qin,qncn,qnin,qnwfan,qnifan,                              &
+            thvk,pk,entexp,entw,beta_dm,entexm,rho_int
+        real(kind_phys):: jump_thv,jump_qt,jump_thetal,               &
+            refthl,refthv,refthlv,refqt,refqc,refqi,refqnc,refqni,    &
+            refqnwfa,refqnifa,refu,refv,refqke,refqt2,reftk,refp,     &
+            qx_k,qx_km1,refthvm1,cftop,ac_wsp,wspd_pbl
+
+  ! dd specific internal variables
+        real(kind_phys):: radflux, f0, wstar_rad, dz_ent
+        logical :: cloudflg
+        logical :: singlelayer             !check for single or multi-layer clouds
+        real(kind_phys):: sigq,xl,rsl,cpm,a,mf_cf,diffqt,             &
+            fng,qww,alpha,beta,bb,f,pt,t,q2p,b9,satvp,rhgrid,         &
+            def_th,def_qt,frac_liq,frac_ice,qs1,qs2
+
+  ! w parameters
+        real(kind_phys),parameter ::                                  &
+            &wa=1., wb=1.5, z00=100.
+        real(kind_phys) :: buoy,bcoeff,ecoeff
+
+  ! additional printouts for debugging
+        integer, parameter :: debug_dd=0
+
+  ! =================================================================
+  ! initialize downdraft properties
+   downw      =0.
+   downthl    =0.
+   downthv    =0.
+   downqt     =0.
+   downa      =0.
+   downu      =0.
+   downv      =0.
+   downqc     =0.
+   downqi     =0.
+   downqnc    =0.
+   downqni    =0.
+   downqnwfa  =0.
+   downqnifa  =0.
+   ent        =0.
+   tkeprod_dn =0.
+   dd_initk   =0
+
+   edmf_a_dd  =0.
+   edmf_w_dd  =0.
+   edmf_qt_dd =0.
+   edmf_thl_dd=0.
+   edmf_ent_dd=0.
+   edmf_qc_dd =0.
+
+   sd_aw      =0.
+   sd_awthl   =0.
+   sd_awqt    =0.
+   sd_awqv    =0.
+   sd_awqc    =0.
+   sd_awqi    =0.
+   sd_awqnc   =0.
+   sd_awqni   =0.
+   sd_awqnwfa =0.
+   sd_awqnifa =0.
+   sd_awu     =0.
+   sd_awv     =0.
+   sd_awqke   =0.
+
+  ! determine maximum downdraft width and increments
+   maxdd2     =min(maxddd, 1.2*dx)
+   dl         =max(maxdd2-minddd, 0.0)/real(ndd-1)
+
+  ! first, check for stratocumulus-topped pbl with cooling at the cloud top.
+   cloudflg   =.false.
+   singlelayer=.false.
+   qltop      =1     !initialize
+   qlbase     =1     !initialize
+   do k = max(kmin+1,kpbl-2),kpbl+10
+      qx_k    =max(qt(k)  , qc_bl1(k)  +qi_bl1(k))   !total clouds at k
+      qx_km1  =max(qt(k-1), qc_bl1(k-1)+qi_bl1(k-1)) !total clouds at k-1
+!      if (qx_k  .lt. 1.e-6 .and. cldfra_bl(k-1).lt.0.1 .and. &
+!          qx_km1.gt. 1.e-6 .and. cldfra_bl(k)  .gt.0.5 .and. &
+       !---------------------------------criteria for downdraft activation
+      if ((cldfra_bl1(k-1).gt.0.5       ) .and. & !1) stratocumulus exists
+!          (cldfra_bl1(k)  .lt.0.1       ) .and. & !2) clear above
+          (rthraten(k-1) .lt. -0.000025)  .and. & !3) radiative cooling
+          (           dl .gt.0.0       )) then   !4) widest downdraft > thinnest
+         cloudflg =.true. ! found sc cloud
+         qltop    =k-1    ! index for sc cloud top
+         cftop    =cldfra_bl1(k-1)
+         if (cldfra_bl1(k-2).lt.0.1)singlelayer=.true.
+      endif
+   enddo
+
+   !found sc cloud, trigger downdrafts
+   if (cloudflg) then
+      do k = qltop, kts, -1
+         qx_k    =max(qt(k)  , qc_bl1(k) +qi_bl1(k))   !total clouds at k
+         if (qx_k .gt. 1e-6) then
+            qlbase = k ! index for sc cloud base
+         endif
+      enddo
+
+      do i=1,ndd
+         ! downdraft starts at the first layer interface below the cloud top
+         dd_initk(i) = qltop
+      enddo
+
+      ! loop radflux
+      f0 = 0.0
+      do k = kmin, qltop
+         radflux = rthraten(k) * exner(k) ! converts theta/s to temperature/s
+         radflux = radflux * cp / grav * ( p(k) - p(k+1) ) ! converts k/s to w/m^2
+         if ( radflux < 0.0 ) f0 = abs(radflux) + f0
+      enddo
+      f0 = min(max(f0, 1.0), 200.)  !total radiative cooling (w/m2)
+
+      !allow the total fractional area of the downdrafts (add) to be proportional
+      !to the radiative forcing:
+      !for  50 w/m2, add = 0.20
+      !for 100 w/m2, add = 0.30
+      !for 150 w/m2, add = 0.40
+      add = min( 0.1 + f0*0.002, 0.4)
+      !taper off area for high wind speeds
+      wspd_pbl=SQRT(MAX(u(kts)**2 + v(kts)**2, 0.01_kind_phys))
+      if (wspd_pbl .le. 10.) then
+         ac_wsp = 1.0
+      else
+         ac_wsp = 1.0 - min((wspd_pbl - 10.0)/15., 1.0)
+      endif
+      add  = add * ac_wsp
+
+      !find inversion strength across cloud top entrainment zone--normalized to 200 m vertical grid spacing
+      dz_ent      = 0.5 * (dz(qltop+1) + dz(qltop))
+      jump_thv    = (thv(qltop+1) - thv(qltop)) / dz_ent * 200._kind_phys
+      jump_qt     = (qt(qltop+1)  - qt(qltop))	/ dz_ent * 200._kind_phys
+      jump_thetal = (thl(qltop+1) - thl(qltop))	/ dz_ent * 200._kind_phys
+
+      ki = qltop  !index of cloud top
+      if (singlelayer) then !initialize dd with cloud properties (not using info from above)
+         refthl  = thl(ki)
+         refthlv = refthl*(1.+p608*qv(ki))
+         refthv  = thv(ki)
+         refthvm1= thv(ki-1)
+         reftk   = tk(ki)
+         refqt   = qt(ki)
+         refqc   = qc(ki)
+         refqi   = qi(ki)
+         refqnc  = qnc(ki)
+         refqni  = qni(ki)
+         refqnwfa= qnwfa(ki)
+         refqnifa= qnifa(ki)
+         refu    = u(ki)
+         refv    = v(ki)
+         refqke  = qke(ki)
+         refp    = p(ki)
+      else                  !initialize dd with avg of in-cloud properties (at & below) cloud top 
+         refthl  = (thl(ki-1)*dz(ki) + thl(ki)*dz(ki-1)) /(dz(ki)+dz(ki-1))
+         refthlv = refthl*(1.+p608*(qv(ki-1)*dz(ki) + qv(ki)*dz(ki-1)) /(dz(ki)+dz(ki-1)))
+         refthv  = (thv(ki-1)*dz(ki) + thv(ki)*dz(ki-1)) /(dz(ki)+dz(ki-1))
+         refthvm1= (thv(ki-2)*dz(ki-1) + thv(ki-1)*dz(ki-2)) /(dz(ki-1)+dz(ki-2)) 
+         reftk   = (tk(ki-1)*dz(ki)  + tk(ki)*dz(ki-1))  /(dz(ki)+dz(ki-1))
+         refqt   = (qt(ki-1)*dz(ki)  + qt(ki)*dz(ki-1))  /(dz(ki)+dz(ki-1))
+         refqc   = (qc(ki-1)*dz(ki)  + qc(ki)*dz(ki-1))  /(dz(ki)+dz(ki-1))
+         refqi   = (qi(ki-1)*dz(ki)  + qi(ki)*dz(ki-1))  /(dz(ki)+dz(ki-1))
+         refqnc  = (qnc(ki-1)*dz(ki) + qnc(ki)*dz(ki-1)) /(dz(ki)+dz(ki-1))
+         refqni  = (qni(ki-1)*dz(ki) + qni(ki)*dz(ki-1)) /(dz(ki)+dz(ki-1))
+         refqnwfa= (qnwfa(ki-1)*dz(ki) + qnwfa(ki)*dz(ki-1)) /(dz(ki)+dz(ki-1))
+         refqnifa= (qnifa(ki-1)*dz(ki) + qnifa(ki)*dz(ki-1)) /(dz(ki)+dz(ki-1))
+         refu    = (u(ki-1)*dz(ki)   + u(ki)*dz(ki-1))   /(dz(ki)+dz(ki-1))
+         refv    = (v(ki-1)*dz(ki)   + v(ki)*dz(ki-1))   /(dz(ki)+dz(ki-1))
+         refqke  = (qke(ki-1)*dz(ki) + qke(ki)*dz(ki-1)) /(dz(ki)+dz(ki-1))
+         refp    = (p(ki-1)*dz(ki)   + p(ki)*dz(ki-1))   /(dz(ki)+dz(ki-1))
+      endif
+
+      ! w* from radiative forcing
+      wstar_rad = ( grav * zw(ki) * f0 / (refthl * rho(ki) * cp) ) **onethird
+      wstar_rad = max(wstar_rad, 0.1)
+      went      = thv(1) / ( grav * jump_thv * zw(ki) ) * &
+                  (0.5 * wstar_rad**3 )
+      qstar     = abs(went*jump_qt/wstar_rad)
+      thstar    = f0/rho(ki)/cp/wstar_rad - went*jump_thv/wstar_rad
+
+      sigmaw    = 0.3 * wstar_rad ! 0.8*wstar_rad ! tuning parameter ! 0.5 was good
+      sigmaqt   = 40  * qstar  ! 50 was good
+      sigmath   = 1.0 * thstar ! 0.5 was good
+
+      pwmin     = -1. ! drawing from the negative tail -3sigma to -1sigma
+      pwmax     = -3.
+      wmin      = max(min(sigmaw*pwmin, -0.1), -0.2)
+      wmax      = max(min(sigmaw*pwmax, -0.2), -0.5)
+
+      !initialize downdraft temperature deficit def_th
+      minexc = min(-0.05     , 0.5*(refthvm1 - refthv)) !increase prob to go down 1 level
+      maxexc = min(minexc-0.1, -0.5          )
+      maxexc = max(maxexc    , thv(1) - refthlv)  !init parcel temp >= thv_sfc
+      def_th = max(min(0.05*(-0.3)*sigmath/sigmaw, minexc), maxexc)
+
+      !initialize downdraft moisture deficit def_qt (consistent with def_th)
+      qs1    = qsat_blend(reftk       ,refp)
+      qs2    = qsat_blend(reftk+def_th,refp)
+      refqt2 = refqt*qs2/qs1
+      !def_qt = min(refqt2 - refqt, 0.0) !small negative moisture perturbation
+      def_qt = min(qs2 - qs1,  -0.33*(refqc+refqi)) !small negative moisture perturbation
+      !def_qt = 0.5*(-0.3)*sigmaqt/sigmaw
+
+      if (refqc+refqi > 0.0) then
+         frac_liq = refqc/(refqc+refqi)
+         frac_ice = 1.0 - frac_liq
+      else
+         frac_liq = 0.0
+         frac_ice = 0.0
+      endif
+
+      if (debug_dd .eq. 1) then
+         print*,"found conditions for downdraft mixing"
+         print*,"qltop=",qltop," qlbase=",qlbase
+         print*,"qstar=",qstar," thstar=",thstar," went=",went
+         print*,"f0=",f0," jump_thv=",jump_thv
+         print*,"u*=",ust," jump_qt=",jump_qt," fltv=",fltv
+         print*,"grav=",grav," pblh=",pblh," thv(1)=",thv(1)
+         print*,"p(1)=",p(1)," jump_thetal=",jump_thetal
+         print*,"sigmaw=",sigmaw," wmin=",wmin," wmax=",wmax
+      endif
+
+      !intialize downdrafts
+      !as of now, all downdrafts start at the same height
+      do i=1,ndd
+         ki = dd_initk(i)
+
+         !initialize a negative (downward) vertical velocity
+         downw(ki,i)=wmin-(abs(wmax)-abs(wmin))/real(ndd-1)*(i-1)
+
+         !perhaps multiply downa by cloud fraction, so it's impact will diminish if
+         !clouds are mixed away over the course of the longer radiation time step(?)
+         downa(ki,i)     = add/real(ndd)
+         downu(ki,i)     = refu
+         downv(ki,i)     = refv
+         downqc(ki,i)    = max(refqc + def_qt*frac_liq, 0.0)
+         downqi(ki,i)    = max(refqi + def_qt*frac_ice, 0.0)
+         downqnc(ki,i)   = refqnc
+         downqni(ki,i)   = refqni
+         downqnwfa(ki,i) = refqnwfa
+         downqnifa(ki,i) = refqnifa
+         downqt(ki,i)    = refqt  + def_qt
+         downthv(ki,i)   = refthv + def_th*real(i)/real(ndd)
+         downthl(ki,i)   = refthl + def_th*real(i)/real(ndd)
+
+         !input :: qt,thv,p,zagl,  output :: thl, qc
+!         pk  =(p(ki-1)*dz(ki)+p(ki)*dz(ki-1))/(dz(ki)+dz(ki-1))
+!         call condensation_edmf_r(downqt(ki,i),   &
+!              &        downthl(ki,i),pk,zw(ki),   &
+!              &     downthv(ki,i),downqc(ki,i)    )
+      enddo
+
+      if (debug_dd .eq.1) then
+         print*,"=====initialized downdraft properties===="
+         print*,"downw=",downw(ki,:)
+         print*,"downa=",downa(ki,:)
+         print*,"downthv=",downthv(ki,:)
+         print*,"def_qt=",def_qt," def_th=",def_th," tot area=",add
+         print*,"begin integration of downdrafts (smallest to largest):"
+      endif
+
+      do i=1,ndd
+         ddd  = minddd + dl*real(i-1) !downdraft diameter
+         !initialize input into condensation routine
+         thvn = downthv(ki,i)
+         qcn  = downqc(ki,i)
+         qin  = downqi(ki,i)
+         do k=dd_initk(i)-1,kts+1,-1
+            !entrainment from tian and kuang (2016), with constraints
+            wmin = 0.1 + ddd*0.0005
+            !ent(k,i) = 0.33/(min(max(abs(downw(k+1,i)),wmin),0.9)*ddd)
+            ent(k,i) = 0.53/(min(max(abs(downw(k+1,i)),wmin),0.6)*ddd)
+
+            !minimum background entrainment and 1/z enhancement near surface
+            ent(k,i) = max(ent(k,i),0.0003)
+            ent(k,i) = max(ent(k,i),0.06/zw(k))
+            ent(k,i) = min(ent(k,i),0.9/dz(k)) ! liberal check for numerical stability
+
+            !starting at the first interface level below cloud top
+            !entexp=exp(-ent(k,i)*dz(k))
+            !entexp_m=exp(-ent(k,i)/3.*dz(k))
+            entexp  =ent(k,i)*dz(k)        !for all scalars
+            entexm  =ent(k,i)*dz(k)*0.5    !test for momentum
+
+            qtn     =downqt(k+1,i) *(1.-entexp) + qt(k)*entexp
+            thln    =downthl(k+1,i)*(1.-entexp) + thl(k)*entexp
+            qncn    =downqnc(k+1,i) *(1.-entexp) + qnc(k)*entexp
+            qnin    =downqni(k+1,i) *(1.-entexp) + qni(k)*entexp
+            qnwfan  =downqnwfa(k+1,i) *(1.-entexp) + qnwfa(k)*entexp
+            qnifan  =downqnifa(k+1,i) *(1.-entexp) + qnifa(k)*entexp
+            un      =downu(k+1,i)  *(1.-entexm) + u(k)*entexm
+            vn      =downv(k+1,i)  *(1.-entexm) + v(k)*entexm
+            !qken=downqke(k-1,i)*(1.-entexp) + qke(k)*entexp
+!            qtn =downqt(k+1,i) +(qt(k) -downqt(k+1,i)) *(1.-entexp)
+!            thln=downthl(k+1,i)+(thl(k)-downthl(k+1,i))*(1.-entexp)
+!            un  =downu(k+1,i)  +(u(k)  -downu(k+1,i))*(1.-entexp_m)
+!            vn  =downv(k+1,i)  +(v(k)  -downv(k+1,i))*(1.-entexp_m)
+
+            ! given new p & z, solve for thvn, qcn, and qin
+            pk  =(p(k-1)*dz(k)+p(k)*dz(k-1))/(dz(k)+dz(k-1))
+            call condensation_ddmf(qtn,thln,pk,zw(k),thvn,qcn,qin,debug_dd)
+
+            !calculate buoyancy
+            thvk =(thv(k-1)*dz(k)+thv(k)*dz(k-1))/(dz(k)+dz(k-1))
+            buoy =grav*(thvn/thvk - 1.0)
+            !downdraft decelleration to limit large tendencies at the surface
+            if (buoy > 0.0) then
+               bcoeff =  0.2  !0.15 = same as in updrafts
+               ecoeff = -2.0
+            else
+               bcoeff = 0.2*min(zw(k)/pblh, 1.0)
+               ecoeff = -2.0 - max(0.5*pblh-zw(k), 0.0)/(0.5*pblh)
+               buoy   = buoy*min(zw(k)/pblh, 1.0)
+            endif
+            if (k==kts+2) buoy=max(buoy,0.01)
+            if (k==kts+1) buoy=max(buoy,0.05)
+
+!            beta_dm = 2*wb*ent(k,i) + 0.5/(zw(k)-dz(k)) * &
+!                 &    max(1. - exp((zw(k) -dz(k))/z00 - 1. ) , 0.)
+!            entw=exp(-beta_dm * dz(k))
+!            entw=entexp
+!            if (beta_dm >0) then
+!               wn2=downw(k+1,i)**2*entw - wa*buoy/beta_dm * (1. - entw)
+!            else
+!               wn2=downw(k+1,i)**2      - 2.*wa*buoy*dz(k)
+!            end if
+
+            mindownw = min(downw(k+1,i),-0.2)
+            wn = downw(k+1,i) + (ecoeff*ent(k,i)*downw(k+1,i)        &
+                              - bcoeff*buoy/mindownw)*min(dz(k), 250.)
+
+            !do not allow a parcel to accelerate more than 1.25 m/s over 200 m.
+            !add max acceleration of -2.0 m/s for coarse vertical resolution.
+            if (wn < downw(k+1,i) - min(1.25*dz(k)/200., 2.0))then
+                wn = downw(k+1,i) - min(1.25*dz(k)/200., 2.0)
+            endif
+            !add symmetrical max decrease in velocity (less negative)
+            if (wn > downw(k+1,i) + min(1.25*dz(k)/200., 2.0))then
+                wn = downw(k+1,i) + min(1.25*dz(k)/200., 2.0)
+            endif
+            wn = max(min(wn,0.0), -3.0)
+
+            if (debug_dd .eq.1) then
+               print *, "downdraft #:", i," diameter:",ddd,"==========="
+               print *, "  k       =",      k,      " z    =", zw(k)
+               print *, "  ent     =",ent(k,i),     " bouy =", buoy
+               print *, "  downthv =",   thvn,      " thvk =", thvk
+               print *, "  downthl =",   thln,      " thl  =", thl(k)
+               print *, "  downqt  =",   qtn ,      " qt   =", qt(k)
+               print *, "  downqc  =",   qcn ,      " qc   =", qc(k)
+               print *, "  downw+1 =",downw(k+1,i), " wn2  =", wn
+            endif
+
+            if (wn .lt. 0.) then !terminate when velocity is too small
+               downw(k,i)  = wn !-sqrt(wn2)
+               downthv(k,i)   = thvn
+               downthl(k,i)   = thln
+               downqt(k,i)    = qtn
+               downqc(k,i)    = qcn
+               downqi(k,i)    = qin
+               downqnc(k,i)   = qncn
+               downqni(k,i)   = qnin
+               downqnwfa(k,i) = qnwfan
+               downqnifa(k,i) = qnifan
+               downu(k,i)     = un
+               downv(k,i)     = vn
+               downa(k,i)     = downa(k+1,i)
+            else
+               !downdrafts must go at least 2 levels
+!               if (dd_initk(i) - k .lt. 2) then
+!                  downw(:,i)  = 0.0
+!                  downthv(:,i)= 0.0
+!                  downthl(:,i)= 0.0
+!                  downqt(:,i) = 0.0
+!                  downqc(:,i) = 0.0
+!                  downu(:,i)  = 0.0
+!                  downv(:,i)  = 0.0
+!               endif
+               exit
+            endif
+         enddo
+      enddo
+   endif ! end cloud flag
+
+   downw(1,:) = 0. !make sure downdrafts do not penetrate the surface
+   downa(1,:) = 0.
+
+   !
+   ! combine all downdrafts into one averaged downdraft
+   !
+   do k=qltop,kts,-1
+      do i=1,ndd
+         edmf_a_dd(k)  =edmf_a_dd(k)  +downa(k,i)
+         edmf_w_dd(k)  =edmf_w_dd(k)  +downa(k,i)*downw(k,i)
+         edmf_qt_dd(k) =edmf_qt_dd(k) +downa(k,i)*downqt(k,i)
+         edmf_thl_dd(k)=edmf_thl_dd(k)+downa(k,i)*downthl(k,i)
+         edmf_ent_dd(k)=edmf_ent_dd(k)+downa(k,i)*ent(k,i)
+         edmf_qc_dd(k) =edmf_qc_dd(k) +downa(k,i)*downqc(k,i)
+      enddo
+
+      if (edmf_a_dd(k) > 0.) then
+         edmf_w_dd(k)  =edmf_w_dd(k)  /edmf_a_dd(k)
+         edmf_qt_dd(k) =edmf_qt_dd(k) /edmf_a_dd(k)
+         edmf_thl_dd(k)=edmf_thl_dd(k)/edmf_a_dd(k)
+         edmf_ent_dd(k)=edmf_ent_dd(k)/edmf_a_dd(k)
+         edmf_qc_dd(k) =edmf_qc_dd(k) /edmf_a_dd(k)
+      endif
+      !instead of dTKE/dt = 1/2 w^3, multiply by 2 for QKE.
+      tkeprod_dn(k)=(abs(edmf_w_dd(k))**3)*edmf_a_dd(k)/(b1*max(el(k),0.1))
+   enddo
+
+   !
+   ! compute variables needed for solver
+   !
+   do k=kts,qltop
+      rho_int = (rho(k)*dz(k+1)+rho(k+1)*dz(k))/(dz(k+1)+dz(k))
+      do i=1,ndd
+         sd_aw(k)   =sd_aw(k)   +rho_int*downa(k,i)*abs(downw(k,i))
+         sd_awthl(k)=sd_awthl(k)+rho_int*downa(k,i)*downw(k,i)*downthl(k,i)
+         sd_awqt(k) =sd_awqt(k) +rho_int*downa(k,i)*downw(k,i)*downqt(k,i)
+         sd_awqc(k) =sd_awqc(k) +rho_int*downa(k,i)*downw(k,i)*downqc(k,i)
+         sd_awqi(k) =sd_awqi(k) +rho_int*downa(k,i)*downw(k,i)*downqi(k,i)
+         sd_awqnc(k)=sd_awqnc(k)+rho_int*downa(k,i)*downw(k,i)*downqnc(k,i)
+         sd_awqni(k)=sd_awqni(k)+rho_int*downa(k,i)*downw(k,i)*downqni(k,i)
+         sd_awqnwfa(k)=sd_awqnwfa(k)+rho_int*downa(k,i)*downw(k,i)*downqnwfa(k,i)
+         sd_awqnifa(k)=sd_awqnifa(k)+rho_int*downa(k,i)*downw(k,i)*downqnifa(k,i)
+         sd_awu(k)  =sd_awu(k)  +rho_int*downa(k,i)*downw(k,i)*downu(k,i)
+         sd_awv(k)  =sd_awv(k)  +rho_int*downa(k,i)*downw(k,i)*downv(k,i)
+      enddo
+      sd_awqv(k) = sd_awqt(k)  - sd_awqc(k) - sd_awqi(k)
+   enddo
+
+end subroutine ddmp_mf
+!=============================================================== 
+
+SUBROUTINE SCALE_AWARE(dx,pblh,Psig_bl,Psig_shcu)
+
+    !---------------------------------------------------------------
+    !             NOTES ON SCALE-AWARE FORMULATION
+    !
+    !JOE: add scale-aware factor (Psig) here, taken from Honnert et al. (2011,
+    !     JAS) and/or from Hyeyum Hailey Shin and Song-You Hong (2013, JAS)
+    !
+    ! Psig_bl tapers local mixing
+    ! Psig_shcu tapers nonlocal mixing
+
+    real(kind_phys), intent(in)  :: dx,pblh
+    real(kind_phys), intent(out) :: Psig_bl,Psig_shcu
+    real(kind_phys)              :: dxdh
+
+    Psig_bl=1.0
+    Psig_shcu=1.0
+    dxdh=MAX(2.5*dx,10.)/MIN(PBLH,3000.)
+    ! Honnert et al. 2011, TKE in PBL  *** original form used until 201605
+    !Psig_bl= ((dxdh**2) + 0.07*(dxdh**0.667))/((dxdh**2) + &
+    !         (3./21.)*(dxdh**0.67) + (3./42.))
+    ! Honnert et al. 2011, TKE in entrainment layer
+    !Psig_bl= ((dxdh**2) + (4./21.)*(dxdh**0.667))/((dxdh**2) + &
+     !        (3./20.)*(dxdh**0.67) + (7./21.))
+    ! New form to preseve parameterized mixing - only down 5% at dx = 750 m
+     Psig_bl= ((dxdh**2) + 0.106*(dxdh**0.667))/((dxdh**2) +0.066*(dxdh**0.667) + 0.071)
+
+    !assume a 500 m cloud depth for shallow-cu clods
+    dxdh=MAX(2.5*dx,10.)/MIN(PBLH+500.,3500.)
+    ! Honnert et al. 2011, TKE in entrainment layer *** original form used until 201605
+    !Psig_shcu= ((dxdh**2) + (4./21.)*(dxdh**0.667))/((dxdh**2) + &
+    !         (3./20.)*(dxdh**0.67) + (7./21.))
+
+    ! Honnert et al. 2011, TKE in cumulus
+    !Psig(i)= ((dxdh**2) + 1.67*(dxdh**1.4))/((dxdh**2) +1.66*(dxdh**1.4) +
+    !0.2)
+
+    ! Honnert et al. 2011, w'q' in PBL
+    !Psig(i)= 0.5 + 0.5*((dxdh**2) + 0.03*(dxdh**1.4) -
+    !(4./13.))/((dxdh**2) + 0.03*(dxdh**1.4) + (4./13.))
+    ! Honnert et al. 2011, w'q' in cumulus
+    !Psig(i)= ((dxdh**2) - 0.07*(dxdh**1.4))/((dxdh**2) -0.07*(dxdh**1.4) +
+    !0.02)
+
+    ! Honnert et al. 2011, q'q' in PBL
+    !Psig(i)= 0.5 + 0.5*((dxdh**2) + 0.25*(dxdh**0.667) -0.73)/((dxdh**2)
+    !-0.03*(dxdh**0.667) + 0.73)
+    ! Honnert et al. 2011, q'q' in cumulus
+    !Psig(i)= ((dxdh**2) - 0.34*(dxdh**1.4))/((dxdh**2) - 0.35*(dxdh**1.4)
+    !+ 0.37)
+
+    ! Hyeyum Hailey Shin and Song-You Hong 2013, TKE in PBL (same as Honnert's above)
+    !Psig_shcu= ((dxdh**2) + 0.070*(dxdh**0.667))/((dxdh**2)
+    !+0.142*(dxdh**0.667) + 0.071)
+    ! Hyeyum Hailey Shin and Song-You Hong 2013, TKE in entrainment zone  *** switch to this form 201605
+    Psig_shcu= ((dxdh**2) + 0.145*(dxdh**0.667))/((dxdh**2) +0.172*(dxdh**0.667) + 0.170)
+
+    ! Hyeyum Hailey Shin and Song-You Hong 2013, w'theta' in PBL
+    !Psig(i)= 0.5 + 0.5*((dxdh**2) -0.098)/((dxdh**2) + 0.106) 
+    ! Hyeyum Hailey Shin and Song-You Hong 2013, w'theta' in entrainment zone
+    !Psig(i)= 0.5 + 0.5*((dxdh**2) - 0.112*(dxdh**0.25) -0.071)/((dxdh**2)
+    !+ 0.054*(dxdh**0.25) + 0.10)
+
+    !print*,"in scale_aware; dx, dxdh, Psig(i)=",dx,dxdh,Psig(i)
+    !If(Psig_bl(i) < 0.0 .OR. Psig(i) > 1.)print*,"dx, dxdh, Psig(i)=",dx,dxdh,Psig_bl(i) 
+    If(Psig_bl > 1.0) Psig_bl=1.0
+    If(Psig_bl < 0.0) Psig_bl=0.0
+
+    If(Psig_shcu > 1.0) Psig_shcu=1.0
+    If(Psig_shcu < 0.0) Psig_shcu=0.0
+
+  END SUBROUTINE SCALE_AWARE
+
+! =====================================================================
+!>\ingroup gsd_mynn_edmf
+!! \author JAYMES- added 22 Apr 2015
+!! This function calculates saturation vapor pressure.  Separate ice and liquid functions
+!! are used (identical to those in module_mp_thompson.F, v3.6). Then, the
+!! final returned value is a temperature-dependant "blend". Because the final
+!! value is "phase-aware", this formulation may be preferred for use throughout
+!! the module (replacing "svp").
+  FUNCTION esat_blend(t) 
+
+      IMPLICIT NONE
+      
+      real(kind_phys), intent(in):: t
+      real(kind_phys):: esat_blend,XC,ESL,ESI,chi
+      !liquid
+      real(kind_phys), parameter:: J0= .611583699E03
+      real(kind_phys), parameter:: J1= .444606896E02
+      real(kind_phys), parameter:: J2= .143177157E01
+      real(kind_phys), parameter:: J3= .264224321E-1
+      real(kind_phys), parameter:: J4= .299291081E-3
+      real(kind_phys), parameter:: J5= .203154182E-5
+      real(kind_phys), parameter:: J6= .702620698E-8
+      real(kind_phys), parameter:: J7= .379534310E-11
+      real(kind_phys), parameter:: J8=-.321582393E-13
+      !ice
+      real(kind_phys), parameter:: K0= .609868993E03
+      real(kind_phys), parameter:: K1= .499320233E02
+      real(kind_phys), parameter:: K2= .184672631E01
+      real(kind_phys), parameter:: K3= .402737184E-1
+      real(kind_phys), parameter:: K4= .565392987E-3
+      real(kind_phys), parameter:: K5= .521693933E-5
+      real(kind_phys), parameter:: K6= .307839583E-7
+      real(kind_phys), parameter:: K7= .105785160E-9
+      real(kind_phys), parameter:: K8= .161444444E-12
+
+      XC=MAX(-80.,t - t0c) !note t0c = 273.15, tice is set in module mynn_common to 240
+
+! For 240 < t < 268.16 K, the vapor pressures are "blended" as a function of temperature, 
+! using the approach similar to Chaboureau and Bechtold (2002), JAS, p. 2363.  The resulting 
+! values are returned from the function.
+      IF (t .GE. (t0c-6.)) THEN
+          esat_blend = J0+XC*(J1+XC*(J2+XC*(J3+XC*(J4+XC*(J5+XC*(J6+XC*(J7+XC*J8))))))) 
+      ELSE IF (t .LE. tice) THEN
+          esat_blend = K0+XC*(K1+XC*(K2+XC*(K3+XC*(K4+XC*(K5+XC*(K6+XC*(K7+XC*K8)))))))
+      ELSE
+          ESL = J0+XC*(J1+XC*(J2+XC*(J3+XC*(J4+XC*(J5+XC*(J6+XC*(J7+XC*J8)))))))
+          ESI = K0+XC*(K1+XC*(K2+XC*(K3+XC*(K4+XC*(K5+XC*(K6+XC*(K7+XC*K8)))))))
+          chi = ((t0c-6.) - t)/((t0c-6.) - tice)
+          esat_blend = (1.-chi)*ESL  + chi*ESI
+      END IF
+
+  END FUNCTION esat_blend
+
+! ====================================================================
+
+!>\ingroup gsd_mynn_edmf
+!! This function extends function "esat" and returns a "blended"
+!! saturation mixing ratio. Tice currently set to 240 K, t0c = 273.15 K.
+!!\author JAYMES
+  FUNCTION qsat_blend(t, P)
+
+      IMPLICIT NONE
+
+      real(kind_phys), intent(in):: t, P
+      real(kind_phys):: qsat_blend,XC,ESL,ESI,RSLF,RSIF,chi
+      !liquid
+      real(kind_phys), parameter:: J0= .611583699E03
+      real(kind_phys), parameter:: J1= .444606896E02
+      real(kind_phys), parameter:: J2= .143177157E01
+      real(kind_phys), parameter:: J3= .264224321E-1
+      real(kind_phys), parameter:: J4= .299291081E-3
+      real(kind_phys), parameter:: J5= .203154182E-5
+      real(kind_phys), parameter:: J6= .702620698E-8
+      real(kind_phys), parameter:: J7= .379534310E-11
+      real(kind_phys), parameter:: J8=-.321582393E-13
+      !ice
+      real(kind_phys), parameter:: K0= .609868993E03
+      real(kind_phys), parameter:: K1= .499320233E02
+      real(kind_phys), parameter:: K2= .184672631E01
+      real(kind_phys), parameter:: K3= .402737184E-1
+      real(kind_phys), parameter:: K4= .565392987E-3
+      real(kind_phys), parameter:: K5= .521693933E-5
+      real(kind_phys), parameter:: K6= .307839583E-7
+      real(kind_phys), parameter:: K7= .105785160E-9
+      real(kind_phys), parameter:: K8= .161444444E-12
+
+      XC=MAX(-80.,t - t0c)
+
+      IF (t .GE. (t0c-6.)) THEN
+          ESL  = J0+XC*(J1+XC*(J2+XC*(J3+XC*(J4+XC*(J5+XC*(J6+XC*(J7+XC*J8)))))))
+          ESL  = min(ESL, P*0.15) ! Even with P=1050mb and T=55C, the sat. vap. pres only contributes to ~15% of total pres.
+          qsat_blend = 0.622*ESL/max(P-ESL, 1e-5) 
+      ELSE IF (t .LE. tice) THEN
+          ESI  = K0+XC*(K1+XC*(K2+XC*(K3+XC*(K4+XC*(K5+XC*(K6+XC*(K7+XC*K8)))))))
+          ESI  = min(ESI, P*0.15)
+          qsat_blend = 0.622*ESI/max(P-ESI, 1e-5)
+      ELSE
+          ESL  = J0+XC*(J1+XC*(J2+XC*(J3+XC*(J4+XC*(J5+XC*(J6+XC*(J7+XC*J8)))))))
+          ESL  = min(ESL, P*0.15)
+          ESI  = K0+XC*(K1+XC*(K2+XC*(K3+XC*(K4+XC*(K5+XC*(K6+XC*(K7+XC*K8)))))))
+          ESI  = min(ESI, P*0.15)
+          RSLF = 0.622*ESL/max(P-ESL, 1e-5)
+          RSIF = 0.622*ESI/max(P-ESI, 1e-5)
+!          chi  = (268.16-t)/(268.16-240.)
+          chi  = ((t0c-6.) - t)/((t0c-6.) - tice) 
+         qsat_blend = (1.-chi)*RSLF + chi*RSIF
+      END IF
+
+  END FUNCTION qsat_blend
+
+! ===================================================================
+
+!>\ingroup gsd_mynn_edmf
+!! This function interpolates the latent heats of vaporization and sublimation into
+!! a single, temperature-dependent, "blended" value, following 
+!! Chaboureau and Bechtold (2002) \cite Chaboureau_2002, Appendix.
+!!\author JAYMES
+  FUNCTION xl_blend(t)
+
+      IMPLICIT NONE
+
+      real(kind_phys), intent(in):: t
+      real(kind_phys):: xl_blend,xlvt,xlst,chi
+      !note: t0c = 273.15, tice is set in mynn_common
+
+      IF (t .GE. t0c) THEN
+          xl_blend = xlv + (cpv-cliq)*(t-t0c)  !vaporization/condensation
+      ELSE IF (t .LE. tice) THEN
+          xl_blend = xls + (cpv-cice)*(t-t0c)  !sublimation/deposition
+      ELSE
+          xlvt = xlv + (cpv-cliq)*(t-t0c)  !vaporization/condensation
+          xlst = xls + (cpv-cice)*(t-t0c)  !sublimation/deposition
+!          chi  = (273.16-t)/(273.16-240.)
+          chi  = (t0c - t)/(t0c - tice)
+          xl_blend = (1.-chi)*xlvt + chi*xlst     !blended
+      END IF
+
+  END FUNCTION xl_blend
+
+! ===================================================================
+
+  FUNCTION phim(zet)
+     ! New stability function parameters for momentum (Puhales, 2020, WRF 4.2.1)
+     ! The forms in unstable conditions (z/L < 0) use Grachev et al. (2000), which are a blend of 
+     ! the classical (Kansas) forms (i.e., Paulson 1970, Dyer and Hicks 1970), valid for weakly 
+     ! unstable conditions (-1 < z/L < 0). The stability functions for stable conditions use an
+     ! updated form taken from Cheng and Brutsaert (2005), which extends the validity into very
+     ! stable conditions [z/L ~ O(10)].
+      IMPLICIT NONE
+
+      real(kind_phys), intent(in):: zet
+      real(kind_phys):: dummy_0,dummy_1,dummy_11,dummy_2,dummy_22,dummy_3,dummy_33,dummy_4,dummy_44,dummy_psi
+      real(kind_phys), parameter :: am_st=6.1, bm_st=2.5, rbm_st=1./bm_st
+      real(kind_phys), parameter :: ah_st=5.3, bh_st=1.1, rbh_st=1./bh_st
+      real(kind_phys), parameter :: am_unst=10., ah_unst=34.
+      real(kind_phys):: phi_m,phim
+
+      if ( zet >= 0.0 ) then
+         dummy_0=1+zet**bm_st
+         dummy_1=zet+dummy_0**(rbm_st)
+         dummy_11=1+dummy_0**(rbm_st-1)*zet**(bm_st-1)
+         dummy_2=(-am_st/dummy_1)*dummy_11
+         phi_m = 1-zet*dummy_2
+      else
+         dummy_0 = (1.0-cphm_unst*zet)**0.25
+         phi_m = 1./dummy_0
+         dummy_psi = 2.*log(0.5*(1.+dummy_0))+log(0.5*(1.+dummy_0**2))-2.*atan(dummy_0)+1.570796
+
+         dummy_0=(1.-am_unst*zet)          ! parentesis arg
+         dummy_1=dummy_0**0.333333         ! y
+         dummy_11=-0.33333*am_unst*dummy_0**(-0.6666667) ! dy/dzet
+         dummy_2 = 0.33333*(dummy_1**2.+dummy_1+1.)    ! f
+         dummy_22 = 0.3333*dummy_11*(2.*dummy_1+1.)    ! df/dzet
+         dummy_3 = 0.57735*(2.*dummy_1+1.) ! g
+         dummy_33 = 1.1547*dummy_11        ! dg/dzet
+         dummy_4 = 1.5*log(dummy_2)-1.73205*atan(dummy_3)+1.813799364 !psic
+         dummy_44 = (1.5/dummy_2)*dummy_22-1.73205*dummy_33/(1.+dummy_3**2)! dpsic/dzet
+
+         dummy_0 = zet**2
+         dummy_1 = 1./(1.+dummy_0) ! denon
+         dummy_11 = 2.*zet         ! denon/dzet
+         dummy_2 = ((1-phi_m)/zet+dummy_11*dummy_4+dummy_0*dummy_44)*dummy_1
+         dummy_22 = -dummy_11*(dummy_psi+dummy_0*dummy_4)*dummy_1**2
+
+         phi_m = 1.-zet*(dummy_2+dummy_22)
+      end if
+
+      !phim = phi_m - zet
+      phim = phi_m
+
+  END FUNCTION phim
+! ===================================================================
+
+  FUNCTION phih(zet)
+    ! New stability function parameters for heat (Puhales, 2020, WRF 4.2.1)
+    ! The forms in unstable conditions (z/L < 0) use Grachev et al. (2000), which are a blend of
+    ! the classical (Kansas) forms (i.e., Paulson 1970, Dyer and Hicks 1970), valid for weakly
+    ! unstable conditions (-1 < z/L < 0). The stability functions for stable conditions use an
+    ! updated form taken from Cheng and Brutsaert (2005), which extends the validity into very
+    ! stable conditions [z/L ~ O(10)].
+      IMPLICIT NONE
+
+      real(kind_phys), intent(in):: zet
+      real(kind_phys):: dummy_0,dummy_1,dummy_11,dummy_2,dummy_22,dummy_3,dummy_33,dummy_4,dummy_44,dummy_psi
+      real(kind_phys), parameter :: am_st=6.1, bm_st=2.5, rbm_st=1./bm_st
+      real(kind_phys), parameter :: ah_st=5.3, bh_st=1.1, rbh_st=1./bh_st
+      real(kind_phys), parameter :: am_unst=10., ah_unst=34.
+      real(kind_phys):: phh,phih
+
+      if ( zet >= 0.0 ) then
+         dummy_0=1+zet**bh_st
+         dummy_1=zet+dummy_0**(rbh_st)
+         dummy_11=1+dummy_0**(rbh_st-1)*zet**(bh_st-1)
+         dummy_2=(-ah_st/dummy_1)*dummy_11
+         phih = 1-zet*dummy_2
+      else
+         dummy_0 = (1.0-cphh_unst*zet)**0.5
+         phh = 1./dummy_0
+         dummy_psi = 2.*log(0.5*(1.+dummy_0))
+
+         dummy_0=(1.-ah_unst*zet)          ! parentesis arg
+         dummy_1=dummy_0**0.333333         ! y
+         dummy_11=-0.33333*ah_unst*dummy_0**(-0.6666667) ! dy/dzet
+         dummy_2 = 0.33333*(dummy_1**2.+dummy_1+1.)    ! f
+         dummy_22 = 0.3333*dummy_11*(2.*dummy_1+1.)    ! df/dzet
+         dummy_3 = 0.57735*(2.*dummy_1+1.) ! g
+         dummy_33 = 1.1547*dummy_11        ! dg/dzet
+         dummy_4 = 1.5*log(dummy_2)-1.73205*atan(dummy_3)+1.813799364 !psic
+         dummy_44 = (1.5/dummy_2)*dummy_22-1.73205*dummy_33/(1.+dummy_3**2)! dpsic/dzet
+
+         dummy_0 = zet**2
+         dummy_1 = 1./(1.+dummy_0)         ! denon
+         dummy_11 = 2.*zet                 ! ddenon/dzet
+         dummy_2 = ((1-phh)/zet+dummy_11*dummy_4+dummy_0*dummy_44)*dummy_1
+         dummy_22 = -dummy_11*(dummy_psi+dummy_0*dummy_4)*dummy_1**2
+
+         phih = 1.-zet*(dummy_2+dummy_22)
+      end if
+
+END FUNCTION phih
+! ==================================================================
+ SUBROUTINE topdown_cloudrad(kts,kte,                         &
+               &dz1,zw,fltv,xland,kpbl,PBLH,                  &
+               &sqc,sqi,sqw,thl,th1,ex1,p1,rho1,thv,          &
+               &cldfra_bl1,rthraten,                         &
+               &maxKHtopdown,KHtopdown,TKEprodTD              )
+
+    !input
+    integer,         intent(in) :: kte,kts
+    real(kind_phys), dimension(kts:kte), intent(in) :: dz1,sqc,sqi,sqw,&
+          thl,th1,ex1,p1,rho1,thv,cldfra_bl1
+    real(kind_phys), dimension(kts:kte), intent(in) :: rthraten
+    real(kind_phys), dimension(kts:kte+1), intent(in) :: zw
+    real(kind_phys), intent(in) :: pblh,fltv
+    real(kind_phys), intent(in) :: xland
+    integer        , intent(in) :: kpbl
+    !output
+    real(kind_phys), intent(out) :: maxKHtopdown
+    real(kind_phys), dimension(kts:kte), intent(out) :: KHtopdown,TKEprodTD
+    !local
+    real(kind_phys), dimension(kts:kte) :: zfac,wscalek2,zfacent
+    real(kind_phys) :: bfx0,wm2,wm3,bfxpbl,dthvx,tmp1
+    real(kind_phys) :: temps,templ,zl1,wstar3_2
+    real(kind_phys) :: ent_eff,radsum,radflux,we,rcldb,rvls,minrad,zminrad
+    real(kind_phys), parameter :: pfac =2.0, zfmin = 0.01, phifac=8.0
+    integer :: k,kk,kminrad
+    logical :: cloudflg
+
+    cloudflg=.false.
+    minrad=100.
+    kminrad=kpbl
+    zminrad=PBLH
+    KHtopdown(kts:kte)=0.0
+    TKEprodTD(kts:kte)=0.0
+    maxKHtopdown=0.0
+
+    !CHECK FOR STRATOCUMULUS-TOPPED BOUNDARY LAYERS
+    DO kk = MAX(1,kpbl-2),kpbl+3
+       if (sqc(kk).gt. 1.e-6 .OR. sqi(kk).gt. 1.e-6 .OR. &
+           cldfra_bl1(kk).gt.0.5) then
+          cloudflg=.true.
+       endif
+       if (rthraten(kk) < minrad)then
+          minrad=rthraten(kk)
+          kminrad=kk
+          zminrad=zw(kk) + 0.5*dz1(kk)
+       endif
+    ENDDO
+
+    IF (MAX(kminrad,kpbl) < 2)cloudflg = .false.
+    IF (cloudflg) THEN
+       zl1 = dz1(kts)
+       k = MAX(kpbl-1, kminrad-1)
+       !Best estimate of height of TKE source (top of downdrafts):
+       !zminrad = 0.5*pblh(i) + 0.5*zminrad
+
+       templ=thl(k)*ex1(k)
+       !rvls is ws at full level
+       rvls=100.*6.112*EXP(17.67*(templ-273.16)/(templ-29.65))*(ep_2/p1(k+1))
+       temps=templ + (sqw(k)-rvls)/(cp/xlv  +  ep_2*xlv*rvls/(r_d*templ**2))
+       rvls=100.*6.112*EXP(17.67*(temps-273.15)/(temps-29.65))*(ep_2/p1(k+1))
+       rcldb=max(sqw(k)-rvls,0.)
+
+       !entrainment efficiency
+       dthvx     = (thl(k+2) + th1(k+2)*p608*sqw(k+2)) &
+                 - (thl(k)   + th1(k)  *p608*sqw(k))
+       dthvx     = max(dthvx,0.1)
+       tmp1      = xlvcp * rcldb/(ex1(k)*dthvx)
+       !Originally from Nichols and Turton (1986), where a2 = 60, but lowered
+       !here to 8, as in Grenier and Bretherton (2001).
+       ent_eff   = 0.2 + 0.2*8.*tmp1
+
+       radsum=0.
+       DO kk = MAX(1,kpbl-3),kpbl+3
+          radflux=rthraten(kk)*ex1(kk)         !converts theta/s to temp/s
+          radflux=radflux*cp/grav*(p1(kk)-p1(kk+1)) ! converts temp/s to W/m^2
+          if (radflux < 0.0 ) radsum=abs(radflux)+radsum
+       ENDDO
+
+       !More strict limits over land to reduce stable-layer mixouts
+       if ((xland-1.5).GE.0)THEN      ! WATER
+          radsum=MIN(radsum,90.0)
+          bfx0 = max(radsum/rho1(k)/cp,0.)
+       else                           ! LAND
+          radsum=MIN(0.25*radsum,30.0)!practically turn off over land
+          bfx0 = max(radsum/rho1(k)/cp - max(fltv,0.0),0.)
+       endif
+
+       !entrainment from PBL top thermals
+       wm3    = grav/thv(k)*bfx0*MIN(pblh,1500.) ! this is wstar3(i)
+       wm2    = wm2 + wm3**twothirds
+       bfxpbl = - ent_eff * bfx0
+       dthvx  = max(thv(k+1)-thv(k),0.1)
+       we     = max(bfxpbl/dthvx,-sqrt(wm3**twothirds))
+
+       DO kk = kts,kpbl+3
+          !Analytic vertical profile
+          zfac(kk) = min(max((1.-(zw(kk+1)-zl1)/(zminrad-zl1)),zfmin),1.)
+          zfacent(kk) = 10.*MAX((zminrad-zw(kk+1))/zminrad,0.0)*(1.-zfac(kk))**3
+
+          !Calculate an eddy diffusivity profile (not used at the moment)
+          wscalek2(kk) = (phifac*karman*wm3*(zfac(kk)))**onethird
+          !Modify shape of Kh to be similar to Lock et al (2000): use pfac = 3.0
+          KHtopdown(kk) = wscalek2(kk)*karman*(zminrad-zw(kk+1))*(1.-zfac(kk))**3 !pfac
+          KHtopdown(kk) = MAX(KHtopdown(kk),0.0)
+
+          !Calculate TKE production = 2(g/TH)(w'TH'), where w'TH' = A(TH/g)wstar^3/PBLH,
+          !A = ent_eff, and wstar is associated with the radiative cooling at top of PBL.
+          !An analytic profile controls the magnitude of this TKE prod in the vertical.
+          TKEprodTD(kk)=2.*ent_eff*wm3/MAX(pblh,100.)*zfacent(kk)
+          TKEprodTD(kk)= MAX(TKEprodTD(kk),0.0)
+       ENDDO
+    ENDIF !end cloud check
+    maxKHtopdown=MAXVAL(KHtopdown(:))
+
+ END SUBROUTINE topdown_cloudrad
+! ==================================================================
+! ===================================================================
+! ===================================================================
 
 END MODULE module_bl_mynn

--- a/src/core_atmosphere/physics/physics_wrf/module_bl_mynn_common.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_bl_mynn_common.F
@@ -1,0 +1,95 @@
+!====================================================================
+
+ module module_bl_mynn_common
+
+!------------------------------------------
+!Define Model-specific constants/parameters.
+!This module will be used at the initialization stage
+!where all model-specific constants are read and saved into
+!memory. This module is then used again in the MYNN-EDMF. All
+!MYNN-specific constants are declared globally in the main
+!module (module_bl_mynn) further below:
+!------------------------------------------
+!
+! The following 5-6 lines are the only lines in this file that are not
+! universal for all dycores... Any ideas how to universalize it?
+! For MPAS:
+  use mpas_kind_types, only: kind_phys => RKIND
+  !use ccpp_kinds, only: kind_phys
+! For CCPP:
+!  use ccpp_kind_types, only : kind_phys
+! For WRF
+!  use module_gfs_machine,  only : kind_phys
+
+!WRF CONSTANTS
+ use mpas_atmphys_constants, only:           &
+    & karman, grav => gravity, p1000mb => P0,&
+    & cp, r_d, r_v, rcp, xlv, xlf, xls,      &
+    & svp1, svp2, svp3, p608 => ep_1, ep_2,  &
+    & rvovrd => rvord, cpv, cliq, cice,      &
+    & t0c => svpt0
+
+ implicit none
+ save
+
+! To be specified from dycore
+! real:: cp           != 7.*r_d/2. (J/kg/K)
+! real:: cpv          != 4.*r_v    (J/kg/K) Spec heat H2O gas
+! real:: cice         != 2106.     (J/kg/K) Spec heat H2O ice
+! real:: cliq         != 4190.     (J/kg/K) Spec heat H2O liq
+! real:: p608         != R_v/R_d-1.
+! real:: ep_2         != R_d/R_v
+! real:: grav         != accel due to gravity
+! real:: karman       != von Karman constant
+! real:: t0c          != temperature of water at freezing, 273.15 K
+! real:: rcp          != r_d/cp
+! real:: r_d          != 287.  (J/kg/K) gas const dry air
+! real:: r_v          != 461.6 (J/kg/K) gas const water
+! real:: xlf          != 0.35E6 (J/kg) fusion at 0 C
+! real:: xlv          != 2.50E6 (J/kg) vaporization at 0 C
+! real:: xls          != 2.85E6 (J/kg) sublimation
+! real:: rvovrd       != r_v/r_d != 1.608
+
+! Specified locally
+! Define single & double precision
+! integer, parameter :: sp = selected_real_kind(6, 37)
+! integer, parameter :: dp = selected_real_kind(15, 307)
+! integer, parameter :: kind_phys = sp
+ real(kind_phys),parameter:: zero   = 0.0
+ real(kind_phys),parameter:: half   = 0.5
+ real(kind_phys),parameter:: one    = 1.0
+ real(kind_phys),parameter:: two    = 2.0
+ real(kind_phys),parameter:: onethird  = 1./3.
+ real(kind_phys),parameter:: twothirds = 2./3.
+ real(kind_phys),parameter:: tref  = 300.0   ! reference temperature (K)
+ real(kind_phys),parameter:: TKmin = 253.0   ! for total water conversion, Tripoli and Cotton (1981)
+! real(kind_phys),parameter:: p1000mb=100000.0
+! real(kind_phys),parameter:: svp1  = 0.6112 !(kPa)
+! real(kind_phys),parameter:: svp2  = 17.67  !(dimensionless)
+! real(kind_phys),parameter:: svp3  = 29.65  !(K)
+ real(kind_phys),parameter:: tice  = 240.0  !-33 (C), temp at saturation w.r.t. ice
+! real(kind_phys),parameter:: grav  = g
+! real(kind_phys),parameter:: t0c   = svpt0        != 273.15
+
+! To be derived in the init routine
+ real(kind_phys),parameter:: ep_3   = 1.-ep_2 != 0.378
+ real(kind_phys),parameter:: gtr    = grav/tref
+ real(kind_phys),parameter:: rk     = cp/r_d
+ real(kind_phys),parameter:: tv0    =  p608*tref
+ real(kind_phys),parameter:: tv1    = (1.+p608)*tref
+ real(kind_phys),parameter:: xlscp  = (xlv+xlf)/cp
+ real(kind_phys),parameter:: xlvcp  = xlv/cp
+ real(kind_phys),parameter:: g_inv  = 1./grav
+
+! grav   = g
+! t0c    = svpt0        != 273.15
+! ep_3   = 1.-ep_2      != 0.378                                                                                   
+! gtr    = grav/tref
+! rk     = cp/r_d
+! tv0    = p608*tref
+! tv1    = (1.+p608)*tref
+! xlscp  = (xlv+xlf)/cp
+! xlvcp  = xlv/cp
+! g_inv  = 1./grav
+
+ end module module_bl_mynn_common

--- a/src/core_atmosphere/physics/physics_wrf/module_bl_mynn_wrapper.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_bl_mynn_wrapper.F
@@ -1,0 +1,851 @@
+!> \file module_bl_mynn_wrapper.F90
+!!  This serves as the interface between the WRF PBL driver and the MYNN 
+!!  eddy-diffusivity mass-flux scheme in module_bl_mynn.F. 
+
+!>\ingroup gsd_mynn_edmf
+!> The following references best describe the code within
+!!    Olson et al. (2019, NOAA Technical Memorandum)
+!!    Nakanishi and Niino (2009) \cite NAKANISHI_2009
+      MODULE module_bl_mynn_wrapper
+
+      use module_bl_mynn_common
+
+      contains
+
+!> \section arg_table_mynnedmf_wrapper_init Argument Table
+!! \htmlinclude mynnedmf_wrapper_init.html
+!!
+      subroutine mynnedmf_wrapper_init (              &
+        &  RUBLTEN,RVBLTEN,RTHBLTEN,RQVBLTEN,RQCBLTEN,&
+        &  RQIBLTEN,QKE,                              &
+        &  restart,allowed_to_read,                   &
+        &  P_QC,P_QI,PARAM_FIRST_SCALAR,              &
+        &  IDS,IDE,JDS,JDE,KDS,KDE,                   &
+        &  IMS,IME,JMS,JME,KMS,KME,                   &
+        &  ITS,ITE,JTS,JTE,KTS,KTE                    )
+
+        implicit none
+        
+        LOGICAL,INTENT(IN) :: ALLOWED_TO_READ,RESTART
+
+        INTEGER,INTENT(IN) :: IDS,IDE,JDS,JDE,KDS,KDE,  &
+             &                IMS,IME,JMS,JME,KMS,KME,  &
+             &                ITS,ITE,JTS,JTE,KTS,KTE
+
+
+        REAL,DIMENSION(IMS:IME,KMS:KME,JMS:JME),INTENT(INOUT) :: &
+             &RUBLTEN,RVBLTEN,RTHBLTEN,RQVBLTEN,                 &
+             &RQCBLTEN,RQIBLTEN,QKE
+
+        INTEGER,  intent(in) :: P_QC,P_QI,PARAM_FIRST_SCALAR
+
+        INTEGER :: I,J,K,ITF,JTF,KTF
+
+        JTF=MIN0(JTE,JDE-1)
+        KTF=MIN0(KTE,KDE-1)
+        ITF=MIN0(ITE,IDE-1)
+
+        IF (.NOT.RESTART) THEN
+         DO J=JTS,JTF
+          DO K=KTS,KTF
+           DO I=ITS,ITF
+              RUBLTEN(i,k,j)=0.
+              RVBLTEN(i,k,j)=0.
+              RTHBLTEN(i,k,j)=0.
+              RQVBLTEN(i,k,j)=0.
+              if( p_qc >= param_first_scalar ) RQCBLTEN(i,k,j)=0.
+              if( p_qi >= param_first_scalar ) RQIBLTEN(i,k,j)=0.
+           ENDDO
+          ENDDO
+         ENDDO
+        ENDIF
+
+      end subroutine mynnedmf_wrapper_init
+
+      subroutine mynnedmf_wrapper_finalize ()
+      end subroutine mynnedmf_wrapper_finalize
+
+! \brief This scheme (1) performs pre-mynnedmf work, (2) runs the mynnedmf, and (3) performs post-mynnedmf work
+!> \section arg_table_mynnedmf_wrapper_run Argument Table
+!! \htmlinclude mynnedmf_wrapper_run.html
+!!
+SUBROUTINE mynnedmf_wrapper_run(                 &
+     &  initflag,restart,cycling,                &
+     &  delt,dz,dxc,znt,                         &
+     &  u,v,w,th,                                &
+     &  qv,qc,qi,qs,qnc,qni,qnwfa,qnifa,qnbca,   &
+!     &  ozone,                                   &
+     &  p,exner,rho,t3d,                         &
+     &  xland,ts,qsfc,ps,                        &
+     &  ust,ch,hfx,qfx,rmol,wspd,                &
+     &  uoce,voce,                               &
+     &  qke,qke_adv,sh3d,sm3d,                   &
+!--- chem/smoke
+#if (WRF_CHEM == 1)
+     &  mix_chem,chem3d,vd3d,nchem,kdvel,        &
+     &  ndvel,num_vert_mix,                      &
+!     &  frp_mean,emis_ant_no,enh_mix,            & !to be included soon
+#endif
+!--- end chem/smoke 
+     &  tsq,qsq,cov,                             &
+     &  rublten,rvblten,rthblten,                &
+     &  rqvblten,rqcblten,rqiblten,rqsblten,     &
+     &  rqncblten,rqniblten,                     &
+     &  rqnwfablten,rqnifablten,rqnbcablten,     &
+!     &  ro3blten,                                &
+     &  kh,km,pblh,kpbl,el_pbl,                  &
+     &  dqke,qwt,qshear,qbuoy,qdiss,             &
+     &  qc_bl,qi_bl,cldfra_bl,                   &
+     &  edmf_a,edmf_w,edmf_qt,                   &
+     &  edmf_thl,edmf_ent,edmf_qc,               &
+     &  sub_thl,sub_sqv,                         &
+     &  det_thl,det_sqv,                         &
+     &  maxwidth,maxMF,ztop_plume,               &
+     &  rthraten,                                &
+     &  tke_budget,         bl_mynn_tkeadvect,   &
+     &  bl_mynn_cloudpdf,   bl_mynn_mixlength,   &
+     &  icloud_bl,          bl_mynn_edmf,        &
+     &  bl_mynn_edmf_mom,   bl_mynn_edmf_tke,    &
+     &  bl_mynn_cloudmix,   bl_mynn_mixqt,       &
+     &  bl_mynn_output,     bl_mynn_closure,     &
+     &  bl_mynn_mixscalars,                      &
+     &  spp_pbl,pattern_spp_pbl,                 &
+     &  flag_qc,flag_qi,flag_qs,                 &
+     &  flag_qnc,flag_qni,                       &
+     &  flag_qnwfa,flag_qnifa,flag_qnbca,        &
+     &  ids,ide,jds,jde,kds,kde,                 &
+     &  ims,ime,jms,jme,kms,kme,                 &
+     &  its,ite,jts,jte,kts,kte                  )
+
+     use module_bl_mynn, only: mynn_bl_driver
+
+!------------------------------------------------------------------- 
+     implicit none
+!------------------------------------------------------------------- 
+
+     !smoke/chem: disclaimer: all smoke-related variables are still
+     !considered under development in CCPP. Until that work is
+     !completed, these flags/arrays must be kept hard-coded as is.
+#if (WRF_CHEM == 1)
+     logical, intent(in) :: mix_chem
+     integer, intent(in) :: nchem, ndvel, kdvel, num_vert_mix
+     logical, parameter ::                                  &
+     &       rrfs_sd    =.false.,                           &
+     &       smoke_dbg  =.false.,                           &
+     &       enh_mix    =.false.
+#else
+     logical, parameter ::                                  &
+     &       mix_chem   =.false.,                           &
+     &       enh_mix    =.false.,                           &
+     &       rrfs_sd    =.false.,                           &
+     &       smoke_dbg  =.false.
+     integer, parameter :: nchem=2, ndvel=2, kdvel=1,       &
+             num_vert_mix = 1
+#endif
+
+! NAMELIST OPTIONS (INPUT):
+     logical, intent(in) ::                                 &
+     &       bl_mynn_tkeadvect,                             &
+     &       cycling
+      integer, intent(in) ::                                &
+     &       bl_mynn_cloudpdf,                              &
+     &       bl_mynn_mixlength,                             &
+     &       icloud_bl,                                     &
+     &       bl_mynn_edmf,                                  &
+     &       bl_mynn_edmf_mom,                              &
+     &       bl_mynn_edmf_tke,                              &
+     &       bl_mynn_cloudmix,                              &
+     &       bl_mynn_mixqt,                                 &
+     &       bl_mynn_output,                                &
+     &       bl_mynn_mixscalars,                            &
+     &       spp_pbl,                                       &
+     &       tke_budget
+      real(kind_phys), intent(in) ::                        &
+     &       bl_mynn_closure
+
+      logical, intent(in) ::                                &
+     &       FLAG_QI, FLAG_QNI, FLAG_QC, FLAG_QNC,          &
+     &       FLAG_QS, FLAG_QNWFA, FLAG_QNIFA, FLAG_QNBCA
+      logical, parameter :: FLAG_OZONE = .false.
+
+!MYNN-1D
+      REAL(kind_phys),    intent(in) :: delt
+      LOGICAL, intent(in) :: restart
+      INTEGER :: i, j, k, itf, jtf, n
+      INTEGER, intent(in) :: initflag,                      &
+     &           IDS,IDE,JDS,JDE,KDS,KDE,                   &
+     &           IMS,IME,JMS,JME,KMS,KME,                   &
+     &           ITS,ITE,JTS,JTE,KTS,KTE
+
+!MYNN-3D
+      real(kind_phys), dimension(ims:ime,kms:kme,jms:jme), intent(in) ::               &
+     &       u,v,w,t3d,th,rho,exner,p,dz
+      real(kind_phys), dimension(ims:ime,kms:kme,jms:jme), intent(inout) ::            &
+     &       rublten,rvblten,rthblten
+      real(kind_phys), dimension(ims:ime,kms:kme,jms:jme), intent(inout) ::            &
+     &       qke, el_pbl, sh3d, sm3d, tsq, qsq, cov
+      real(kind_phys), dimension(ims:ime,kms:kme,jms:jme), intent(inout) ::            &
+     &       kh, km
+      real(kind_phys), dimension(ims:ime,kms:kme,jms:jme), intent(in) :: rthraten
+
+!optional 3D arrays
+      real(kind_phys), dimension(ims:ime,kms:kme,jms:jme), optional, intent(inout) ::  &
+     &       rqvblten,rqcblten,rqiblten,rqsblten,rqncblten,rqniblten,                  &
+     &       rqnwfablten,rqnifablten,rqnbcablten !,ro3blten
+      real(kind_phys), dimension(ims:ime,kms:kme,jms:jme), optional, intent(in)  ::    &
+     &       pattern_spp_pbl
+      real(kind_phys), dimension(ims:ime,kms:kme,jms:jme), optional, intent(inout) ::  &
+     &       qc_bl, qi_bl, cldfra_bl, qke_adv
+      real(kind_phys), dimension(ims:ime,kms:kme,jms:jme), optional, intent(inout) ::  &
+     &       edmf_a,edmf_w,edmf_qt,                                                    &
+     &       edmf_thl,edmf_ent,edmf_qc,                                                &
+     &       sub_thl,sub_sqv,det_thl,det_sqv
+      real(kind_phys), dimension(ims:ime,kms:kme,jms:jme), optional, intent(inout) ::  &
+     &       dqke,qWT,qSHEAR,qBUOY,qDISS
+      real(kind_phys), dimension(ims:ime,kms:kme,jms:jme), optional, intent(inout) ::  &
+     &       qv,qc,qi,qs,qnc,qni,qnwfa,qnifa,qnbca!,o3
+
+!(non-optional) 1D arrays
+      real(kind_phys), dimension(kts:kte) ::                                           &
+     &       u1,v1,w1,th1,tk1,rho1,ex1,p1,dz1,rthraten1
+      real(kind_phys), dimension(kts:kte) ::                                           &
+     &       edmf_a1,edmf_w1,edmf_qt1,edmf_thl1,edmf_ent1,edmf_qc1,                    &
+     &       sub_thl1,sub_sqv1,det_thl1,det_sqv1
+      real(kind_phys), dimension(kts:kte) ::                                           &
+     &       qc_bl1, qi_bl1, cldfra_bl1, pattern_spp_pbl1
+      real(kind_phys), dimension(kts:kte) ::                                           &
+     &       dqke1,qWT1,qSHEAR1,qBUOY1,qDISS1
+      real(kind_phys), dimension(kts:kte) ::                                           &
+             qke1, qke_adv1, el1, sh1, sm1,  km1, kh1, tsq1, qsq1, cov1
+      real(kind_phys), dimension(kts:kte) ::                                           &
+     &       qc1,qi1,qs1,qnc1,qni1,qnwfa1,qnifa1,qnbca1,ozone1
+      real(kind_phys), dimension(kts:kte) ::                                           &
+     &       du1,dv1,dth1,dqv1,dqc1,dqi1,dqs1,                                         &
+     &       dqni1,dqnc1,dqnwfa1,dqnifa1,dqnbca1,dozone1
+
+!smoke/chem arrays - no if-defs in module_bl_mynn.F, so must define arrays
+#if (WRF_CHEM == 1)
+      real(kind_phys), dimension(ims:ime,kms:kme,jms:jme,nchem), intent(inout) :: chem3d
+      real(kind_phys), dimension(ims:ime,kdvel,jms:jme, ndvel),  intent(in)    :: vd3d
+      real(kind_phys), dimension(kms:kme,nchem) :: chem
+      real(kind_phys), dimension(ndvel)         :: vd
+      real(kind_phys), dimension(ims:ime)       :: frp_mean, emis_ant_no
+#else
+      real(kind_phys), dimension(kms:kme,nchem) :: chem
+      real(kind_phys), dimension(ndvel)         :: vd
+      real(kind_phys), dimension(ims:ime)       :: frp_mean, emis_ant_no
+#endif
+
+!MYNN-2D
+      real(kind_phys), dimension(ims:ime,jms:jme), intent(in) ::                       &
+     &       xland,ts,qsfc,ps,ch,hfx,qfx,ust,wspd,znt,dxc,                             &
+     &       uoce,voce
+      real(kind_phys), dimension(ims:ime,jms:jme), intent(inout) ::                    &
+     &       rmol
+     real(kind_phys), dimension(ims:ime,jms:jme), intent(out) ::                       &
+     &       pblh,maxwidth,maxmf,ztop_plume
+      integer, dimension(ims:ime,jms:jme), intent(out) ::                              &
+     &       kpbl
+
+!Local
+      real(kind_phys), dimension(kts:kte)                 :: delp,sqv1,sqc1,sqi1,sqs1,kzero
+      real(kind_phys)                                     :: dx
+      real(kind_phys), dimension(ims:ime,kms:kme,jms:jme) :: ozone,rO3blten
+      !debugging
+      logical, parameter                                  :: debug = .false.
+      integer, parameter                                  :: idb = 20, jdb = 1
+
+   if (debug) then
+      write(0,*)"=============================================="
+      write(0,*)"in mynn wrapper..."
+      write(0,*)"initflag=",initflag," restart =",restart
+   endif
+
+   jtf=MIN0(JTE,JDE-1)
+   itf=MIN0(ITE,IDE-1)
+
+   !For now, initialized bogus array
+   ozone            =0.0
+   rO3blten         =0.0
+   kzero            =0.0
+   !initialize 2d diagnostic output
+   pblh             =0.0
+   maxwidth         =0.0
+   maxmf            =0.0
+   ztop_plume       =0.0
+   kpbl             =0  !int
+   !initialize subgrid clouds:
+   qc_bl1           =0.0
+   qi_bl1           =0.0
+   cldfra_bl1       =0.0
+   !spp
+   pattern_spp_pbl1 =0.0
+   !turbulence properties
+   qke1             =0.0
+   qke_adv1         =0.0
+   el1              =0.0
+   sh1              =0.0
+   sm1              =0.0
+   kh1              =0.0
+   km1              =0.0
+   tsq1             =0.0
+   qsq1             =0.0
+   cov1             =0.0
+   !tke budget
+   dqke1            =0.0
+   qWT1             =0.0
+   qSHEAR1          =0.0
+   qBUOY1           =0.0
+   qDISS1           =0.0
+   !mass-flux arrays
+   edmf_a1          =0.0
+   edmf_w1          =0.0
+   edmf_qt1         =0.0
+   edmf_thl1        =0.0
+   edmf_ent1        =0.0
+   edmf_qc1         =0.0
+   sub_thl1         =0.0
+   sub_sqv1         =0.0
+   det_thl1         =0.0
+   det_sqv1         =0.0
+   !moist species
+   qc1              =0.0
+   qi1              =0.0
+   qs1              =0.0
+   qnc1             =0.0
+   qni1             =0.0
+   qnwfa1           =0.0
+   qnifa1           =0.0
+   qnbca1           =0.0
+   ozone1           =0.0
+   !1d (non-optional) tendencies
+   du1              =0.0
+   dv1              =0.0
+   dth1             =0.0
+   dqv1             =0.0
+   dqc1             =0.0
+   dqi1             =0.0
+   dqs1             =0.0
+   dqni1            =0.0
+   dqnc1            =0.0
+   dqnwfa1          =0.0
+   dqnifa1          =0.0
+   dqnbca1          =0.0
+   dozone1          =0.0
+   dz1              =0.0
+   rthraten1        =0.0
+
+   !---------------------------------------
+   !Begin looping in the i- and j-direction
+   !---------------------------------------
+   do j = jts, jte !jtf
+   do i = its, ite !itf
+
+      dx = dxc(i,j)
+      
+      do k=kts,kte
+         u1(k)       = u(i,k,j)
+         v1(k)       = v(i,k,j)
+         w1(k)       = w(i,k,j)
+         th1(k)      = th(i,k,j)
+         p1(k)       = p(i,k,j)
+         ex1(k)      = exner(i,k,j)
+         rho1(k)     = rho(i,k,j)
+         tk1(k)      = t3d(i,k,j)
+         dz1(k)      = dz(i,k,j)
+         rthraten1(k)= rthraten(i,k,j)
+      enddo
+      
+      !update sgs cloud info.
+      if (icloud_bl > 0) then
+         do k=kts,kte
+            qc_bl1(k)     = qc_bl(i,k,j)
+            qi_bl1(k)     = qi_bl(i,k,j)
+            cldfra_bl1(k) = cldfra_bl(i,k,j)
+         enddo
+      endif
+
+      !spp input
+      if (spp_pbl > 0) then
+         do k=kts,kte
+            pattern_spp_pbl1(k) = pattern_spp_pbl(i,k,j)
+         enddo
+      endif
+
+      !tke
+      do k=kts,kte
+         qke1(k) = qke(i,k,j)
+      enddo
+      if (bl_mynn_tkeadvect) then
+         do k=kts,kte
+            qke_adv1(k) = qke_adv(i,k,j)
+         enddo
+      else
+         qke_adv1 = 0.0
+      endif
+
+      !intialize moist species
+      if (flag_qc) then
+         do k=kts,kte
+            qc1(k) = qc(i,k,j)
+         enddo
+      endif
+      if (flag_qi) then
+         do k=kts,kte
+            qi1(k) = qi(i,k,j)
+         enddo
+      endif
+      if (flag_qs) then
+         do k=kts,kte
+            qs1(k) = qs(i,k,j)
+         enddo
+      endif
+      if (flag_qnc) then
+         do k=kts,kte
+            qnc1(k) = qnc(i,k,j)
+         enddo
+      endif
+      if (flag_qni) then
+         do k=kts,kte
+            qni1(k) = qni(i,k,j)
+         enddo
+      endif
+      if (flag_qnwfa) then
+         do k=kts,kte
+            qnwfa1(k) = qnwfa(i,k,j)
+         enddo
+      endif
+      if (flag_qnifa) then
+         do k=kts,kte
+            qnifa1(k) = qnifa(i,k,j)
+         enddo
+      endif
+      if (flag_qnbca) then
+         do k=kts,kte
+            qnbca1(k) = qnbca(i,k,j)
+         enddo
+      endif
+      if (flag_ozone) then
+         do k=kts,kte
+            ozone1(k) = ozone(i,k,j)
+         enddo
+      endif
+#if (WRF_CHEM == 1)
+      if (mix_chem) then
+         do n=1,nchem
+         do k=kts,kte
+            chem(k,n)=chem3d(i,k,j,n)
+         enddo
+         enddo
+
+         !set kdvel =1
+         do n=1,ndvel
+            vd(n) = vd3d(i,1,j,n)
+         enddo
+      endif
+      frp_mean    = 0.0
+      emis_ant_no = 0.0
+#else
+      chem        = 0.0
+      vd          = 0.0
+      frp_mean    = 0.0
+      emis_ant_no = 0.0
+#endif
+
+
+      !find/fix negative mixing ratios
+!      call moisture_check2(kte, delt,                 &
+!                           delp(i,:), exner(i,:,j),   &
+!                           qv(i,:,j), qc(i,:,j),      &
+!                           qi(i,:,j), t3d(i,:,j)      )
+
+      !In WRF, mixing ratio is incoming. Convert to specific humidity:
+      do k=kts,kte
+         sqv1(k)=qv(i,k,j)/(1.0 + qv(i,k,j))
+         sqc1(k)=qc1(k)/(1.0 + qv(i,k,j))
+         sqi1(k)=qi1(k)/(1.0 + qv(i,k,j))
+      enddo
+      if (flag_qs) then
+         do k=kts,kte
+            sqs1(k)=max(qs1(k)/(1.0 + qv(i,k,j)), 0.0)
+         enddo
+      else
+         sqs1=0.0
+      endif
+
+      if (debug .and. i==idb .and. j==jdb) then
+         print*
+         write(0,*)"===CALLING mynn_bl_driver; input:"
+         print*,"tke_budget=",tke_budget
+         print*,"bl_mynn_tkeadvect=",bl_mynn_tkeadvect
+         print*,"bl_mynn_cloudpdf=",bl_mynn_cloudpdf
+         print*,"bl_mynn_mixlength=",bl_mynn_mixlength
+         print*,"bl_mynn_edmf=",bl_mynn_edmf
+         print*,"bl_mynn_edmf_mom=",bl_mynn_edmf_mom
+         print*,"bl_mynn_edmf_tke=",bl_mynn_edmf_tke
+         print*,"bl_mynn_cloudmix=",bl_mynn_cloudmix
+         print*,"bl_mynn_mixqt=",bl_mynn_mixqt
+         print*,"icloud_bl=",icloud_bl
+         print*,"initflag=",initflag
+         print*,"T:",t3d(i,1,j),t3d(i,2,j),t3d(i,kte,j)
+         print*,"TH:",th(i,1,j),th(i,2,j),th(i,kte,j)
+         print*,"rho:",rho(i,1,j),rho(i,2,j),rho(i,kte,j)
+         print*,"exner:",exner(i,1,j),exner(i,2,j),exner(i,kte,j)
+         print*,"p:",p(i,1,j),p(i,2,j),p(i,kte,j)
+         print*,"dz:",dz(i,1,j),dz(i,2,j),dz(i,kte,j)
+         print*,"u:",u(i,1,j),u(i,2,j),u(i,kte,j)
+         print*,"v:",v(i,1,j),v(i,2,j),v(i,kte,j)
+         print*,"sqv:",sqv1(1),sqv1(2),sqv1(kte)
+         print*,"sqc:",sqc1(1),sqc1(2),sqc1(kte)
+         print*,"sqi:",sqi1(1),sqi1(2),sqi1(kte)
+         print*,"rmol:",rmol(i,j)," ust:",ust(i,j)
+         print*,"dx=",dxc(i,j)," delt=",delt
+         print*,"Thetasurf:",ts(i,j)," wspd:",wspd(i,j)
+         print*,"hfx:",hfx(i,j)," qfx",qfx(i,j)
+         print*,"qsfc:",qsfc(i,j)," ps:",ps(i,j)
+         print*,"znt:",znt(i,j)," xland=",xland(i,j)
+         print*,"ite=",ite," kte=",kte
+         print*,"pblh=",pblh(i,j)," kpbl=",KPBL(i,j)
+         print*,"qke:",qke(i,1,j),qke(i,2,j),qke(i,kte,j)
+         print*,"el_pbl:",el_pbl(i,1,j),el_pbl(i,2,j),el_pbl(i,kte,j)
+         print*,"Sh3d:",Sh3d(i,1,j),sh3d(i,2,j),sh3d(i,kte,j)
+         print*,"max cf_bl:",maxval(cldfra_bl(i,:,j))
+         print*,"max qc_bl:",maxval(qc_bl(i,:,j))
+      endif
+
+!print*,"In mynn wrapper, calling mynn_bl_driver"
+      call mynn_bl_driver(i=i,           j=j,                          &
+     &        initflag=initflag,         restart=restart,              &
+     &        cycling=cycling,           delt=delt,                    &
+     &        dz1=dz1,                   dx=dx,                        &
+     &        u1=u1,                     v1=v1,                        &
+     &        w1=w1,                     th1=th1,                      &
+     &        sqv1=sqv1,                 sqc1=sqc1,                    &
+     &        sqi1=sqi1,                 sqs1=sqs1,                    &
+     &        qnc1=qnc1,                 qni1=qni1,                    &
+     &        qnwfa1=qnwfa1,             qnifa1=qnifa1,                &
+     &        qnbca1=qnbca1,             ozone1=ozone1,                &
+     &        p1=p1,                     ex1=ex1,                      &
+     &        rho1=rho1,                 tk1=tk1,                      &
+              !2d variables
+     &        xland=xland(i,j),          ts=ts(i,j),                   &
+     &        qsfc=qsfc(i,j),            ps=ps(i,j),                   &
+     &        ust=ust(i,j),              ch=ch(i,j),                   &
+     &        hfx=hfx(i,j),              qfx=qfx(i,j),                 &
+     &        rmol=rmol(i,j),            wspd=wspd(i,j),               &
+     &        pblh=pblh(i,j),            KPBL=KPBL(i,j),               & !output
+     &        uoce=uoce(i,j),            voce=voce(i,j),               & !input
+     &        znt=znt(i,j),                                            & !input
+              !smoke/chem
+     &        nchem=nchem,               kdvel=kdvel,                  &
+     &        ndvel=ndvel,                                             &
+     &        chem=chem,                 vdep=vd,                      &
+     &        FRP=frp_mean(i),           EMIS_ANT_NO=emis_ant_no(i),   &
+     &        mix_chem=mix_chem,         enh_mix=enh_mix,              &
+     &        rrfs_sd=rrfs_sd,           smoke_dbg=smoke_dbg,          &
+              !higher-order variables and subgrid clouds
+     &        tsq1=tsq1,                 qsq1=qsq1,                    & !output
+     &        cov1=cov1,                 cldfra_bl1=cldfra_bl1,        & !output
+     &        qc_bl1=qc_bl1,             qi_bl1=qi_bl1,                & !output
+              !eddy diffusivity/viscosity and components
+     &        kh1=kh1,                   km1=km1,                      & !output
+     &        qke1=qke1,                 qke_adv1=qke_adv1,            & !output
+     &        sh1=sh1,                   sm1=sm1,                      & !output
+     &        el1=el1,                                                 &
+              !tendencies
+     &        du1=du1,                   dv1=dv1,                      & !output
+     &        dth1=dth1,                 dqv1=dqv1,                    & !output
+     &        dqc1=dqc1,                 dqi1=dqi1,                    & !output
+     &        dqnc1=dqnc1,               dqni1=dqni1,                  & !output
+     &        dqs1=kzero,                                              & !there is no RQSBLTEN, so use dummy arary
+     &        dqnwfa1=dqnwfa1,           dqnifa1=dqnifa1,              & !output
+     &        dqnbca1=dqnbca1,           dozone1=dozone1,              & !output
+              !tke budget
+     &        dqke1=dqke1,                                             & !output
+     &        qWT1=qWT1,                 qSHEAR1=qSHEAR1,              & !output
+     &        qBUOY1=qBUOY1,             qDISS1=qDISS1,                & !output
+              !input namelist parameters
+     &        bl_mynn_tkeadvect  = bl_mynn_tkeadvect,                  & !input parameter
+     &        tke_budget         = tke_budget,                         & !input parameter
+     &        bl_mynn_cloudpdf   = bl_mynn_cloudpdf,                   & !input parameter
+     &        bl_mynn_mixlength  = bl_mynn_mixlength,                  & !input parameter
+     &        icloud_bl          = icloud_bl,                          & !input parameter
+     &        closure            = bl_mynn_closure,                    & !input parameter
+     &        bl_mynn_edmf       = bl_mynn_edmf,                       & !input parameter
+     &        bl_mynn_edmf_mom   = bl_mynn_edmf_mom,                   & !input parameter
+     &        bl_mynn_edmf_tke   = bl_mynn_edmf_tke,                   & !input parameter
+     &        bl_mynn_mixscalars = bl_mynn_mixscalars,                 & !input parameter
+     &        bl_mynn_output     = bl_mynn_output,                     & !input parameter
+     &        bl_mynn_cloudmix   = bl_mynn_cloudmix,                   & !input parameter
+     &        bl_mynn_mixqt      = bl_mynn_mixqt,                      & !input parameter
+     &        edmf_a1=edmf_a1,           edmf_w1=edmf_w1,              & !output
+     &        edmf_qt1=edmf_qt1,         edmf_thl1=edmf_thl1,          & !output
+     &        edmf_ent1=edmf_ent1,       edmf_qc1=edmf_qc1,            & !output
+     &        sub_thl1=sub_thl1,         sub_sqv1=sub_sqv1,            & !output
+     &        det_thl1=det_thl1,         det_sqv1=det_sqv1,            & !output
+     &        maxwidth=maxwidth(i,j),    maxmf=maxMF(i,j),             & !output
+     &        ztop_plume=ztop_plume(i,j),                              & !output
+     &        spp_pbl=spp_pbl, pattern_spp_pbl1=pattern_spp_pbl1,      & !input
+     &        rthraten1=rthraten1,                                     & !input
+     &        FLAG_QI=flag_qi,FLAG_QNI=flag_qni,FLAG_QS=flag_qs,       & !input
+     &        FLAG_QC=flag_qc,FLAG_QNC=flag_qnc,                       & !input
+     &        FLAG_QNWFA=FLAG_QNWFA,FLAG_QNIFA=FLAG_QNIFA,             & !input
+     &        FLAG_QNBCA=FLAG_QNBCA,FLAG_OZONE=flag_ozone,             & !input
+     &        IDS=ids,IDE=ide,JDS=jds,JDE=jde,KDS=kds,KDE=kde,         & !input
+     &        IMS=ims,IME=ime,JMS=jms,JME=jme,KMS=kms,KME=kme,         & !input
+     &        ITS=its,ITE=itf,JTS=jts,JTE=jtf,KTS=kts,KTE=kte          ) !input
+
+      if (debug .and. i==idb .and. j==jdb) then
+         print*,"In mynn wrapper, after bl_mynn_driver"
+      endif
+
+      ! update turbulence properties output
+      do k=kts,kte
+         qke(i,k,j)     = qke1(k)
+         el_pbl(i,k,j)  = el1(k)
+         sh3d(i,k,j)    = sh1(k)
+         sm3d(i,k,j)    = sm1(k)
+         kh(i,k,j)      = kh1(k)
+         km(i,k,j)      = km1(k)
+         tsq(i,k,j)     = tsq1(k)
+         qsq(i,k,j)     = qsq1(k)
+         cov(i,k,j)     = cov1(k)
+      enddo
+      if (bl_mynn_tkeadvect) then
+         do k=kts,kte
+            qke_adv(i,k,j) = qke_adv1(k)
+         enddo
+      endif
+      
+      ! SHOULD CONVERT BACK WITH THE UPDATED QV??????????
+      !- Update 3d tendencies, convert spec hum to mixing ratio:
+      do k=kts,kte
+         RUBLTEN(i,k,j)  = du1(k)
+         RVBLTEN(i,k,j)  = dv1(k)
+         RTHBLTEN(i,k,j) = dth1(k)
+      enddo
+      if (present(RQVBLTEN)) then
+         do k=kts,kte
+            RQVBLTEN(i,k,j) = dqv1(k)/(1.0 - sqv1(k))
+         enddo
+      endif
+      if (present(RQCBLTEN)) then
+         do k=kts,kte
+            RQCBLTEN(i,k,j) = dqc1(k)/(1.0 - sqv1(k))
+         enddo
+      endif
+      if (present(RQIBLTEN)) then
+         do k=kts,kte
+            RQIBLTEN(i,k,j) = dqi1(k)/(1.0 - sqv1(k))
+         enddo
+      endif
+      if (.false.) then !as of now, there is no RQSBLTEN in WRF
+        do k=kts,kte
+           RQSBLTEN(i,k,j) = dqs1(k)/(1.0 - sqv1(k))
+        enddo
+      endif
+      if (present(RQNCBLTEN)) then
+         do k=kts,kte
+            RQNCBLTEN(i,k,j) = dqnc1(k)
+         enddo
+      endif
+      if (present(RQNIBLTEN)) then
+         do k=kts,kte
+            RQNIBLTEN(i,k,j) = dqni1(k)
+         enddo
+      endif
+      if (present(RQNWFABLTEN)) then
+         do k=kts,kte
+            RQNWFABLTEN(i,k,j) = dqnwfa1(k)
+         enddo
+      endif
+      if (present(RQNIFABLTEN)) then
+         do k=kts,kte
+            RQNIFABLTEN(i,k,j) = dqnifa1(k)
+         enddo
+      endif
+      if (present(RQNBCABLTEN)) then
+         do k=kts,kte
+            RQNBCABLTEN(i,k,j) = dqnbca1(k)
+         enddo
+      endif
+
+     !- Collect 3D ouput:
+      if (icloud_bl > 0) then
+         do k=kts,kte
+            qc_bl(i,k,j)     = qc_bl1(k)/(1.0 - sqv1(k))
+            qi_bl(i,k,j)     = qi_bl1(k)/(1.0 - sqv1(k))
+            cldfra_bl(i,k,j) = cldfra_bl1(k)
+         enddo
+      endif
+
+      if (tke_budget .eq. 1) then
+         do k=kts,kte
+            dqke(i,k,j)     = dqke1(k)
+            qwt(i,k,j)      = qwt1(k)
+            qshear(i,k,j)   = qshear1(k)
+            qbuoy(i,k,j)    = qbuoy1(k)
+            qdiss(i,k,j)    = qdiss1(k)
+         enddo
+      endif
+
+      if (bl_mynn_output > 0) then
+         do k=kts,kte
+            edmf_a(i,k,j)     = edmf_a1(k)
+            edmf_w(i,k,j)     = edmf_w1(k)
+            edmf_qt(i,k,j)    = edmf_qt1(k)
+            edmf_thl(i,k,j)   = edmf_thl1(k)
+            edmf_ent(i,k,j)   = edmf_ent1(k)
+            edmf_qc(i,k,j)    = edmf_qc1(k)
+            sub_thl(i,k,j)    = sub_thl1(k)
+            sub_sqv(i,k,j)    = sub_sqv1(k)
+            det_thl(i,k,j)    = det_thl1(k)
+            det_sqv(i,k,j)    = det_sqv1(k)
+         enddo
+      endif
+
+#if (WRF_CHEM == 1)
+      if (mix_chem) then
+         do ic = 1,nchem
+            do k = kts,kte
+               chem3d(i,k,j,ic) = max(1.e-12, chem(k,ic))
+            enddo
+         enddo
+      endif
+#endif
+
+      if (debug .and. i==idb .and. j==jdb) then
+          print*
+          print*,"===Finished with mynn_bl_driver; output:"
+          print*,"T:",t3d(i,1,j),t3d(i,2,j),t3d(i,kte,j)
+          print*,"TH:",th(i,1,j),th(i,2,j),th(i,kte,j)
+          print*,"rho:",rho(i,1,j),rho(i,2,j),rho(i,kte,j)
+          print*,"exner:",exner(i,1,j),exner(i,2,j),exner(i,kte,j)
+          print*,"p:",p(i,1,j),p(i,2,j),p(i,kte,j)
+          print*,"dz:",dz(i,1,j),dz(i,2,j),dz(i,kte,j)
+          print*,"u:",u(i,1,j),u(i,2,j),u(i,kte,j)
+          print*,"v:",v(i,1,j),v(i,2,j),v(i,kte,j)
+          print*,"sqv:",sqv1(1),sqv1(2),sqv1(kte)
+          print*,"sqc:",sqc1(1),sqc1(2),sqc1(kte)
+          print*,"sqi:",sqi1(1),sqi1(2),sqi1(kte)
+          print*,"rmol:",rmol(i,j)," ust:",ust(i,j)
+          print*,"dx=",dxc(i,j)," delt=",delt
+          print*,"Thetasurf:",ts(i,j)," wspd:",wspd(i,j)
+          print*,"hfx:",hfx(i,j)," qfx",qfx(i,j)
+          print*,"qsfc:",qsfc(i,j)," ps:",ps(i,j)
+          print*,"znt:",znt(i,j)," xland=",xland(i,j)
+          print*,"ite=",ite," kte=",kte
+          print*,"pblh=",pblh(i,j)," kpbl=",KPBL(i,j)
+          print*,"qke:",qke(i,1,j),qke(i,2,j),qke(i,kte,j)
+          print*,"el_pbl:",el_pbl(i,1,j),el_pbl(i,2,j),el_pbl(i,kte,j)
+          print*,"Sh3d:",Sh3d(i,1,j),sh3d(i,2,j),sh3d(i,kte,j)
+          print*,"kh:",kh(i,1,j),kh(i,2,j),kh(i,kte,j)
+          print*,"km:",km(i,1,j),km(i,2,j),km(i,kte,j)
+          print*,"max cf_bl:",maxval(cldfra_bl(i,:,j))
+          print*,"max qc_bl:",maxval(qc_bl(i,:,j))
+          print*,"dtdt:",rthblten(i,1,j),rthblten(i,2,j),rthblten(i,kte,j)
+          print*,"dudt:",rublten(i,1,j),rublten(i,2,j),rublten(i,kte,j)
+          print*,"dvdt:",rvblten(i,1,j),rvblten(i,2,j),rvblten(i,kte,j)
+          print*,"dqdt:",rqvblten(i,1,j),rqvblten(i,2,j),rqvblten(i,kte,j)
+          print*,"ztop_plume:",ztop_plume(i,j)," maxmf:",maxmf(i,j)
+          print*
+       endif
+
+   enddo  !end j-loop
+   enddo  !end i-loop
+
+   if (debug) then
+      print*,"In mynn wrapper, at end"
+   endif
+
+  CONTAINS
+
+! ==================================================================
+  SUBROUTINE moisture_check2(kte, delt, dp, exner, &
+                             qv, qc, qi, th        )
+  !
+  ! If qc < qcmin, qi < qimin, or qv < qvmin happens in any layer,
+  ! force them to be larger than minimum value by (1) condensating 
+  ! water vapor into liquid or ice, and (2) by transporting water vapor 
+  ! from the very lower layer.
+  ! 
+  ! We then update the final state variables and tendencies associated
+  ! with this correction. If any condensation happens, update theta/temperature too.
+  ! Note that (qv,qc,qi,th) are the final state variables after
+  ! applying corresponding input tendencies and corrective tendencies.
+
+    implicit none
+    integer,  intent(in)     :: kte
+    real, intent(in)     :: delt
+    real, dimension(kte), intent(in)     :: dp
+    real, dimension(kte), intent(in)     :: exner
+    real, dimension(kte), intent(inout)  :: qv, qc, qi, th
+    integer   k
+    real ::  dqc2, dqi2, dqv2, sum, aa, dum
+    real, parameter :: qvmin1= 1e-8,    & !min at k=1
+                       qvmin = 1e-20,   & !min above k=1
+                       qcmin = 0.0,     &
+                       qimin = 0.0
+
+    do k = kte, 1, -1  ! From the top to the surface
+       dqc2 = max(0.0, qcmin-qc(k)) !qc deficit (>=0)
+       dqi2 = max(0.0, qimin-qi(k)) !qi deficit (>=0)
+
+       !update species
+       qc(k)  = qc(k)  +  dqc2
+       qi(k)  = qi(k)  +  dqi2
+       qv(k)  = qv(k)  -  dqc2 - dqi2
+       !for theta
+       !th(k)  = th(k)  +  xlvcp/exner(k)*dqc2 + &
+       !                   xlscp/exner(k)*dqi2
+       !for temperature
+       th(k)  = th(k)  +  xlvcp*dqc2 + &
+                          xlscp*dqi2
+
+       !then fix qv if lending qv made it negative
+       if (k .eq. 1) then
+          dqv2   = max(0.0, qvmin1-qv(k)) !qv deficit (>=0)
+          qv(k)  = qv(k)  + dqv2
+          qv(k)  = max(qv(k),qvmin1)
+          dqv2   = 0.0
+       else
+          dqv2   = max(0.0, qvmin-qv(k)) !qv deficit (>=0)
+          qv(k)  = qv(k)  + dqv2
+          qv(k-1)= qv(k-1)  - dqv2*dp(k)/dp(k-1)
+          qv(k)  = max(qv(k),qvmin)
+       endif
+       qc(k) = max(qc(k),qcmin)
+       qi(k) = max(qi(k),qimin)
+    end do
+
+    ! Extra moisture used to satisfy 'qv(1)>=qvmin' is proportionally
+    ! extracted from all the layers that has 'qv > 2*qvmin'. This fully
+    ! preserves column moisture.
+    if( dqv2 .gt. 1.e-20 ) then
+        sum = 0.0
+        do k = 1, kte
+           if( qv(k) .gt. 2.0*qvmin ) sum = sum + qv(k)*dp(k)
+        enddo
+        aa = dqv2*dp(1)/max(1.e-20,sum)
+        if( aa .lt. 0.5 ) then
+            do k = 1, kte
+               if( qv(k) .gt. 2.0*qvmin ) then
+                   dum    = aa*qv(k)
+                   qv(k)  = qv(k) - dum
+               endif
+            enddo
+        else
+        ! For testing purposes only (not yet found in any output):
+        !    write(*,*) 'Full moisture conservation is impossible'
+        endif
+    endif
+
+    return
+
+  END SUBROUTINE moisture_check2
+
+  END SUBROUTINE mynnedmf_wrapper_run
+
+!###=================================================================
+
+END MODULE module_bl_mynn_wrapper

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_mynn.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_mynn.F
@@ -1,87 +1,99 @@
-!=================================================================================================================
-! copied for implementation in MPAS from WRF version 3.6.1.
-
-! modifications made to sourcecode:
-! * used preprocessing option to replace module_model_constants with mpas_atmphys_constants.
-!   Laura D. Fowler (laura@ucar.edu / 2014-09-25).
-! * used preprocessing option to include the actual mean distance between cell centers.
-!   Laura D. Fowler (laura@ucar.edu / 2015-01-06).
-! * used "dummy" variables in the call to mym_condensation.
-!   Laura D. Fowler (laura@ucar.edu / 2016-10-28).
-
-!=================================================================================================================
-
+!WRF:MODEL_LAYER:PHYSICS
+!
 MODULE module_sf_mynn
 
 !-------------------------------------------------------------------
-!Modifications implemented by Joseph Olson NOAA/GSD/AMB - CU/CIRES
-!for WRFv3.4 and WRFv3.4.1:
+!Modifications implemented by Joseph Olson NOAA/GSL
+!The following overviews the current state of this scheme::
 !
 !   BOTH LAND AND WATER:
 !1) Calculation of stability parameter (z/L) taken from Li et al. (2010 BLM)
-!   for first iteration of first time step; afterwards, exact calculation.  
+!   for first iteration of first time step; afterwards, exact calculation
+!   using a brute force iterative method described in Olson et al. (2021 NOAA
+!   Tech memorandum). This method replaces the iterative technique used in 
+!   module_sf_sfclayrev.F (Jimenez et al. 2013) with mods. Either technique
+!   gives about the same result. The former technique is retained in this
+!   module (commented out) for potential subsequent benchmarking.
 !2) Fixed isflux=0 option to turn off scalar fluxes, but keep momentum
 !   fluxes for idealized studies (credit: Anna Fitch).
-!3) Kinematic viscosity now varies with temperature
-!4) Uses Monin-Obukhov flux-profile relationships more consistent with
-!   those used in the MYNN PBL code.
-!5) Allows negative QFX, similar to MYJ scheme
+!3) Kinematic viscosity varies with temperature according to Andreas (1989).
+!4) Uses the blended Monin-Obukhov flux-profile relationships COARE (Fairall 
+!   et al 2003) for the unstable regime (a blended mix of Dyer-Hicks 1974 and
+!   Grachev et al (2000). Uses Cheng and Brutsaert (2005) for stable conditions.
+!5) The following overviews the namelist variables that control the 
+!   aerodynamic roughness lengths (over water) and the thermal and moisture
+!   roughness lengths (defaults are recommended):
 !
 !   LAND only:
-!1) iz0tlnd option is now available with the following options:
-!   (default) =0: Zilitinkevich (1995) 
+!   "iz0tlnd" namelist option is used to select the following options:
+!   (default) =0: Zilitinkevich (1995); Czil now set to 0.095
 !             =1: Czil_new (modified according to Chen & Zhang 2008)
 !             =2: Modified Yang et al (2002, 2008) - generalized for all landuse
 !             =3: constant zt = z0/7.4 (original form; Garratt 1992)
-!             =4: Pan et al. (1994) with RUC mods for z_q, zili for z_t
-!2) Relaxed u* minimum from 0.1 to 0.01
 !
 !   WATER only:
-!1) isftcflx option is now available with the following options:
-!   (default) =0: z0, zt, and zq from COARE3.0 (Fairall et al 2003) 
-!             =1: z0 from Davis et al (2008), zt & zq from COARE3.0    
-!             =2: z0 from Davis et al (2008), zt & zq from Garratt (1992) 
-!             =3: z0 from Taylor and Yelland (2004), zt and zq from COARE3.0 
-!             =4: z0 from Zilitinkevich (2001), zt & zq from COARE3.0 
+!   "isftcflx" namelist option is used to select the following options:
+!   (default) =0: z0, zt, and zq from the COARE algorithm. Set COARE_OPT (below) to
+!                 3.0 (Fairall et al. 2003, default)
+!                 3.5 (Edson et al 2013) - now with bug fix (Edson et al. 2014, JPO)
+!             =1: z0 from Davis et al (2008), zt & zq from COARE 3.0/3.5
+!             =2: z0 from Davis et al (2008), zt & zq from Garratt (1992)
+!             =3: z0 from Taylor and Yelland (2004), zt and zq from COARE 3.0/3.5
 !
 !   SNOW/ICE only:
-!1) Added Andreas (2002) snow/ice parameterization for thermal and
-!   moisture roughness to help reduce the cool/moist bias in the arctic 
-!   region.
+!   Andreas (2002) snow/ice parameterization for thermal and
+!   moisture roughness is used over all gridpoints with snow deeper than
+!   0.1 m. This algorithm calculates a z0 for snow (Andreas et al. 2005, BLM), 
+!   which is only used as part of the thermal and moisture roughness
+!   length calculation, not to directly impact the surface winds.
+!
+! Misc:
+!1) Added a more elaborate diagnostic for u10 & V10 for high vertical resolution
+!   model configurations but for most model configurations with depth of
+!   the lowest half-model level near 10 m, a neutral-log diagnostic is used.
+!
+!2) Option to activate stochastic parameter perturbations (SPP), which
+!   perturb z0, zt, and zq, along with many other parameters in the MYNN-
+!   EDMF scheme. 
 !
 !NOTE: This code was primarily tested in combination with the RUC LSM.
 !      Performance with the Noah (or other) LSM is relatively unknown.
 !-------------------------------------------------------------------
-
-#if defined(mpas)
- use mpas_atmphys_constants,only: p1000mb => P0,cp,xlv,ep_2
- use module_bl_mynn,only: tv0,mym_condensation
- use module_sf_sfclay,only: sfclayinit
-
- implicit none
- private
- public:: mynn_sf_init_driver, &
-          sfclay_mynn 
-
-#else
-  USE module_model_constants, only: &
-       &p1000mb, cp, xlv, ep_2
-
-  USE module_sf_sfclay, ONLY: sfclayinit
-  USE module_bl_mynn,   only: tv0, mym_condensation
-  USE module_wrf_error
+!For WRF
+!  USE module_model_constants, only: &
+!       &p1000mb, ep_2
+!For MPAS
+   USE mpas_atmphys_constants, only: &
+        p1000mb => P0, ep_2 
 !-------------------------------------------------------------------
   IMPLICIT NONE
 !-------------------------------------------------------------------
-#endif
+!For non-WRF
+!   REAL    , PARAMETER :: g            = 9.81
+!   REAL    , PARAMETER :: r_d          = 287.
+!   REAL    , PARAMETER :: cp           = 7.*r_d/2.
+!   REAL    , PARAMETER :: r_v          = 461.6
+!   REAL    , PARAMETER :: cpv          = 4.*r_v
+!   REAL    , PARAMETER :: rcp          = r_d/cp
+!   REAL    , PARAMETER :: XLV          = 2.5E6
+!   REAL    , PARAMETER :: XLF          = 3.50E5
+!   REAL    , PARAMETER :: p1000mb      = 100000.
+!   REAL    , PARAMETER :: EP_2         = r_d/r_v
 
-  REAL, PARAMETER :: xlvcp=xlv/cp, ep_3=1.-ep_2
- 
+  REAL :: ep_3=1.-ep_2 
   REAL, PARAMETER :: wmin=0.1    ! Minimum wind speed
-  REAL, PARAMETER :: VCONVC=1.0
-  REAL, PARAMETER :: SNOWZ0=0.012
+  REAL, PARAMETER :: VCONVC=1.25
+  REAL, PARAMETER :: SNOWZ0=0.011
+  REAL, PARAMETER :: COARE_OPT=3.5  ! 3.0 or 3.5
+  INTEGER, PARAMETER :: psi_opt = 0    ! 0 = stable: Cheng and Brustaert
+                                       !     unstable: blended COARE
+                                       ! 1 = GFS
+  REAL, PARAMETER :: qvmin = 1e-9
+  !For debugging purposes:
+  LOGICAL, PARAMETER :: debug_code = .false.
 
-  REAL, DIMENSION(0:1000 ),SAVE          :: PSIMTB,PSIHTB
+  REAL,   DIMENSION(0:1000 ),SAVE :: psim_stab,psim_unstab, &
+                                     psih_stab,psih_unstab
 
 CONTAINS
 
@@ -90,36 +102,31 @@ CONTAINS
 
     LOGICAL, INTENT(in) :: allowed_to_read
 
-    !Fill the PSIM and PSIH tables. The subroutine "sfclayinit" 
-    !can be found in module_sf_sfclay.F. This subroutine returns
-    !the forms from Dyer and Hicks (1974).
-       
-    CALL sfclayinit(allowed_to_read)
+    !Fill the PSIM and PSIH tables. This code was leveraged from
+    !module_sf_sfclayrev.F, leveraging the work from Pedro Jimenez.
+    !This subroutine returns a blended form from Dyer and Hicks (1974)
+    !and Grachev et al (2000) for unstable conditions and the form 
+    !from Cheng and Brutsaert (2005) for stable conditions.
+
+     CALL psi_init(psi_opt)
 
   END SUBROUTINE mynn_sf_init_driver
 
 !-------------------------------------------------------------------
-   SUBROUTINE SFCLAY_mynn(U3D,V3D,T3D,QV3D,P3D,dz8w,               &
-                     CP,G,ROVCP,R,XLV,PSFCPA,CHS,CHS2,CQS2,CPM,    &
-                     ZNT,UST,PBLH,MAVAIL,ZOL,MOL,REGIME,PSIM,PSIH, &
-                     XLAND,HFX,QFX,LH,TSK,FLHC,FLQC,QGH,QSFC,RMOL, &
-                     U10,V10,TH2,T2,Q2,SNOWH,                      &
-                     GZ1OZ0,WSPD,BR,ISFFLX,DX,                     &
-                     SVP1,SVP2,SVP3,SVPT0,EP1,EP2,                 &
-                     KARMAN,itimestep,ch,th3d,pi3d,qc3d,rho3d,     &
-                     tsq,qsq,cov,sh3d,el_pbl,qcg,                  &
-!JOE-add output
-!                     z0zt_ratio,BulkRi,wstar,qstar,resist,logres,  &
-!JOE-end 
-                     ids,ide, jds,jde, kds,kde,                    &
-                     ims,ime, jms,jme, kms,kme,                    &
-                     its,ite, jts,jte, kts,kte,                    &
-                     ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,          &
-                     bl_mynn_cloudpdf                              &
-#if defined(mpas)
-                    ,dxCell                                        &
-#endif
-                         )
+   SUBROUTINE SFCLAY_mynn(                                  &
+              U3D,V3D,T3D,QV3D,P3D,dz8w,th3d,rho3d,         &
+              CP,G,ROVCP,R,XLV,PSFCPA,CHS,CHS2,CQS2,CPM,    &
+              ZNT,UST,PBLH,MAVAIL,ZOL,MOL,REGIME,PSIM,PSIH, &
+              XLAND,HFX,QFX,LH,TSK,FLHC,FLQC,QGH,QSFC,RMOL, &
+              U10,V10,TH2,T2,Q2,SNOWH,                      &
+              GZ1OZ0,WSPD,BR,ISFFLX,DX,                     &
+              SVP1,SVP2,SVP3,SVPT0,EP1,EP2,                 &
+              KARMAN,itimestep,ch,qcg,                      &
+              spp_pbl,pattern_spp_pbl,                      &
+              ids,ide, jds,jde, kds,kde,                    &
+              ims,ime, jms,jme, kms,kme,                    &
+              its,ite, jts,jte, kts,kte,                    &
+              ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,dx2d       )
 !-------------------------------------------------------------------
       IMPLICIT NONE
 !-------------------------------------------------------------------
@@ -138,7 +145,7 @@ CONTAINS
 !-- PSFCPA      surface pressure (Pa)
 !-- ZNT         roughness length (m)
 !-- UST         u* in similarity theory (m/s)
-!-- USTM        u* in similarity theory (m/s) w* added to WSPD. This is                                                                         
+!-- USTM        u* in similarity theory (m/s) w* added to WSPD. This is
 !               used to couple with TKE scheme but not in MYNN.
 !               (as of now, USTM = UST in this version)
 !-- PBLH        PBL height from previous time (m)
@@ -179,27 +186,18 @@ CONTAINS
 !-- EP2         constant for spec. hum. calc (Rd/Rv = 0.622) (dimensionless)
 !-- EP3         constant for spec. hum. calc (1 - Rd/Rv = 0.378 ) (dimensionless)
 !-- KARMAN      Von Karman constant
-!-- ck          enthalpy exchange coeff at 10 meters                                                                                           
-!-- cd          momentum exchange coeff at 10 meters                                                                                           
-!-- cka         enthalpy exchange coeff at the lowest model level                                                                              
-!-- cda         momentum exchange coeff at the lowest model level                                                                              
-!-- isftcflx    =0: z0, zt, and zq from COARE3.0 (Fairall et al 2003)
-!   (water      =1: z0 from Davis et al (2008), zt & zq from COARE3.0
+!-- ck          enthalpy exchange coeff at 10 meters
+!-- cd          momentum exchange coeff at 10 meters
+!-- cka         enthalpy exchange coeff at the lowest model level
+!-- cda         momentum exchange coeff at the lowest model level
+!-- isftcflx    =0: z0, zt, and zq from COARE3.0/3.5 (Fairall et al 2003/Edson et al 2013)
+!   (water      =1: z0 from Davis et al (2008), zt & zq from COARE3.0/3.5
 !    only)      =2: z0 from Davis et al (2008), zt & zq from Garratt (1992)
-!               =3: z0 from Taylor and Yelland (2004), zt and zq from COARE3.0                                                                 
-!               =4: z0 from Zilitinkevich (2001), zt & zq from COARE3.0
-!-- iz0tlnd     =0: Zilitinkevich (1995) with Czil=0.14, 
+!               =3: z0 from Taylor and Yelland (2004), zt and zq from COARE 3.0/3.5
+!-- iz0tlnd     =0: Zilitinkevich (1995) with Czil=0.095, 
 !   (land       =1: Czil_new (modified according to Chen & Zhang 2008)
 !    only)      =2: Modified Yang et al (2002, 2008) - generalized for all landuse
 !               =3: constant zt = z0/7.4 (Garratt 1992)
-!               =4: Pan et al (1994) for zq; ZIlitintevich for zt
-!-- bl_mynn_cloudpdf =0: Mellor & Yamada
-!                    =1: Kuwano et al.
-!-- el_pbl      = mixing length from PBL scheme (meters)
-!-- Sh3d        = Stability finction for heat (unitless)
-!-- cov         = T'q' from PBL scheme
-!-- tsq         = T'T' from PBL scheme
-!-- qsq         = q'q' from PBL scheme
 !
 !-- ids         start index for i in domain
 !-- ide         end index for i in domain
@@ -231,8 +229,9 @@ CONTAINS
       REAL,     INTENT(IN)   ::        CP,G,ROVCP,R,XLV,DX
 !NAMELIST OPTIONS:
       INTEGER,  INTENT(IN)   ::        ISFFLX
-      INTEGER,  OPTIONAL,  INTENT(IN)   ::     ISFTCFLX, IZ0TLND,&
-                                                bl_mynn_cloudpdf
+      INTEGER,  OPTIONAL,  INTENT(IN)   ::     ISFTCFLX, IZ0TLND
+      INTEGER,  OPTIONAL,  INTENT(IN)   ::     spp_pbl
+
 !===================================
 ! 3D VARIABLES
 !===================================
@@ -241,9 +240,11 @@ CONTAINS
                                                              QV3D, &
                                                               P3D, &
                                                               T3D, &
-                                                             QC3D, &
                                                           U3D,V3D, &
-                             RHO3D,th3d,pi3d,tsq,qsq,cov,sh3d,el_pbl
+                                                       RHO3D,th3d
+
+      REAL, DIMENSION( ims:ime, kms:kme, jms:jme ), OPTIONAL,      &
+                INTENT(IN) ::                      pattern_spp_pbl
 !===================================
 ! 2D VARIABLES
 !===================================
@@ -253,15 +254,11 @@ CONTAINS
                                                             XLAND, &
                                                               TSK, &
                                                               QCG, &
-                                                           PSFCPA , &
+                                                           PSFCPA ,&
                                                             SNOWH
 
-#if defined(mpas)
-!MPAS specific (Laura D. Fowler - 2014-12-02):
-      real,intent(in),dimension(ims:ime,jms:jme),optional:: dxCell
-!MPAS specific end.
-#endif
-
+      REAL, OPTIONAL, DIMENSION(ims:ime, jms:jme), &
+                INTENT(IN)                        ::         DX2D
       REAL,     DIMENSION( ims:ime, jms:jme )                    , &
                 INTENT(OUT  )               ::            U10,V10, &
                                                         TH2,T2,Q2
@@ -289,29 +286,23 @@ CONTAINS
                                                         PSIM,PSIH
 
 !ADDITIONAL OUTPUT
-!JOE-begin
-      REAL,     DIMENSION( ims:ime, jms:jme )    ::    z0zt_ratio, &
-                                 BulkRi,wstar,qstar,resist,logres
-!JOE-end 
+      REAL,     DIMENSION( ims:ime, jms:jme )    ::   wstar,qstar
 !===================================
 ! 1D LOCAL ARRAYS
 !===================================
       REAL,     DIMENSION( its:ite ) ::                       U1D, &
                                                               V1D, &
+                                                        U1D2,V1D2, & !level2 winds
                                                              QV1D, &
                                                               P1D, &
-                                                         T1D,QC1D, &
+                                                              T1D, &
                                                             RHO1D, &
-                                                           dz8w1d
+                                                           dz8w1d, & !level 1 height
+                                                           dz2w1d    !level 2 height
 
-      ! VARIABLE FOR PASSING TO MYM_CONDENSATION
-      REAL,     DIMENSION(kts:kts+1 ) :: dummy1,dummy2,dummy3,dummy4, &
-                                         dummy5,dummy6,dummy7,dummy8, &
-                                         dummy9,dummy10
 
-      REAL,     DIMENSION( its:ite ) ::  vt1,vq1
-      REAL,     DIMENSION(kts:kts+1) ::  thl, qw, vt, vq
-      REAL                           ::  ql
+      REAL,     DIMENSION( its:ite ) ::                  rstoch1D, &
+                                                             dx1D
 
       INTEGER ::  I,J,K,itf,jtf,ktf
 !-----------------------------------------------------------
@@ -320,67 +311,53 @@ CONTAINS
       jtf=MIN0(jte,jde-1)
       ktf=MIN0(kte,kde-1)
 
+      IF (debug_code) THEN
+        write(0,*)"======= printing of constants:"
+        write(0,*)"cp=",   cp," g=",      g
+        write(0,*)"Rd=",    R," ep1=",    ep1
+        write(0,*)"xlv=", XLV," karman=", karman
+        write(0,*)"ep2=", ep2
+      ENDIF
+
       DO J=jts,jte
         DO i=its,ite
            dz8w1d(I) = dz8w(i,kts,j)
+           dz2w1d(I) = dz8w(i,kts+1,j)
            U1D(i) =U3D(i,kts,j)
            V1D(i) =V3D(i,kts,j)
+           !2nd model level winds - for diags with high-res grids
+           U1D2(i) =U3D(i,kts+1,j)
+           V1D2(i) =V3D(i,kts+1,j)
            QV1D(i)=QV3D(i,kts,j)
-           QC1D(i)=QC3D(i,kts,j)
            P1D(i) =P3D(i,kts,j)
            T1D(i) =T3D(i,kts,j)
            RHO1D(i)=RHO3D(i,kts,j)
+
+           if(present(dx2d)) then
+              dx1d(I) = dx2d(i,j)
+           else
+              dx1d(I) = dx
+           endif
+
+           if (spp_pbl==1) then
+               rstoch1D(i)=pattern_spp_pbl(i,kts,j)
+           else
+               rstoch1D(i)=0.0
+           endif
         ENDDO
 
         IF (itimestep==1) THEN
-!          write(0,*)
-!          write(0,*) '--- sfc_mynn itimestep = ', itimestep
-!          write(0,*) '--- initialize vt1, vq1, ust, mol, qsfc, qstar'
-!          write(0,*)
            DO i=its,ite
-              vt1(i)=0.
-              vq1(i)=0.
-              UST(i,j)=MAX(0.025*SQRT(U1D(i)*U1D(i) + V1D(i)*V1D(i)),0.001)
+              UST(i,j)=MAX(0.04*SQRT(U1D(i)*U1D(i) + V1D(i)*V1D(i)),0.001)
               MOL(i,j)=0.     ! Tstar
               QSFC(i,j)=QV3D(i,kts,j)/(1.+QV3D(i,kts,j))
               qstar(i,j)=0.0
            ENDDO
-        ELSE
-!          write(0,*)
-!          write(0,*) '--- sfc_mynn itimestep = ', itimestep
-!          write(0,*) '--- call mym_condensation:'
-!          write(0,*)
-           DO i=its,ite
-              do k = kts,kts+1
-                ql = qc3d(i,k,j)/(1.+qc3d(i,k,j))
-                qw(k) = qv3d(i,k,j)/(1.+qv3d(i,k,j)) + ql
-                thl(k) = th3d(i,k,j)-xlvcp*ql/pi3d(i,k,j)
-                dummy1(k)  = dz8w(i,k,j)
-                dummy2(k)  = thl(k)
-                dummy3(k)  = qw(k)
-                dummy4(k)  = p3d(i,k,j)
-                dummy5(k)  = pi3d(i,k,j)
-                dummy6(k)  = tsq(i,k,j)
-                dummy7(k)  = qsq(i,k,j)
-                dummy8(k)  = cov(i,k,j)
-                dummy9(k)  = Sh3d(i,k,j)
-                dummy10(k) = el_pbl(i,k,j)
-              end do
-
-              ! NOTE: The last grid number is kts+1 instead of kte.
-              CALL mym_condensation (kts,kts+1, &
-                   &            dummy1,dummy2,dummy3, &
-                   &            dummy4,dummy5,dummy6, &
-                   &            dummy7,dummy8,dummy9, &
-                   &            dummy10,              &
-                   &            bl_mynn_cloudpdf,     &
-                   &            vt(kts:kts+1), vq(kts:kts+1))
-              vt1(i) = vt(kts)
-              vq1(i) = vq(kts)
-           ENDDO
         ENDIF
 
-        CALL SFCLAY1D_mynn(J,U1D,V1D,T1D,QV1D,P1D,dz8w1d,rho1d,    &
+        CALL SFCLAY1D_mynn(                                        &
+                J,U1D,V1D,T1D,QV1D,P1D,dz8w1d,rho1d,               &
+                U1D2,V1D2,dz2w1d,                                  &
                 CP,G,ROVCP,R,XLV,PSFCPA(ims,j),CHS(ims,j),CHS2(ims,j),&
                 CQS2(ims,j),CPM(ims,j),PBLH(ims,j), RMOL(ims,j),   &
                 ZNT(ims,j),UST(ims,j),MAVAIL(ims,j),ZOL(ims,j),    &
@@ -389,54 +366,46 @@ CONTAINS
                 U10(ims,j),V10(ims,j),TH2(ims,j),T2(ims,j),        &
                 Q2(ims,j),FLHC(ims,j),FLQC(ims,j),SNOWH(ims,j),    &
                 QGH(ims,j),QSFC(ims,j),LH(ims,j),                  &
-                GZ1OZ0(ims,j),WSPD(ims,j),BR(ims,j),ISFFLX,DX,     &
+                GZ1OZ0(ims,j),WSPD(ims,j),BR(ims,j),ISFFLX,DX1d,  &
                 SVP1,SVP2,SVP3,SVPT0,EP1,EP2,KARMAN,               &
-                ch(ims,j),vt1,vq1,qc1d,qcg(ims,j),itimestep,       &
+                ch(ims,j),qcg(ims,j),                              &
+                itimestep,                                         &
 !JOE-begin additional output
-                z0zt_ratio(ims,j),BulkRi(ims,j),wstar(ims,j),      &
-                qstar(ims,j),resist(ims,j),logres(ims,j),          &
+                wstar(ims,j),qstar(ims,j),                         &
 !JOE-end
+                spp_pbl,rstoch1D,                                  &
                 ids,ide, jds,jde, kds,kde,                         &
                 ims,ime, jms,jme, kms,kme,                         &
-                its,ite, jts,jte, kts,kte                          &
-#if defined(mpas)
-!MPAS specific (Laura D. Fowler - 2014-12-02):
-                ,isftcflx,iz0tlnd,                                 &
-                USTM(ims,j),CK(ims,j),CKA(ims,j),                  &
-                CD(ims,j),CDA(ims,j),dxCell(ims,j)                 &
-#else
-                ,isftcflx,iz0tlnd,                                 &
+                its,ite, jts,jte, kts,kte,                         &
+                isftcflx, iz0tlnd,                                 &
                 USTM(ims,j),CK(ims,j),CKA(ims,j),                  &
                 CD(ims,j),CDA(ims,j)                               &
-#endif
                                                                    )
-
       ENDDO
 
     END SUBROUTINE SFCLAY_MYNN
 
 !-------------------------------------------------------------------
-   SUBROUTINE SFCLAY1D_mynn(J,U1D,V1D,T1D,QV1D,P1D,dz8w1d,rho1d,   &
+   SUBROUTINE SFCLAY1D_mynn(                                       &
+                     J,U1D,V1D,T1D,QV1D,P1D,dz8w1d,rho1d,          &
+                     U1D2,V1D2,dz2w1d,                             &
                      CP,G,ROVCP,R,XLV,PSFCPA,CHS,CHS2,CQS2,CPM,    &
                      PBLH,RMOL,ZNT,UST,MAVAIL,ZOL,MOL,REGIME,      &
                      PSIM,PSIH,XLAND,HFX,QFX,TSK,                  &
                      U10,V10,TH2,T2,Q2,FLHC,FLQC,SNOWH,QGH,        &
                      QSFC,LH,GZ1OZ0,WSPD,BR,ISFFLX,DX,             &
                      SVP1,SVP2,SVP3,SVPT0,EP1,EP2,                 &
-                     KARMAN,ch,vt1,vq1,qc1d,qcg,itimestep,         &
+                     KARMAN,ch,qcg,                                &
+                     itimestep,                                    &
 !JOE-additional output
-                     zratio,BRi,wstar,qstar,resist,logres,         &
+                     wstar,qstar,                                  &
 !JOE-end
+                     spp_pbl,rstoch1D,                             &
                      ids,ide, jds,jde, kds,kde,                    &
                      ims,ime, jms,jme, kms,kme,                    &
-                     its,ite, jts,jte, kts,kte                     &
-                     ,isftcflx, iz0tlnd,                           &
-#if defined(mpas)
-!MPAS specific (Laura D. Fowler - 2014-12-02):
-                     ustm,ck,cka,cd,cda,dxCell                     &
-#else
+                     its,ite, jts,jte, kts,kte,                    &
+                     isftcflx, iz0tlnd,                            &
                      ustm,ck,cka,cd,cda                            &
-#endif
                      )
 
 !-------------------------------------------------------------------
@@ -452,13 +421,14 @@ CONTAINS
       REAL,     PARAMETER  :: XKA=2.4E-5   !molecular diffusivity
       REAL,     PARAMETER  :: PRT=1.       !prandlt number
       REAL,     INTENT(IN) :: SVP1,SVP2,SVP3,SVPT0,EP1,EP2
-      REAL,     INTENT(IN) :: KARMAN,CP,G,ROVCP,R,XLV,DX
+      REAL,     INTENT(IN) :: KARMAN,CP,G,ROVCP,R,XLV!,DX
 
 !-----------------------------
 ! NAMELIST OPTIONS
 !-----------------------------
       INTEGER,  INTENT(IN) :: ISFFLX
       INTEGER,  OPTIONAL,  INTENT(IN )   ::     ISFTCFLX, IZ0TLND
+      INTEGER,    INTENT(IN)             ::     spp_pbl
 
 !-----------------------------
 ! 1D ARRAYS
@@ -469,14 +439,15 @@ CONTAINS
                                                               TSK, &
                                                            PSFCPA, &
                                                               QCG, &
-                                                            SNOWH
+                                                            SNOWH, &
+                                                               DX
 
       REAL,     DIMENSION( its:ite ), INTENT(IN)   ::     U1D,V1D, &
+                                                        U1D2,V1D2, &
                                                          QV1D,P1D, &
-                                                         T1D,QC1d, &
-                                                           dz8w1d, &
-                                                            RHO1D, &
-                                                          vt1,vq1
+                                                              T1D, &
+                                                    dz8w1d,dz2w1d, &
+                                                            RHO1D
 
       REAL,     DIMENSION( ims:ime ), INTENT(INOUT) ::     REGIME, &
                                                        HFX,QFX,LH, &
@@ -493,6 +464,7 @@ CONTAINS
                                                              WSPD, &
                                                                BR, &
                                                         PSIM,PSIH
+      REAL,     DIMENSION( its:ite ), INTENT(IN)   ::     rstoch1D
 
       ! DIAGNOSTIC OUTPUT
       REAL,     DIMENSION( ims:ime ), INTENT(OUT)   ::    U10,V10, &
@@ -502,25 +474,25 @@ CONTAINS
                 INTENT(OUT)     ::              ck,cka,cd,cda,ustm
 !--------------------------------------------
 !JOE-additinal output
-      REAL,     DIMENSION( ims:ime ) ::    zratio,BRi,wstar,qstar, &
-                                                    resist,logres
+      REAL,     DIMENSION( ims:ime ) ::                wstar,qstar
 !JOE-end
 !----------------------------------------------------------------
 ! LOCAL VARS
 !----------------------------------------------------------------
-      REAL :: thl1,sqv1,sqc1,exner1,sqvg,sqcg,vv,ww
-
       REAL, DIMENSION(its:ite) :: &
                  ZA, &    !Height of lowest 1/2 sigma level(m)
+                ZA2, &    !Height of 2nd lowest 1/2 sigma level(m)
               THV1D, &    !Theta-v at lowest 1/2 sigma (K)
                TH1D, &    !Theta at lowest 1/2 sigma (K)
                TC1D, &    !T at lowest 1/2 sigma (Celsius)
                TV1D, &    !Tv at lowest 1/2 sigma (K)
                QVSH, &    !qv at lowest 1/2 sigma (spec humidity)
-        PSIH2,PSIM2, &    !M-O stability functions at z=2 m
-      PSIH10,PSIM10, &    !M-O stability functions at z=10 m
+              PSIH2, &    !M-O stability functions at z=2 m
+             PSIM10, &    !M-O stability functions at z=10 m
+             PSIH10, &    !M-O stability functions at z=10 m
               WSPDI, & 
             z_t,z_q, &    !thermal & moisture roughness lengths
+           ZNTstoch, &
              GOVRTH, &    !g/theta
                THGB, &    !theta at ground
               THVGB, &    !theta-v at ground
@@ -530,28 +502,23 @@ CONTAINS
             GZ10OZ0, &    !LOG((10.+ZNT(I))/ZNT(I))
              GZ2OZt, &    !LOG((2.0+z_t(i))/z_t(i))
             GZ10OZt, &    !LOG((10.+z_t(i))/z_t(i))
-             GZ1OZt       !LOG((ZA(I)+z_t(i))/z_t(i))
+             GZ1OZt, &    !LOG((ZA(I)+z_t(i))/z_t(i))
+             zratio       !z0/zt
 
-      INTEGER ::  N,I,K,L,NZOL,NK,NZOL2,NZOL10, ITER
-      INTEGER, PARAMETER :: ITMAX=5
+      INTEGER ::  N,I,K,L,yesno
 
       REAL    ::  PL,THCON,TVCON,E1
-      REAL    ::  DTHVDZ,DTHVM,VCONV,RZOL,RZOL2,RZOL10,ZOL2,ZOL10
-      REAL    ::  DTG,PSIX,DTTHX,DTHDZ,PSIX10,PSIT,PSIT2,PSIT10, &
-                  PSIQ,PSIQ2,PSIQ10
+      REAL    ::  DTHVDZ,DTHVM,VCONV,ZOL2,ZOL10,ZOLZA,ZOLZ0,ZOLZT
+      REAL    ::  DTG,PSIX,DTTHX,DTHDZ,PSIX10,PSIT,PSIT2, &
+                  PSIQ,PSIQ2,PSIQ10,DZDT
       REAL    ::  FLUXC,VSGD
       REAL    ::  restar,VISC,DQG,OLDUST,OLDTST
-      REAL, PARAMETER :: psilim = -10.  ! ONLY AFFECTS z/L > 2.0
-
-#if defined(mpas)
-!MPAS specific (Laura D. Fowler - 2014-12-02):
-      real,intent(in),dimension(ims:ime),optional:: dxCell
-!MPAS specific end.
-#endif
+      REAL    ::  DXC
 
 !-------------------------------------------------------------------
 
       DO I=its,ite
+         DXC = DX(i)
          ! CONVERT GROUND & LOWEST LAYER TEMPERATURE TO POTENTIAL TEMPERATURE:
          ! PSFC cmb
          PSFC(I)=PSFCPA(I)/1000.
@@ -566,10 +533,11 @@ CONTAINS
          QVSH(I)=QV1D(I)/(1.+QV1D(I))        !CONVERT TO SPEC HUM (kg/kg)
          TVCON=(1.+EP1*QVSH(I))
          THV1D(I)=TH1D(I)*TVCON                 !(K)
-         TV1D(I)=T1D(I)*TVCON                   !(K)
+         TV1D(I)=T1D(I)*TVCON   !(K)
 
          !RHO1D(I)=PSFCPA(I)/(R*TV1D(I)) !now using value calculated in sfc driver
          ZA(I)=0.5*dz8w1d(I)             !height of first half-sigma level 
+         ZA2(I)=dz8w1d(I) + 0.5*dz2w1d(I)    !height of 2nd half-sigma level
          GOVRTH(I)=G/TH1D(I)
       ENDDO
 
@@ -609,66 +577,33 @@ CONTAINS
       DO I=its,ite
          WSPD(I)=SQRT(U1D(I)*U1D(I)+V1D(I)*V1D(I))     
 
-         !account for partial condensation
-         exner1=(p1d(I)/p1000mb)**ROVCP
-         sqc1=qc1d(I)/(1.+qc1d(I))         !lowest mod level cloud water spec hum
-         sqv1=QVSH(I)                      !lowest mod level water vapor spec hum
-         thl1=TH1D(I)-xlvcp/exner1*sqc1
-         sqvg=qsfc(I)                      !sfc water vapor spec hum
-         sqcg=qcg(I)/(1.+qcg(I))           !sfc cloud water spec hum
-
-         vv = thl1-THGB(I)
-         !TGS:ww = mavail(I)*(sqv1-sqvg) + (sqc1-sqcg)
-         ww = (sqv1-sqvg) + (sqc1-sqcg)
-
          !TGS:THVGB(I)=THGB(I)*(1.+EP1*QSFC(I)*MAVAIL(I)) 
          THVGB(I)=THGB(I)*(1.+EP1*QSFC(I))
 
          DTHDZ=(TH1D(I)-THGB(I))
          DTHVDZ=(THV1D(I)-THVGB(I))
-         !DTHVDZ= (vt1(i) + 1.0)*vv + (vq1(i) + tv0)*ww
 
          !--------------------------------------------------------
          !  Calculate the convective velocity scale (WSTAR) and 
          !  subgrid-scale velocity (VSGD) following Beljaars (1995, QJRMS) 
          !  and Mahrt and Sun (1995, MWR), respectively
          !-------------------------------------------------------
-         !       VCONV = 0.25*sqrt(g/THVGB(I)*pblh(i)*dthvm)
-         !  Use Beljaars over land, old MM5 (Wyngaard) formula over water
-         IF (xland(i).lt.1.5) then     !LAND (xland == 1)
-
-            fluxc = max(hfx(i)/RHO1D(i)/cp                    &
-            &    + ep1*THVGB(I)*qfx(i)/RHO1D(i),0.)
+         !  Use Beljaars over land and water
+         fluxc = max(hfx(i)/RHO1D(i)/cp                    &
+         &    + ep1*THVGB(I)*qfx(i)/RHO1D(i),0.)
+         !WSTAR(I) = vconvc*(g/TSK(i)*pblh(i)*fluxc)**.33
+         IF (xland(i).gt.1.5 .or. QSFC(i).le.0.0) THEN   !WATER
             WSTAR(I) = vconvc*(g/TSK(i)*pblh(i)*fluxc)**.33
-
-         ELSE                          !WATER (xland == 2)
-
-            !JOE-the Wyngaard formula is ~3 times larger than the Beljaars 
-            !formula, so switch to Beljaars for water, but use VCONVC = 1.25,
-            !as in the COARE3.0 bulk parameterizations.
-            !IF(-DTHVDZ.GE.0)THEN
-            !   DTHVM=-DTHVDZ
-            !ELSE
-            !   DTHVM=0.
-            !ENDIF
-            !WSTAR(I) = 2.*SQRT(DTHVM)
-            fluxc = max(hfx(i)/RHO1D(i)/cp                    &
-            &     + ep1*THVGB(I)*qfx(i)/RHO1D(i),0.)
-            WSTAR(I) = 1.25*(g/TSK(i)*pblh(i)*fluxc)**.33
-
+         ELSE                                            !LAND
+            !increase height scale, assuming that the non-local transoport
+            !from the mass-flux (plume) mixing exceedsd the PBLH.
+            WSTAR(I) = vconvc*(g/TSK(i)*MIN(1.5*pblh(i),4000.)*fluxc)**.33
          ENDIF
-
          !--------------------------------------------------------
          ! Mahrt and Sun low-res correction
          ! (for 13 km ~ 0.37 m/s; for 3 km == 0 m/s)
          !--------------------------------------------------------
-!MPAS specific (Laura D. Fowler): We take into accound the actual size of individual
-!grid-boxes:
-        if(present(dxCell)) then
-           VSGD = 0.32 * (max(dxCell(i)/5000.-1.,0.))**.33
-         else
-           VSGD = 0.32 * (max(dx/5000.-1.,0.))**.33
-         endif
+         VSGD = 0.32 * (max(dxc/5000.-1.,0.))**.33
          WSPD(I)=SQRT(WSPD(I)*WSPD(I)+WSTAR(I)*WSTAR(I)+vsgd*vsgd)
          WSPD(I)=MAX(WSPD(I),wmin)
 
@@ -677,419 +612,430 @@ CONTAINS
          ! ACCORDING TO AKB(1976), EQ(12). 
          !--------------------------------------------------------
          BR(I)=GOVRTH(I)*ZA(I)*DTHVDZ/(WSPD(I)*WSPD(I))
-         !SET LIMITS ACCORDING TO Li et al. (2010) Boundary-Layer Meteorol (p.158)
-         !JOE: defying limits: BR(I)=MAX(BR(I),-2.0)
-         BR(I)=MAX(BR(I),-20.0)
-         BR(I)=MIN(BR(I),2.0)
-         BRi(I)=BR(I)  !new variable for output - BR is not a "state" variable.
-               
+         IF (ITIMESTEP == 1) THEN
+            !SET LIMITS ACCORDING TO Li et al. (2010) Boundary-Layer Meteorol (p.158)
+            BR(I)=MAX(BR(I),-2.0)
+            BR(I)=MIN(BR(I),2.0)
+         ELSE
+            BR(I)=MAX(BR(I),-4.0)
+            BR(I)=MIN(BR(I), 4.0)
+         ENDIF
+
          ! IF PREVIOUSLY UNSTABLE, DO NOT LET INTO REGIMES 1 AND 2 (STABLE)
          !if (itimestep .GT. 1) THEN
          !    IF(MOL(I).LT.0.)BR(I)=MIN(BR(I),0.0)
          !ENDIF
      
-         !IF(I .eq. 2)THEN
-         !  write(*,1006)"BR:",BR(I)," fluxc:",fluxc," vt1:",vt1(i)," vq1:",vq1(i)
-         !  write(*,1007)"XLAND:",XLAND(I)," WSPD:",WSPD(I)," DTHVDZ:",DTHVDZ," WSTAR:",WSTAR(I)
-         !ENDIF
-
       ENDDO
+
+      IF (debug_code) THEN
+        DO i=its,ite
+           write(0,*)"===important input to mynnsfclay: i=",i," ITIME=",ITIMESTEP
+           write(0,*)"xland=",xland(i)," pblh=",pblh(i)," tsk=",tsk(i),&
+             " th1=", th1d(i)," qsfc=", qsfc(i)," znt=", znt(i),       &
+             " ust=", ust(i)," snowh=", snowh(i)," psfcpa=",PSFCPA(i), &
+             " fluxc=",fluxc," qfx=",qfx(i)," hfx=",hfx(i),            &
+             " u1=",u1d(i)," v1=",v1d(i)," qv1=",qvsh(i),              &
+             " rho=",rho1d(i)," w*=",wstar(i)," dz1=",za(i),           &
+             " br=",br(i)," THVGB=",THVGB(i)," DTHVDZ=",DTHVDZ,        &
+             " psim_stab=",psim_stab(1)," psim_unstab=",psim_stab(1),  &
+             " psih_stab=",psih_stab(1)," psih_unstab=",psih_unstab(1)
+        ENDDO
+      ENDIF
 
  1006   format(A,F7.3,A,f9.4,A,f9.5,A,f9.4)
  1007   format(A,F2.0,A,f6.2,A,f7.3,A,f7.2)
 
 !--------------------------------------------------------------------      
 !--------------------------------------------------------------------      
-!--- BEGIN ITERATION LOOP (ITMAX=5); USUALLY CONVERGES IN TWO PASSES
+!--- BEGIN I-LOOP
 !--------------------------------------------------------------------
 !--------------------------------------------------------------------
 
  DO I=its,ite
 
-   ITER = 1
-   DO WHILE (ITER .LE. ITMAX)
+    !COMPUTE KINEMATIC VISCOSITY (m2/s) Andreas (1989) CRREL Rep. 89-11
+    !valid between -173 and 277 degrees C.
+    VISC=1.326e-5*(1. + 6.542e-3*TC1D(I) + 8.301e-6*TC1D(I)*TC1D(I) &
+                      - 4.84e-9*TC1D(I)*TC1D(I)*TC1D(I))
 
-      !COMPUTE KINEMATIC VISCOSITY (m2/s) Andreas (1989) CRREL Rep. 89-11
-      !valid between -173 and 277 degrees C.
-      VISC=1.326e-5*(1. + 6.542e-3*TC1D(I) + 8.301e-6*TC1D(I)*TC1D(I) &
-                        - 4.84e-9*TC1D(I)*TC1D(I)*TC1D(I))
-
-      IF((XLAND(I)-1.5).GE.0)THEN
-          !--------------------------------------
-          ! WATER
-          !--------------------------------------
-          ! CALCULATE z0 (znt)
-          !--------------------------------------
-          IF ( PRESENT(ISFTCFLX) ) THEN
-             IF ( ISFTCFLX .EQ. 0 ) THEN
-                !NAME OF SUBROUTINE IS MISLEADING - ACTUALLY VARIABLE CHARNOCK
-                !PARAMETER FROM COARE3.0:
-                CALL charnock_1955(ZNT(i),UST(i),WSPD(i),visc)
-             ELSEIF ( ISFTCFLX .EQ. 1 .OR. ISFTCFLX .EQ. 2 ) THEN
-                CALL davis_etal_2008(ZNT(i),UST(i))
-             ELSEIF ( ISFTCFLX .EQ. 3 ) THEN
-                CALL Taylor_Yelland_2001(ZNT(i),UST(i),WSPD(i))                                                      
-             ELSEIF ( ISFTCFLX .EQ. 4 ) THEN
-                CALL charnock_1955(ZNT(i),UST(i),WSPD(i),visc)
-             ENDIF
-          ELSE
-             !DEFAULT TO COARE 3.0
-             CALL charnock_1955(ZNT(i),UST(i),WSPD(i),visc)
-          ENDIF
-
-          !COMPUTE ROUGHNESS REYNOLDS NUMBER (restar) USING NEW ZNT
-          ! AHW: Garrattt formula: Calculate roughness Reynolds number
-          !      Kinematic viscosity of air (linear approx to
-          !      temp dependence at sea level)
-          restar=MAX(ust(i)*ZNT(i)/visc, 0.1)
-
-          !--------------------------------------
-          !CALCULATE z_t and z_q
-          !--------------------------------------
-          IF ( PRESENT(ISFTCFLX) ) THEN
-             IF ( ISFTCFLX .EQ. 0 ) THEN
-                CALL fairall_2001(z_t(i),z_q(i),restar,UST(i),visc)
-             ELSEIF ( ISFTCFLX .EQ. 1 ) THEN
-                CALL fairall_2001(z_t(i),z_q(i),restar,UST(i),visc)
-             ELSEIF ( ISFTCFLX .EQ. 2 ) THEN
-                CALL garratt_1992(z_t(i),z_q(i),ZNT(i),restar,XLAND(I))
-             ELSEIF ( ISFTCFLX .EQ. 3 ) THEN
-                CALL fairall_2001(z_t(i),z_q(i),restar,UST(i),visc)
-             ELSEIF ( ISFTCFLX .EQ. 4 ) THEN
-                CALL zilitinkevich_1995(ZNT(i),z_t(i),z_q(i),restar,&
-                                   UST(I),KARMAN,XLAND(I),IZ0TLND)
-             ENDIF
-          ELSE
-             !DEFAULT TO COARE 3.0 
-             CALL fairall_2001(z_t(i),z_q(i),restar,UST(i),visc)
-          ENDIF
- 
-       ELSE
-
-          !--------------------------------------
-          ! LAND
-          !--------------------------------------
-          !COMPUTE ROUGHNESS REYNOLDS NUMBER (restar) USING DEFAULT ZNT
-          restar=MAX(ust(i)*ZNT(i)/visc, 0.1)
-
-          !--------------------------------------
-          !GET z_t and z_q
-          !--------------------------------------
-          !CHECK FOR SNOW/ICE POINTS OVER LAND
-          !IF ( ZNT(i) .LE. SNOWZ0  .AND.  TSK(I) .LE. 273.15 ) THEN
-          IF ( SNOWH(i) .GE. 0.1) THEN
-             CALL Andreas_2002(ZNT(i),restar,z_t(i),z_q(i))
-          ELSE
-             IF ( PRESENT(IZ0TLND) ) THEN
-                IF ( IZ0TLND .LE. 1 .OR. IZ0TLND .EQ. 4) THEN
-                   !IF IZ0TLND==4, THEN PSIQ WILL BE RECALCULATED USING
-                   !PAN ET AL (1994), but PSIT FROM ZILI WILL BE USED.
-                   CALL zilitinkevich_1995(ZNT(i),z_t(i),z_q(i),restar,&
-                                  UST(I),KARMAN,XLAND(I),IZ0TLND)
-                ELSEIF ( IZ0TLND .EQ. 2 ) THEN
-                   CALL Yang_2008(ZNT(i),z_t(i),z_q(i),UST(i),MOL(I),&
-                                  qstar(I),restar,visc,XLAND(I))
-                ELSEIF ( IZ0TLND .EQ. 3 ) THEN
-                   !Original MYNN in WRF-ARW used this form:
-                   CALL garratt_1992(z_t(i),z_q(i),ZNT(i),restar,XLAND(I))
-                ENDIF
+    IF ((XLAND(I)-1.5).GE.0) THEN
+       !--------------------------------------
+       ! WATER
+       !--------------------------------------
+       ! CALCULATE z0 (znt)
+       !--------------------------------------
+       IF ( PRESENT(ISFTCFLX) ) THEN
+          IF ( ISFTCFLX .EQ. 0 ) THEN
+             IF (COARE_OPT .EQ. 3.0) THEN
+                !COARE 3.0 (MISLEADING SUBROUTINE NAME)
+                CALL charnock_1955(ZNT(i),UST(i),WSPD(i),visc,ZA(I))
              ELSE
-                !DEFAULT TO ZILITINKEVICH
-                CALL zilitinkevich_1995(ZNT(i),z_t(i),z_q(i),restar,&
-                                        UST(I),KARMAN,XLAND(I),0)
+                !COARE 3.5
+                CALL edson_etal_2013(ZNT(i),UST(i),WSPD(i),visc,ZA(I))
+             ENDIF
+          ELSEIF ( ISFTCFLX .EQ. 1 .OR. ISFTCFLX .EQ. 2 ) THEN
+             CALL davis_etal_2008(ZNT(i),UST(i))
+          ELSEIF ( ISFTCFLX .EQ. 3 ) THEN
+             CALL Taylor_Yelland_2001(ZNT(i),UST(i),WSPD(i))
+          ELSEIF ( ISFTCFLX .EQ. 4 ) THEN
+             IF (COARE_OPT .EQ. 3.0) THEN
+                !COARE 3.0 (MISLEADING SUBROUTINE NAME)
+                CALL charnock_1955(ZNT(i),UST(i),WSPD(i),visc,ZA(I))
+             ELSE
+                !COARE 3.5
+                CALL edson_etal_2013(ZNT(i),UST(i),WSPD(i),visc,ZA(I))
              ENDIF
           ENDIF
-
+       ELSE
+          !DEFAULT TO COARE 3.0/3.5
+          IF (COARE_OPT .EQ. 3.0) THEN
+             !COARE 3.0
+             CALL charnock_1955(ZNT(i),UST(i),WSPD(i),visc,ZA(I))
+          ELSE
+             !COARE 3.5
+             CALL edson_etal_2013(ZNT(i),UST(i),WSPD(i),visc,ZA(I))
+          ENDIF
        ENDIF
-       zratio(i)=znt(i)/z_t(i)
 
-       !ADD RESISTANCE (SOMEWHAT FOLLOWING JIMENEZ ET AL. (2012)) TO PROTECT AGAINST
-       !EXCESSIVE FLUXES WHEN USING A LOW FIRST MODEL LEVEL (ZA < 10 m).        
-       !Formerly: GZ1OZ0(I)= LOG(ZA(I)/ZNT(I))
-       GZ1OZ0(I)= LOG((ZA(I)+ZNT(I))/ZNT(I))
-       GZ1OZt(I)= LOG((ZA(I)+z_t(i))/z_t(i))           
-       GZ2OZ0(I)= LOG((2.0+ZNT(I))/ZNT(I))                                        
-       GZ2OZt(I)= LOG((2.0+z_t(i))/z_t(i))                                        
-       GZ10OZ0(I)=LOG((10.+ZNT(I))/ZNT(I)) 
-       GZ10OZt(I)=LOG((10.+z_t(i))/z_t(i)) 
+       ! add stochastic perturbaction of ZNT
+       if (spp_pbl==1) then
+          ZNTstoch(I)  = MAX(ZNT(I) + ZNT(I)*1.0*rstoch1D(i), 1e-6)
+       else
+          ZNTstoch(I)  = ZNT(I)
+       endif
 
-     !--------------------------------------------------------------------      
-     !--- DIAGNOSE BASIC PARAMETERS FOR THE APPROPRIATE STABILITY CLASS:
-     !                                                                                
-     !    THE STABILITY CLASSES ARE DETERMINED BY BR (BULK RICHARDSON NO.).
-     !                                                                                
-     !    CRITERIA FOR THE CLASSES ARE AS FOLLOWS:                                   
-     !                                                                                
-     !        1. BR .GE. 0.2;                                                         
-     !               REPRESENTS NIGHTTIME STABLE CONDITIONS (REGIME=1),               
-     !                                                                                
-     !        2. BR .LT. 0.2 .AND. BR .GT. 0.0;                                       
-     !               REPRESENTS DAMPED MECHANICAL TURBULENT CONDITIONS                
-     !               (REGIME=2),                                                      
-     !                                                                                
-     !        3. BR .EQ. 0.0                                                          
-     !               REPRESENTS FORCED CONVECTION CONDITIONS (REGIME=3),              
-     !                                                                                
-     !        4. BR .LT. 0.0                                                          
-     !               REPRESENTS FREE CONVECTION CONDITIONS (REGIME=4).                
-     !                                                                                
-     !--------------------------------------------------------------------
-     IF (BR(I) .GT. 0.0) THEN
-        IF (BR(I) .GT. 0.2) THEN        
-            !---CLASS 1; STABLE (NIGHTTIME) CONDITIONS:                                    
-            REGIME(I)=1.
-        ELSE
-            !---CLASS 2; DAMPED MECHANICAL TURBULENCE:
-            REGIME(I)=2.
-        ENDIF
+       !COMPUTE ROUGHNESS REYNOLDS NUMBER (restar) USING NEW ZNT
+       ! AHW: Garrattt formula: Calculate roughness Reynolds number
+       !      Kinematic viscosity of air (linear approx to
+       !      temp dependence at sea level)
+       restar=MAX(ust(i)*ZNTstoch(i)/visc, 0.1)
 
-        !COMPUTE z/L
-        !CALL Li_etal_2010(ZOL(I),BR(I),ZA(I)/ZNT(I),zratio(I))
-        IF (ITER .EQ. 1 .AND. itimestep .LE. 1) THEN
-           CALL Li_etal_2010(ZOL(I),BR(I),ZA(I)/ZNT(I),zratio(I))
-        ELSE
-           ZOL(I)=ZA(I)*KARMAN*G*MOL(I)/(TH1D(I)*MAX(UST(I),0.001)**2)
-           ZOL(I)=MAX(ZOL(I),0.0)
-           ZOL(I)=MIN(ZOL(I),2.)
-        ENDIF
+       !--------------------------------------
+       !CALCULATE z_t and z_q
+       !--------------------------------------
+       IF ( PRESENT(ISFTCFLX) ) THEN
+          IF ( ISFTCFLX .EQ. 0 ) THEN
+             IF (COARE_OPT .EQ. 3.0) THEN
+                CALL fairall_etal_2003(z_t(i),z_q(i),restar,UST(i),visc,rstoch1D(i),spp_pbl)
+             ELSE
+                !presumably, this will be published soon, but hasn't yet
+                CALL fairall_etal_2014(z_t(i),z_q(i),restar,UST(i),visc,rstoch1D(i),spp_pbl)
+             ENDIF
+          ELSEIF ( ISFTCFLX .EQ. 1 ) THEN
+             IF (COARE_OPT .EQ. 3.0) THEN
+                CALL fairall_etal_2003(z_t(i),z_q(i),restar,UST(i),visc,rstoch1D(i),spp_pbl)
+             ELSE
+                CALL fairall_etal_2014(z_t(i),z_q(i),restar,UST(i),visc,rstoch1D(i),spp_pbl)
+             ENDIF
+          ELSEIF ( ISFTCFLX .EQ. 2 ) THEN
+             CALL garratt_1992(z_t(i),z_q(i),ZNTstoch(i),restar,XLAND(I))
+          ELSEIF ( ISFTCFLX .EQ. 3 ) THEN
+             IF (COARE_OPT .EQ. 3.0) THEN
+                CALL fairall_etal_2003(z_t(i),z_q(i),restar,UST(i),visc,rstoch1D(i),spp_pbl)
+             ELSE
+                CALL fairall_etal_2014(z_t(i),z_q(i),restar,UST(i),visc,rstoch1D(i),spp_pbl)
+             ENDIF
+          ENDIF
+       ELSE
+          !DEFAULT TO COARE 3.0/3.5
+          IF (COARE_OPT .EQ. 3.0) THEN
+             CALL fairall_etal_2003(z_t(i),z_q(i),restar,UST(i),visc,rstoch1D(i),spp_pbl)
+          ELSE
+             CALL fairall_etal_2014(z_t(i),z_q(i),restar,UST(i),visc,rstoch1D(i),spp_pbl)
+          ENDIF
+       ENDIF
  
-        !COMPUTE PSIM and PSIH
-        IF((XLAND(I)-1.5).GE.0)THEN                                            
-           ! WATER
-           !CALL PSI_Suselj_Sood_2010(PSIM(I),PSIH(I),ZOL(I))
-           !CALL PSI_Beljaars_Holtslag_1991(PSIM(I),PSIH(I),ZOL(I))
-           !CALL PSI_Businger_1971(PSIM(I),PSIH(I),ZOL(I))
-           CALL PSI_DyerHicks(PSIM(I),PSIH(I),ZOL(I),z_t(I),ZNT(I),ZA(I))
-        ELSE
-           ! LAND  
-           !CALL PSI_Beljaars_Holtslag_1991(PSIM(I),PSIH(I),ZOL(I))
-           !CALL PSI_Businger_1971(PSIM(I),PSIH(I),ZOL(I))
-           !CALL PSI_Zilitinkevich_Esau_2007(PSIM(I),PSIH(I),ZOL(I))
-           CALL PSI_DyerHicks(PSIM(I),PSIH(I),ZOL(I),z_t(I),ZNT(I),ZA(I))
-        ENDIF              
+    ELSE
 
-        ! LOWER LIMIT ON PSI IN STABLE CONDITIONS
-        PSIM(I)=MAX(PSIM(I),psilim)
-        PSIH(I)=MAX(PSIH(I),psilim)                                     
-        PSIM10(I)=MAX(10./ZA(I)*PSIM(I), psilim)
-        PSIH10(I)=MAX(10./ZA(I)*PSIH(I), psilim)
-        PSIM2(I)=MAX(2./ZA(I)*PSIM(I), psilim)
-        PSIH2(I)=MAX(2./ZA(I)*PSIH(I), psilim)
-        ! 1.0 over Monin-Obukhov length
-        RMOL(I)= ZOL(I)/ZA(I)
+       ! add stochastic perturbaction of ZNT
+       if (spp_pbl==1) then
+          ZNTstoch(I)  = MAX(ZNT(I) + ZNT(I)*1.0*rstoch1D(i), 1e-6)
+       else
+          ZNTstoch(I)  = ZNT(I)
+       endif
+       !add limit to prevent ridiculous values of z0 (more than dz/15)
+       ZNTstoch(I) = min(ZNTstoch(I), dz8w1d(i)*0.075)
 
-     ELSEIF(BR(I) .EQ. 0.) THEN                  
-        !=========================================================  
-        !-----CLASS 3; FORCED CONVECTION/NEUTRAL:                                                
-        !=========================================================
-        REGIME(I)=3.
+       !--------------------------------------
+       ! LAND
+       !--------------------------------------
+       !COMPUTE ROUGHNESS REYNOLDS NUMBER (restar) USING DEFAULT ZNT
+       restar=MAX(ust(i)*ZNTstoch(i)/visc, 0.1)
 
-        PSIM(I)=0.0                                                              
-        PSIH(I)=PSIM(I)                                                          
-        PSIM10(I)=0.                                                   
-        PSIH10(I)=PSIM10(I)                                           
-        PSIM2(I)=0.                                                  
-        PSIH2(I)=PSIM2(I)                                           
-                                           
-        !ZOL(I)=0.                                             
-        IF(UST(I) .LT. 0.01)THEN                                                 
-          ZOL(I)=BR(I)*GZ1OZ0(I)                                               
-        ELSE                                                                     
-          ZOL(I)=KARMAN*GOVRTH(I)*ZA(I)*MOL(I)/(UST(I)*UST(I)) 
-        ENDIF                                                                    
-        RMOL(I) = ZOL(I)/ZA(I)  
+       !--------------------------------------
+       !GET z_t and z_q
+       !--------------------------------------
+       !CHECK FOR SNOW/ICE POINTS OVER LAND
+       IF ( SNOWH(i) .GE. 0.1) THEN
+          CALL Andreas_2002(ZNTSTOCH(i),visc,ust(i),z_t(i),z_q(i))
+       ELSE
+          IF ( PRESENT(IZ0TLND) ) THEN
+             IF ( IZ0TLND .LE. 1 ) THEN
+                CALL zilitinkevich_1995(ZNTSTOCH(i),z_t(i),z_q(i),restar,&
+                           UST(I),KARMAN,XLAND(I),IZ0TLND,spp_pbl,rstoch1D(i))
+             ELSEIF ( IZ0TLND .EQ. 2 ) THEN
+                CALL Yang_2008(ZNTSTOCH(i),z_t(i),z_q(i),UST(i),MOL(I),&
+                               qstar(I),restar,visc,XLAND(I))
+             ELSEIF ( IZ0TLND .EQ. 3 ) THEN
+                !Original MYNN in WRF-ARW used this form:
+                CALL garratt_1992(z_t(i),z_q(i),ZNTSTOCH(i),restar,XLAND(I))
+             ENDIF
+          ELSE
+             !DEFAULT TO ZILITINKEVICH
+             CALL zilitinkevich_1995(ZNTSTOCH(i),z_t(i),z_q(i),restar,&
+                           UST(I),KARMAN,XLAND(I),0,spp_pbl,rstoch1D(i))
+          ENDIF
+       ENDIF
 
-     ELSEIF(BR(I) .LT. 0.)THEN            
-        !==========================================================
-        !-----CLASS 4; FREE CONVECTION:                                                  
-        !==========================================================
-        REGIME(I)=4.
+    ENDIF
+    zratio(i)=ZNTstoch(I)/z_t(I)   !needed for Li et al.
 
-        !COMPUTE z/L
-        !CALL Li_etal_2010(ZOL(I),BR(I),ZA(I)/ZNT(I),zratio(I))
-        IF (ITER .EQ. 1 .AND. itimestep .LE. 1) THEN
-           CALL Li_etal_2010(ZOL(I),BR(I),ZA(I)/ZNT(I),zratio(I))
-        ELSE
-           ZOL(I)=ZA(I)*KARMAN*G*MOL(I)/(TH1D(I)*MAX(UST(I),0.001)**2)
-           ZOL(I)=MAX(ZOL(I),-9.999)
-           ZOL(I)=MIN(ZOL(I),0.0)
-        ENDIF
+    GZ1OZ0(I)= LOG((ZA(I)+ZNTstoch(I))/ZNTstoch(I))
+    GZ1OZt(I)= LOG((ZA(I)+ZNTstoch(I))/z_t(i))
+    GZ2OZ0(I)= LOG((2.0+ZNTstoch(I))/ZNTstoch(I))                                        
+    GZ2OZt(I)= LOG((2.0+ZNTstoch(I))/z_t(i))
+    GZ10OZ0(I)=LOG((10.+ZNTstoch(I))/ZNTstoch(I)) 
+    GZ10OZt(I)=LOG((10.+ZNTstoch(I))/z_t(i))
 
-        ZOL10=10./ZA(I)*ZOL(I)
-        ZOL2=2./ZA(I)*ZOL(I)
-        ZOL(I)=MIN(ZOL(I),0.)
-        ZOL(I)=MAX(ZOL(I),-9.9999)
-        ZOL10=MIN(ZOL10,0.)
-        ZOL10=MAX(ZOL10,-9.9999)
-        ZOL2=MIN(ZOL2,0.)
-        ZOL2=MAX(ZOL2,-9.9999)
-        NZOL=INT(-ZOL(I)*100.)
-        RZOL=-ZOL(I)*100.-NZOL
-        NZOL10=INT(-ZOL10*100.)
-        RZOL10=-ZOL10*100.-NZOL10
-        NZOL2=INT(-ZOL2*100.)
-        RZOL2=-ZOL2*100.-NZOL2
+    !--------------------------------------------------------------------      
+    !--- DIAGNOSE BASIC PARAMETERS FOR THE APPROPRIATE STABILITY CLASS:
+    !                                                                                
+    !    THE STABILITY CLASSES ARE DETERMINED BY BR (BULK RICHARDSON NO.).
+    !                                                                                
+    !    CRITERIA FOR THE CLASSES ARE AS FOLLOWS:                                   
+    !                                                                                
+    !        1. BR .GE. 0.2;                                                         
+    !               REPRESENTS NIGHTTIME STABLE CONDITIONS (REGIME=1),               
+    !                                                                                
+    !        2. BR .LT. 0.2 .AND. BR .GT. 0.0;                                       
+    !               REPRESENTS DAMPED MECHANICAL TURBULENT CONDITIONS                
+    !               (REGIME=2),                                                      
+    !                                                                                
+    !        3. BR .EQ. 0.0                                                          
+    !               REPRESENTS FORCED CONVECTION CONDITIONS (REGIME=3),              
+    !                                                                                
+    !        4. BR .LT. 0.0                                                          
+    !               REPRESENTS FREE CONVECTION CONDITIONS (REGIME=4).                
+    !                                                                                
+    !--------------------------------------------------------------------
+    IF (BR(I) .GT. 0.0) THEN
+       IF (BR(I) .GT. 0.2) THEN        
+          !---CLASS 1; STABLE (NIGHTTIME) CONDITIONS:                                    
+          REGIME(I)=1.
+       ELSE
+          !---CLASS 2; DAMPED MECHANICAL TURBULENCE:
+          REGIME(I)=2.
+       ENDIF
 
-        !COMPUTE PSIM and PSIH
-        IF((XLAND(I)-1.5).GE.0)THEN                                            
-           ! WATER
-           !CALL PSI_Suselj_Sood_2010(PSIM(I),PSIH(I),ZOL(I))
-           !CALL PSI_Hogstrom_1996(PSIM(I),PSIH(I),ZOL(I), z_t(I), ZNT(I), ZA(I))
-           !CALL PSI_Businger_1971(PSIM(I),PSIH(I),ZOL(I))
-           CALL PSI_DyerHicks(PSIM(I),PSIH(I),ZOL(I),z_t(I),ZNT(I),ZA(I))
-        ELSE           
-           ! LAND  
-           !CALL PSI_Hogstrom_1996(PSIM(I),PSIH(I),ZOL(I), z_t(I), ZNT(I), ZA(I))
-           !CALL PSI_Businger_1971(PSIM(I),PSIH(I),ZOL(I))
-           CALL PSI_DyerHicks(PSIM(I),PSIH(I),ZOL(I),z_t(I),ZNT(I),ZA(I))
-        ENDIF              
+       !COMPUTE z/L first guess:
+       IF (itimestep .LE. 1) THEN
+          CALL Li_etal_2010(ZOL(I),BR(I),ZA(I)/ZNTstoch(I),zratio(I))
+       ELSE
+          ZOL(I)=ZA(I)*KARMAN*G*MOL(I)/(TH1D(I)*MAX(UST(I)*UST(I),0.0001))
+          ZOL(I)=MAX(ZOL(I),0.0)
+          ZOL(I)=MIN(ZOL(I),20.)
+       ENDIF
 
-!!!!!JOE-test:avoid using psi tables in entirety
-!        PSIM10(I)=PSIMTB(NZOL10)+RZOL10*(PSIMTB(NZOL10+1)-PSIMTB(NZOL10))
-!        PSIH10(I)=PSIHTB(NZOL10)+RZOL10*(PSIHTB(NZOL10+1)-PSIHTB(NZOL10))
-!        PSIM2(I)=PSIMTB(NZOL2)+RZOL2*(PSIMTB(NZOL2+1)-PSIMTB(NZOL2))
-!        PSIH2(I)=PSIHTB(NZOL2)+RZOL2*(PSIHTB(NZOL2+1)-PSIHTB(NZOL2))
-        PSIM10(I)=10./ZA(I)*PSIM(I)
-        PSIH10(I)=10./ZA(I)*PSIH(I)
-        PSIM2(I)=2./ZA(I)*PSIM(I)
-        PSIH2(I)=2./ZA(I)*PSIH(I)
+       !Use Pedros iterative function to find z/L
+       !zol(I)=zolri(br(I),ZA(I),ZNTstoch(I),z_t(I),ZOL(I),psi_opt)
+       !Use brute-force method
+       zol(I)=zolrib(br(I),ZA(I),ZNTstoch(I),z_t(I),GZ1OZ0(I),GZ1OZt(I),ZOL(I),psi_opt)
+       ZOL(I)=MAX(ZOL(I),0.0)
+       ZOL(I)=MIN(ZOL(I),20.)
 
-        !---LIMIT PSIH AND PSIM IN THE CASE OF THIN LAYERS AND
-        !---HIGH ROUGHNESS.  THIS PREVENTS DENOMINATOR IN FLUXES
-        !---FROM GETTING TOO SMALL
-        !PSIH(I)=MIN(PSIH(I),0.9*GZ1OZt(I))    !JOE: less restricitive over forest/urban.
-        PSIH(I)=MIN(PSIH(I),0.9*GZ1OZ0(I))
-        PSIM(I)=MIN(PSIM(I),0.9*GZ1OZ0(I))
-        !PSIH2(I)=MIN(PSIH2(I),0.9*GZ2OZt(I))  !JOE: less restricitive over forest/urban.
-        PSIH2(I)=MIN(PSIH2(I),0.9*GZ2OZ0(I))
-        PSIM2(I)=MIN(PSIM2(I),0.9*GZ2OZ0(I))
-        PSIM10(I)=MIN(PSIM10(I),0.9*GZ10OZ0(I))
-        PSIH10(I)=MIN(PSIH10(I),0.9*GZ10OZ0(I))
+       zolzt = zol(I)*z_t(I)/ZA(I)               ! zt/L
+       zolz0 = zol(I)*ZNTstoch(I)/ZA(I)          ! z0/L
+       zolza = zol(I)*(za(I)+ZNTstoch(I))/za(I)  ! (z+z0/L
+       zol10 = zol(I)*(10.+ZNTstoch(I))/za(I)    ! (10+z0)/L
+       zol2  = zol(I)*(2.+ZNTstoch(I))/za(I)     ! (2+z0)/L 
 
-        RMOL(I) = ZOL(I)/ZA(I)  
+       !COMPUTE PSIM and PSIH
+       IF ((XLAND(I)-1.5).GE.0) THEN                                            
+          ! WATER
+          !CALL PSI_Suselj_Sood_2010(PSIM(I),PSIH(I),ZOL(I))
+          !CALL PSI_Beljaars_Holtslag_1991(PSIM(I),PSIH(I),ZOL(I))
+          !CALL PSI_Businger_1971(PSIM(I),PSIH(I),ZOL(I))
+          !CALL PSI_DyerHicks(PSIM(I),PSIH(I),ZOL(I),z_t(I),ZNTstoch(I),ZA(I))
+          !CALL PSI_CB2005(PSIM(I),PSIH(I),zolza,zolz0)
+          ! or use tables
+          psim(I)=psim_stable(zolza,psi_opt)-psim_stable(zolz0,psi_opt)
+          psih(I)=psih_stable(zolza,psi_opt)-psih_stable(zolzt,psi_opt)
+          psim10(I)=psim_stable(zol10,psi_opt)-psim_stable(zolz0,psi_opt)
+          psih10(I)=psih_stable(zol10,psi_opt)-psih_stable(zolz0,psi_opt)
+          psih2(I)=psih_stable(zol2,psi_opt)-psih_stable(zolz0,psi_opt)
+       ELSE
+          ! LAND  
+          !CALL PSI_Beljaars_Holtslag_1991(PSIM(I),PSIH(I),ZOL(I))
+          !CALL PSI_Businger_1971(PSIM(I),PSIH(I),ZOL(I))
+          !CALL PSI_Zilitinkevich_Esau_2007(PSIM(I),PSIH(I),ZOL(I))
+          !CALL PSI_DyerHicks(PSIM(I),PSIH(I),ZOL(I),z_t(I),ZNTstoch(I),ZA(I))
+          !CALL PSI_CB2005(PSIM(I),PSIH(I),zolza,zolz0)
+          ! or use tables
+          psim(I)=psim_stable(zolza,psi_opt)-psim_stable(zolz0,psi_opt)
+          psih(I)=psih_stable(zolza,psi_opt)-psih_stable(zolzt,psi_opt)
+          psim10(I)=psim_stable(zol10,psi_opt)-psim_stable(zolz0,psi_opt)
+          psih10(I)=psih_stable(zol10,psi_opt)-psih_stable(zolz0,psi_opt)
+          psih2(I)=psih_stable(zol2,psi_opt)-psih_stable(zolz0,psi_opt)
+       ENDIF
 
-     ENDIF
+       !PSIM10(I)=10./ZA(I)*PSIM(I)
+       !PSIH10(I)=10./ZA(I)*PSIH(I)
+       !PSIM2(I)=2./ZA(I)*PSIM(I)
+       !PSIH2(I)=2./ZA(I)*PSIH(I)
 
-     !------------------------------------------------------------
-     !-----COMPUTE THE FRICTIONAL VELOCITY:                                           
-     !------------------------------------------------------------
-     !     ZA(1982) EQS(2.60),(2.61).                                                 
-      GZ1OZ0(I) =LOG((ZA(I)+ZNT(I))/ZNT(I))
-      GZ10OZ0(I)=LOG((10.+ZNT(I))/ZNT(I)) 
-      PSIX=GZ1OZ0(I)-PSIM(I)
-      PSIX10=GZ10OZ0(I)-PSIM10(I)
-      ! TO PREVENT OSCILLATIONS AVERAGE WITH OLD VALUE 
-      OLDUST = UST(I)
-      UST(I)=0.5*UST(I)+0.5*KARMAN*WSPD(I)/PSIX 
-      !NON-AVERAGED: UST(I)=KARMAN*WSPD(I)/PSIX
+       ! 1.0 over Monin-Obukhov length
+       RMOL(I)= ZOL(I)/ZA(I)
+
+    ELSEIF(BR(I) .EQ. 0.) THEN                  
+       !=========================================================  
+       !-----CLASS 3; FORCED CONVECTION/NEUTRAL:                                                
+       !=========================================================
+       REGIME(I)=3.
+
+       PSIM(I)=0.0
+       PSIH(I)=PSIM(I)
+       PSIM10(I)=0.
+       PSIH10(I)=0.
+       PSIH2(I)=0.
+
+       ZOL(I)=0.
+       !IF (UST(I) .LT. 0.01) THEN
+       !   ZOL(I)=BR(I)*GZ1OZ0(I)
+       !ELSE
+       !   ZOL(I)=KARMAN*GOVRTH(I)*ZA(I)*MOL(I)/(MAX(UST(I)*UST(I),0.001))
+       !ENDIF
+       RMOL(I) = ZOL(I)/ZA(I)
+
+    ELSEIF(BR(I) .LT. 0.)THEN
+       !==========================================================
+       !-----CLASS 4; FREE CONVECTION:                                                  
+       !==========================================================
+       REGIME(I)=4.
+
+       !COMPUTE z/L first guess:
+       IF (itimestep .LE. 1) THEN
+          CALL Li_etal_2010(ZOL(I),BR(I),ZA(I)/ZNTstoch(I),zratio(I))
+       ELSE
+          ZOL(I)=ZA(I)*KARMAN*G*MOL(I)/(TH1D(I)*MAX(UST(I)*UST(I),0.001))
+          ZOL(I)=MAX(ZOL(I),-20.0)
+          ZOL(I)=MIN(ZOL(I),0.0)
+       ENDIF
+
+       !Use Pedros iterative function to find z/L
+       !zol(I)=zolri(br(I),ZA(I),ZNTstoch(I),z_t(I),ZOL(I),psi_opt)
+       !Use alternative method
+       zol(I)=zolrib(br(I),ZA(I),ZNTstoch(I),z_t(I),GZ1OZ0(I),GZ1OZt(I),ZOL(I),psi_opt)
+       ZOL(I)=MAX(ZOL(I),-20.0)
+       ZOL(I)=MIN(ZOL(I),0.0)
+
+       zolzt = zol(I)*z_t(I)/ZA(I)                ! zt/L
+       zolz0 = zol(I)*ZNTstoch(I)/ZA(I)           ! z0/L
+       zolza = zol(I)*(za(I)+ZNTstoch(I))/za(I)   ! (z+z0/L
+       zol10 = zol(I)*(10.+ZNTstoch(I))/za(I)     ! (10+z0)/L
+       zol2  = zol(I)*(2.+ZNTstoch(I))/za(I)      ! (2+z0)/L
+
+       !COMPUTE PSIM and PSIH
+       IF ((XLAND(I)-1.5).GE.0) THEN                                            
+          ! WATER
+          !CALL PSI_Suselj_Sood_2010(PSIM(I),PSIH(I),ZOL(I))
+          !CALL PSI_Hogstrom_1996(PSIM(I),PSIH(I),ZOL(I), z_t(I), ZNTstoch(I), ZA(I))
+          !CALL PSI_Businger_1971(PSIM(I),PSIH(I),ZOL(I))
+          !CALL PSI_DyerHicks(PSIM(I),PSIH(I),ZOL(I),z_t(I),ZNTstoch(I),ZA(I))
+          ! use tables
+          psim(I)=psim_unstable(zolza,psi_opt)-psim_unstable(zolz0,psi_opt)
+          psih(I)=psih_unstable(zolza,psi_opt)-psih_unstable(zolzt,psi_opt)
+          psim10(I)=psim_unstable(zol10,psi_opt)-psim_unstable(zolz0,psi_opt)
+          psih10(I)=psih_unstable(zol10,psi_opt)-psih_unstable(zolz0,psi_opt)
+          psih2(I)=psih_unstable(zol2,psi_opt)-psih_unstable(zolz0,psi_opt)
+       ELSE           
+          ! LAND  
+          !CALL PSI_Hogstrom_1996(PSIM(I),PSIH(I),ZOL(I), z_t(I), ZNTstoch(I), ZA(I))
+          !CALL PSI_Businger_1971(PSIM(I),PSIH(I),ZOL(I))
+          !CALL PSI_DyerHicks(PSIM(I),PSIH(I),ZOL(I),z_t(I),ZNTstoch(I),ZA(I))
+          ! use tables
+          psim(I)=psim_unstable(zolza,psi_opt)-psim_unstable(zolz0,psi_opt)
+          psih(I)=psih_unstable(zolza,psi_opt)-psih_unstable(zolzt,psi_opt)
+          psim10(I)=psim_unstable(zol10,psi_opt)-psim_unstable(zolz0,psi_opt)
+          psih10(I)=psih_unstable(zol10,psi_opt)-psih_unstable(zolz0,psi_opt)
+          psih2(I)=psih_unstable(zol2,psi_opt)-psih_unstable(zolz0,psi_opt)
+       ENDIF              
+
+       !PSIM10(I)=10./ZA(I)*PSIM(I)
+       !PSIH2(I)=2./ZA(I)*PSIH(I)
+
+       !---LIMIT PSIH AND PSIM IN THE CASE OF THIN LAYERS AND
+       !---HIGH ROUGHNESS.  THIS PREVENTS DENOMINATOR IN FLUXES
+       !---FROM GETTING TOO SMALL
+       PSIH(I)=MIN(PSIH(I),0.9*GZ1OZt(I))
+       PSIM(I)=MIN(PSIM(I),0.9*GZ1OZ0(I))
+       PSIH2(I)=MIN(PSIH2(I),0.9*GZ2OZt(I))
+       PSIM10(I)=MIN(PSIM10(I),0.9*GZ10OZ0(I))
+       PSIH10(I)=MIN(PSIH10(I),0.9*GZ10OZt(I))
+
+       RMOL(I) = ZOL(I)/ZA(I)  
+
+    ENDIF
+
+    !------------------------------------------------------------
+    !-----COMPUTE THE FRICTIONAL VELOCITY:                                           
+    !------------------------------------------------------------
+    !     ZA(1982) EQS(2.60),(2.61).
+    PSIX=GZ1OZ0(I)-PSIM(I)
+    PSIX10=GZ10OZ0(I)-PSIM10(I)
+    ! TO PREVENT OSCILLATIONS AVERAGE WITH OLD VALUE 
+    OLDUST = UST(I)
+    UST(I)=0.5*UST(I)+0.5*KARMAN*WSPD(I)/PSIX 
+    !NON-AVERAGED: UST(I)=KARMAN*WSPD(I)/PSIX
      
-      ! Compute u* without vconv for use in HFX calc when isftcflx > 0           
-      WSPDI(I)=MAX(SQRT(U1D(I)*U1D(I)+V1D(I)*V1D(I)), wmin)
-      IF ( PRESENT(USTM) ) THEN
-         USTM(I)=0.5*USTM(I)+0.5*KARMAN*WSPDI(I)/PSIX
-      ENDIF
+    ! Compute u* without vconv for use in HFX calc when isftcflx > 0           
+    WSPDI(I)=MAX(SQRT(U1D(I)*U1D(I)+V1D(I)*V1D(I)), wmin)
+    IF ( PRESENT(USTM) ) THEN
+       USTM(I)=0.5*USTM(I)+0.5*KARMAN*WSPDI(I)/PSIX
+    ENDIF
 
-      IF ((XLAND(I)-1.5).LT.0.) THEN        !LAND
-         UST(I)=MAX(UST(I),0.01)  !JOE:Relaxing this limit
-         !Keep ustm = ust over land.
-         IF ( PRESENT(USTM) ) USTM(I)=UST(I)
-      ENDIF
+    IF ((XLAND(I)-1.5).LT.0.) THEN        !LAND
+       UST(I)=MAX(UST(I),0.005)  !Further relaxing this limit - no need to go lower
+       !Keep ustm = ust over land.
+       IF ( PRESENT(USTM) ) USTM(I)=UST(I)
+    ENDIF
 
-     !------------------------------------------------------------
-     !-----COMPUTE THE THERMAL AND MOISTURE RESISTANCE (PSIQ AND PSIT):                                           
-     !------------------------------------------------------------
-      ! LOWER LIMIT ADDED TO PREVENT LARGE FLHC IN SOIL MODEL
-      ! ACTIVATES IN UNSTABLE CONDITIONS WITH THIN LAYERS OR HIGH Z0
-      GZ1OZt(I)= LOG((ZA(I)+z_t(i))/z_t(i))           
-      GZ2OZt(I)= LOG((2.0+z_t(i))/z_t(i))                                        
+    !------------------------------------------------------------
+    !-----COMPUTE THE THERMAL AND MOISTURE RESISTANCE (PSIQ AND PSIT):
+    !------------------------------------------------------------
+    ! LOWER LIMIT ADDED TO PREVENT LARGE FLHC IN SOIL MODEL
+    ! ACTIVATES IN UNSTABLE CONDITIONS WITH THIN LAYERS OR HIGH Z0
+    GZ1OZt(I)= LOG((ZA(I)+ZNTstoch(I))/z_t(i))
+    GZ2OZt(I)= LOG((2.0+ZNTstoch(I))/z_t(i))
 
-      !PSIT=MAX(GZ1OZ0(I)-PSIH(I),2.)
-      PSIT=MAX(LOG((ZA(I)+z_t(i))/z_t(i))-PSIH(I) ,2.0)
-      PSIT2=MAX(LOG((2.0+z_t(i))/z_t(i))-PSIH2(I) ,2.0)                                    
-      resist(I)=PSIT
-      logres(I)=GZ1OZt(I)
+    PSIT =MAX(GZ1OZt(I)-PSIH(I) ,1.)
+    PSIT2=MAX(GZ2OZt(I)-PSIH2(I),1.)
 
-      PSIQ=MAX(LOG((za(i)+z_q(i))/z_q(I))-PSIH(I) ,2.0)   
-      PSIQ2=MAX(LOG((2.0+z_q(i))/z_q(I))-PSIH2(I) ,2.0) 
+    PSIQ=MAX(LOG((ZA(I)+ZNTstoch(I))/z_q(I))-PSIH(I) ,1.0)
+    PSIQ2=MAX(LOG((2.0+ZNTstoch(I))/z_q(I))-PSIH2(I) ,1.0)
+    PSIQ10=MAX(LOG((10.0+ZNTstoch(I))/z_q(I))-PSIH10(I) ,1.0)
+    !----------------------------------------------------
+    !COMPUTE THE TEMPERATURE SCALE (or FRICTION TEMPERATURE, T*)
+    !----------------------------------------------------
+    DTG=THV1D(I)-THVGB(I)
+    OLDTST=MOL(I)
+    MOL(I)=KARMAN*DTG/PSIT/PRT
+    !t_star(I) = -HFX(I)/(UST(I)*CPM(I)*RHO1D(I))
+    !t_star(I) = MOL(I)
+    !----------------------------------------------------
+    !COMPUTE THE MOISTURE SCALE (or q*)
+    DQG=(QVSH(i)-qsfc(i))*1000.   !(kg/kg -> g/kg)
+    qstar(I)=KARMAN*DQG/PSIQ/PRT
 
-      IF((XLAND(I)-1.5).LT.0)THEN    !Land only
-         IF ( IZ0TLND .EQ. 4 ) THEN
-            CALL Pan_etal_1994(PSIQ,PSIQ2,UST(I),PSIH(I),PSIH2(I),&
-                       & KARMAN,ZA(I))
-         ENDIF
-      ENDIF
-
-      !----------------------------------------------------
-      !COMPUTE THE TEMPERATURE SCALE (or FRICTION TEMPERATURE, T*)
-      !----------------------------------------------------
-      DTG=TH1D(I)-THGB(I)                                                   
-      OLDTST=MOL(I)
-      MOL(I)=KARMAN*DTG/PSIT/PRT
-      !t_star(I) = -HFX(I)/(UST(I)*CPM(I)*RHO1D(I))
-      !t_star(I) = MOL(I)
-      !----------------------------------------------------
-      !COMPUTE THE MOISTURE SCALE (or q*)
-      DQG=(QVSH(i)-qsfc(i))*1000.   !(kg/kg -> g/kg)
-      qstar(I)=KARMAN*DQG/PSIQ/PRT
-
-      !-----------------------------------------------------
-      !COMPUTE DIAGNOSTICS
-      !-----------------------------------------------------
-      !COMPUTE 10 M WNDS
-      !-----------------------------------------------------
-      ! If the lowest model level is close to 10-m, use it 
-      ! instead of the flux-based diagnostic formula.
-      if (ZA(i) .gt. 7.0 .and. ZA(i) .lt. 13.0) then
-         U10(I)=U1D(I)
-         V10(I)=V1D(I)
-      else                                 
-         U10(I)=U1D(I)*PSIX10/PSIX                                    
-         V10(I)=V1D(I)*PSIX10/PSIX     
-      endif
-
-      !-----------------------------------------------------
-      !COMPUTE 2m T, TH, AND Q
-      !THESE WILL BE OVERWRITTEN FOR LAND POINTS IN THE LSM 
-      !-----------------------------------------------------
-      TH2(I)=THGB(I)+DTG*PSIT2/PSIT
-      !***  BE CERTAIN THAT THE 2-M THETA IS BRACKETED BY
-      !***  THE VALUES AT THE SURFACE AND LOWEST MODEL LEVEL.
-!      IF ((TH1D(I)>THGB(I) .AND. (TH2(I)<THGB(I) .OR. TH2(I)>TH1D(I))) .OR. &
-!          (TH1D(I)<THGB(I) .AND. (TH2(I)>THGB(I) .OR. TH2(I)<TH1D(I)))) THEN
-!          TH2(I)=THGB(I) + 2.*(TH1D(I)-THGB(I))/ZA(I)
-!      ENDIF
-      T2(I)=TH2(I)*(PSFC(I)/100.)**ROVCP
-
-      Q2(I)=QSFCMR(I)+(QV1D(I)-QSFCMR(I))*PSIQ2/PSIQ
-      !***  BE CERTAIN THAT THE 2-M MIXING RATIO IS BRACKETED BY
-      !***  THE VALUES AT THE SURFACE AND LOWEST MODEL LEVEL.
-      IF ((QV1D(I)>QSFCMR(I) .AND. (Q2(I)<QSFCMR(I) .OR. Q2(I)>QV1D(I))) .OR. &
-          (QV1D(I)<QSFCMR(I) .AND. (Q2(I)>QSFCMR(I) .OR. Q2(I)<QV1D(I)))) THEN
-          Q2(I)=QSFCMR(I) + 2.*(QV1D(I)-QSFCMR(I))/ZA(I)
-      ENDIF
-
-      !CHECK FOR CONVERGENCE
-      IF (ITER .GE. 2) THEN
-         !IF (ABS(OLDUST-UST(I)) .lt. 0.01) THEN
-         IF (ABS(OLDTST-MOL(I)) .lt. 0.01) THEN
-            ITER = ITER+ITMAX
-         ENDIF
-
-         !IF (I .eq. 2) THEN
-         !  print*,"ITER:",ITER
-         !  write(*,1001)"REGIME:",REGIME(I)," z/L:",ZOL(I)," U*:",UST(I)," Tstar:",MOL(I)
-         !  write(*,1002)"PSIM:",PSIM(I)," PSIH:",PSIH(I)," W*:",WSTAR(I)," DTHV:",THV1D(I)-THVGB(I)
-         !  write(*,1003)"CPM:",CPM(I)," RHO1D:",RHO1D(I)," L:",ZOL(I)/ZA(I)," DTH:",TH1D(I)-THGB(I)
-         !  write(*,1004)"Z0/Zt:",zratio(I)," Z0:",ZNT(I)," Zt:",z_t(I)," za:",za(I)
-         !  write(*,1005)"Re:",restar," MAVAIL:",MAVAIL(I)," QSFC(I):",QSFC(I)," QVSH(I):",QVSH(I)
-         !  print*,"VISC=",VISC," Z0:",ZNT(I)," T1D(i):",T1D(i)
-         !  write(*,*)"============================================="
-         !ENDIF
-      ENDIF
-
-      ITER = ITER + 1
-
-   ENDDO  ! end ITERATION-loop
+    !IF () THEN
+        !  write(*,1001)"REGIME:",REGIME(I)," z/L:",ZOL(I)," U*:",UST(I)," Tstar:",MOL(I)
+        !  write(*,1002)"PSIM:",PSIM(I)," PSIH:",PSIH(I)," W*:",WSTAR(I)," DTHV:",THV1D(I)-THVGB(I)
+        !  write(*,1003)"CPM:",CPM(I)," RHO1D:",RHO1D(I)," L:",ZOL(I)/ZA(I)," DTH:",TH1D(I)-THGB(I)
+        !  write(*,1004)"Z0/Zt:",zratio(I)," Z0:",ZNTstoch(I)," Zt:",z_t(I)," za:",za(I)
+        !  write(*,1005)"Re:",restar," MAVAIL:",MAVAIL(I)," QSFC(I):",QSFC(I)," QVSH(I):",QVSH(I)
+        !  print*,"VISC=",VISC," Z0:",ZNTstoch(I)," T1D(i):",T1D(i)
+        !  write(*,*)"============================================="
+    !ENDIF
 
  ENDDO     ! end i-loop
 
@@ -1105,7 +1051,19 @@ CONTAINS
       !----------------------------------------------------------
  DO I=its,ite
 
-   IF (ISFFLX .LT. 1) THEN                                                
+    !For computing the diagnostics and fluxes (below), whether the fluxes
+    !are turned off or on, we need the following:
+    PSIX=GZ1OZ0(I)-PSIM(I)
+    PSIX10=GZ10OZ0(I)-PSIM10(I)
+
+    PSIT =MAX(GZ1OZt(I)-PSIH(I), 1.0)
+    PSIT2=MAX(GZ2OZt(I)-PSIH2(I),1.0)
+  
+    PSIQ=MAX(LOG((ZA(I)+z_q(i))/z_q(I))-PSIH(I) ,1.0)
+    PSIQ2=MAX(LOG((2.0+z_q(i))/z_q(I))-PSIH2(I) ,1.0)
+    PSIQ10=MAX(LOG((10.0+z_q(i))/z_q(I))-PSIH10(I) ,1.0)
+
+    IF (ISFFLX .LT. 1) THEN                            
 
        QFX(i)  = 0.                                                              
        HFX(i)  = 0.    
@@ -1123,46 +1081,21 @@ CONTAINS
            Cka(I)= 0.
            Cda(I)= 0.
        ENDIF
-   ELSE
-
-      PSIX=GZ1OZ0(I)-PSIM(I)
-      PSIX10=GZ10OZ0(I)-PSIM10(I)
-
-      PSIT=MAX(LOG((ZA(I)+z_t(i))/z_t(i))-PSIH(I) ,2.0)
-      PSIT2=MAX(LOG((2.0+z_t(i))/z_t(i))-PSIH2(I) ,2.0)        
-      PSIT10=MAX(LOG((10.0+z_t(i))/z_t(i))-PSIH10(I) ,2.0)
-
-      PSIQ=MAX(LOG((za(i)+z_q(i))/z_q(I))-PSIH(I) ,2.0)   
-      PSIQ2=MAX(LOG((2.0+z_q(i))/z_q(I))-PSIH2(I) ,2.0) 
-      PSIQ10=MAX(LOG((10.0+z_q(i))/z_q(I))-PSIH10(I) ,2.0)
-
-      IF((XLAND(I)-1.5).LT.0)THEN !LAND Only  
-         IF ( IZ0TLND .EQ. 4 ) THEN
-            CALL Pan_etal_1994(PSIQ,PSIQ2,UST(I),PSIH(I),PSIH2(I),&
-                       & KARMAN,ZA(I))
-         ENDIF
-      ENDIF
+    ELSE
 
       !------------------------------------------
       ! CALCULATE THE EXCHANGE COEFFICIENTS FOR HEAT (FLHC)
       ! AND MOISTURE (FLQC)
       !------------------------------------------
       FLQC(I)=RHO1D(I)*MAVAIL(I)*UST(I)*KARMAN/PSIQ
-
-      DTTHX=ABS(TH1D(I)-THGB(I))                                            
-      IF(DTTHX.GT.1.E-5)THEN                                                   
-         FLHC(I)=CPM(I)*RHO1D(I)*UST(I)*MOL(I)/(TH1D(I)-THGB(I))          
-      ELSE                                                                     
-         FLHC(I)=0.                                                             
-      ENDIF   
+      FLHC(I)=RHO1D(I)*CPM(I)*UST(I)*KARMAN/PSIT
 
       !----------------------------------
       ! COMPUTE SURFACE MOISTURE FLUX:
       !----------------------------------
-
-      QFX(I)=FLQC(I)*(QSFCMR(I)-QV1D(I))          
+      QFX(I)=FLQC(I)*(QSFCMR(I)-QV1D(I))
       !JOE: QFX(I)=MAX(QFX(I),0.)   !originally did not allow neg QFX           
-      QFX(I)=MAX(QFX(I),-0.02)      !allows small neg QFX, like MYJ  
+      QFX(I)=MAX(QFX(I),-0.02)      !allows small neg QFX, like MYJ
       LH(I)=XLV*QFX(I)
 
       !----------------------------------
@@ -1170,12 +1103,12 @@ CONTAINS
       !----------------------------------
       IF(XLAND(I)-1.5.GT.0.)THEN      !WATER                                           
          HFX(I)=FLHC(I)*(THGB(I)-TH1D(I))                                
-!        IF ( PRESENT(ISFTCFLX) ) THEN
-!           IF ( ISFTCFLX.NE.0 ) THEN
-!              ! AHW: add dissipative heating term (commented out in 3.6.1
-!              HFX(I)=HFX(I)+RHO1D(I)*USTM(I)*USTM(I)*WSPDI(I)
-!           ENDIF
-!        ENDIF
+         IF ( PRESENT(ISFTCFLX) ) THEN
+            IF ( ISFTCFLX.NE.0 ) THEN
+               ! AHW: add dissipative heating term
+               HFX(I)=HFX(I)+RHO1D(I)*USTM(I)*USTM(I)*WSPDI(I)
+            ENDIF
+         ENDIF
       ELSEIF(XLAND(I)-1.5.LT.0.)THEN  !LAND                               
          HFX(I)=FLHC(I)*(THGB(I)-TH1D(I))                                
          HFX(I)=MAX(HFX(I),-250.)                                       
@@ -1206,39 +1139,114 @@ CONTAINS
 
    ENDIF !end ISFFLX option
 
-!   IF ( wrf_at_debug_level(3000) ) THEN
-!   IF (HFX(I) > 1200. .OR. HFX(I) < -500. .OR. &
-!      &LH(I)  > 1200. .OR. LH(I)  < -500. .OR. &
-!      &UST(I) < 0.0 .OR. UST(I) > 4.0 .OR. &
-!      &WSTAR(I)<0.0 .OR. WSTAR(I) > 6.0 .OR. &
-!      &RHO1D(I)<0.0 .OR. RHO1D(I) > 1.6 .OR. &
-!      &QSFC(I)*1000. <0.0 .OR. QSFC(I)*1000. >38. .OR. &
-!      &PBLH(I)>6000.) THEN
-!      print*,"SUSPICIOUS VALUES IN MYNN SFCLAYER",&
-!            ITER-ITMAX," ITERATIONS",I,J
-!      write(*,1000)"HFX: ",HFX(I)," LH:",LH(I)," CH:",CH(I),&
-!            " PBLH:",PBLH(I)
-!      write(*,1001)"REGIME:",REGIME(I)," z/L:",ZOL(I)," U*:",UST(I),&
-!            " Tstar:",MOL(I)
-!      write(*,1002)"PSIM:",PSIM(I)," PSIH:",PSIH(I)," W*:",WSTAR(I),&
-!            " DTHV:",THV1D(I)-THVGB(I)
-!      write(*,1003)"CPM:",CPM(I)," RHO1D:",RHO1D(I)," L:",&
-!            ZOL(I)/ZA(I)," DTH:",TH1D(I)-THGB(I)
-!      write(*,1004)"Z0/Zt:",zratio(I)," Z0:",ZNT(I)," Zt:",z_t(I),&
-!            " za:",za(I)
-!      write(*,1005)"Re:",restar," MAVAIL:",MAVAIL(I)," QSFC(I):",&
-!            QSFC(I)," QVSH(I):",QVSH(I)
-!      print*,"PSIX=",PSIX," Z0:",ZNT(I)," T1D(i):",T1D(i)
-!      write(*,*)"============================================="
-!   ENDIF
-!   ENDIF
+   !-----------------------------------------------------
+   !COMPUTE DIAGNOSTICS
+   !-----------------------------------------------------
+   !COMPUTE 10 M WNDS
+   !-----------------------------------------------------
+   ! If the lowest model level is close to 10-m, use it
+   ! instead of the flux-based diagnostic formula.
+   if (ZA(i) .le. 7.0) then
+      ! high vertical resolution
+      if(ZA2(i) .gt. 7.0 .and. ZA2(i) .lt. 13.0) then
+         !use 2nd model level
+         U10(I)=U1D2(I)
+         V10(I)=V1D2(I)
+      else
+         U10(I)=U1D(I)*log(10./ZNTstoch(I))/log(ZA(I)/ZNTstoch(I))
+         V10(I)=V1D(I)*log(10./ZNTstoch(I))/log(ZA(I)/ZNTstoch(I))
+      endif
+   elseif(ZA(i) .gt. 7.0 .and. ZA(i) .lt. 13.0) then
+      !moderate vertical resolution
+      !U10(I)=U1D(I)*PSIX10/PSIX
+      !V10(I)=V1D(I)*PSIX10/PSIX
+      !use neutral-log:
+      U10(I)=U1D(I)*log(10./ZNTstoch(I))/log(ZA(I)/ZNTstoch(I))
+      V10(I)=V1D(I)*log(10./ZNTstoch(I))/log(ZA(I)/ZNTstoch(I))
+   else
+      ! very coarse vertical resolution
+      U10(I)=U1D(I)*PSIX10/PSIX
+      V10(I)=V1D(I)*PSIX10/PSIX
+   endif
+
+   !-----------------------------------------------------
+   !COMPUTE 2m T, TH, AND Q
+   !THESE WILL BE OVERWRITTEN FOR LAND POINTS IN THE LSM
+   !-----------------------------------------------------
+   DTG=TH1D(I)-THGB(I) 
+   TH2(I)=THGB(I)+DTG*PSIT2/PSIT
+   !***  BE CERTAIN THAT THE 2-M THETA IS BRACKETED BY
+   !***  THE VALUES AT THE SURFACE AND LOWEST MODEL LEVEL.
+   IF ((TH1D(I)>THGB(I) .AND. (TH2(I)<THGB(I) .OR. TH2(I)>TH1D(I))) .OR. &
+       (TH1D(I)<THGB(I) .AND. (TH2(I)>THGB(I) .OR. TH2(I)<TH1D(I)))) THEN
+       TH2(I)=THGB(I) + 2.*(TH1D(I)-THGB(I))/ZA(I)
+   ENDIF
+   T2(I)=TH2(I)*(PSFC(I)/100.)**ROVCP
+
+   Q2(I)=QSFCMR(I)+(QV1D(I)-QSFCMR(I))*PSIQ2/PSIQ
+   Q2(I)= MAX(Q2(I), MIN(QSFCMR(I), QV1D(I)))
+   Q2(I)= MIN(Q2(I), 1.05*QV1D(I))
+
+   IF ( debug_code ) THEN
+      yesno = 0
+      IF (HFX(I) > 1200. .OR. HFX(I) < -700.)THEN
+            print*,"SUSPICIOUS VALUES IN MYNN SFCLAYER",&
+            I,J, "HFX: ",HFX(I)
+            yesno = 1
+      ENDIF
+      IF (LH(I)  > 1200. .OR. LH(I)  < -700.)THEN
+            print*,"SUSPICIOUS VALUES IN MYNN SFCLAYER",&
+            I,J, "LH: ",LH(I)
+            yesno = 1
+      ENDIF
+      IF (UST(I) < 0.0 .OR. UST(I) > 4.0 )THEN
+            print*,"SUSPICIOUS VALUES IN MYNN SFCLAYER",&
+            I,J, "UST: ",UST(I)
+            yesno = 1
+      ENDIF
+      IF (WSTAR(I)<0.0 .OR. WSTAR(I) > 6.0)THEN
+            print*,"SUSPICIOUS VALUES IN MYNN SFCLAYER",&
+            I,J, "WSTAR: ",WSTAR(I)
+            yesno = 1
+      ENDIF
+      IF (RHO1D(I)<0.0 .OR. RHO1D(I) > 1.6 )THEN
+            print*,"SUSPICIOUS VALUES IN MYNN SFCLAYER",&
+            I,J, "rho: ",RHO1D(I)
+            yesno = 1
+      ENDIF
+      IF (QSFC(I)*1000. <0.0 .OR. QSFC(I)*1000. >40.)THEN
+            print*,"SUSPICIOUS VALUES IN MYNN SFCLAYER",&
+            I,J, "QSFC: ",QSFC(I)
+            yesno = 1
+      ENDIF
+      IF (PBLH(I)<0. .OR. PBLH(I)>6000.)THEN
+            print*,"SUSPICIOUS VALUES IN MYNN SFCLAYER",&
+            I,J, "PBLH: ",PBLH(I)
+            yesno = 1
+      ENDIF
+
+      IF (yesno == 1) THEN
+        print*," OTHER INFO:"
+        write(*,1001)"REGIME:",REGIME(I)," z/L:",ZOL(I)," U*:",UST(I),&
+              " Tstar:",MOL(I)
+        write(*,1002)"PSIM:",PSIM(I)," PSIH:",PSIH(I)," W*:",WSTAR(I),&
+              " DTHV:",THV1D(I)-THVGB(I)
+        write(*,1003)"CPM:",CPM(I)," RHO1D:",RHO1D(I)," L:",&
+              ZOL(I)/ZA(I)," DTH:",TH1D(I)-THGB(I)
+        write(*,*)" Z0:",ZNTstoch(I)," Zt:",z_t(I)," za:",za(I)
+        write(*,1005)"Re:",restar," MAVAIL:",MAVAIL(I)," QSFC(I):",&
+              QSFC(I)," QVSH(I):",QVSH(I)
+        print*,"PSIX=",PSIX," Z0:",ZNTstoch(I)," T1D(i):",T1D(i)
+        write(*,*)"============================================="
+      ENDIF
+   ENDIF
 
  ENDDO !end i-loop
 
 END SUBROUTINE SFCLAY1D_mynn
 !-------------------------------------------------------------------          
    SUBROUTINE zilitinkevich_1995(Z_0,Zt,Zq,restar,ustar,KARMAN,&
-       & landsea,IZ0TLND2)
+       & landsea,IZ0TLND2,spp_pbl,rstoch)
 
        ! This subroutine returns the thermal and moisture roughness lengths
        ! from Zilitinkevich (1995) and Zilitinkevich et al. (2001) over
@@ -1256,6 +1264,9 @@ END SUBROUTINE SFCLAY1D_mynn
        REAL :: CZIL  !=0.100 in Chen et al. (1997)
                      !=0.075 in Zilitinkevich (1995)
                      !=0.500 in Lemone et al. (2008)
+       INTEGER,  INTENT(IN)  ::    spp_pbl
+       REAL,     INTENT(IN)  ::    rstoch
+
 
        IF (landsea-1.5 .GT. 0) THEN    !WATER
 
@@ -1283,59 +1294,32 @@ END SUBROUTINE SFCLAY1D_mynn
           IF ( IZ0TLND2 .EQ. 1 ) THEN
              CZIL = 10.0 ** ( -0.40 * ( Z_0 / 0.07 ) )
           ELSE
-             CZIL = 0.10
+             CZIL = 0.095 !0.075 !0.10
           END IF
 
           Zt = Z_0*EXP(-KARMAN*CZIL*SQRT(restar))
-          Zt = MIN( Zt, Z_0/2.)
+          Zt = MIN( Zt, 0.75*Z_0)
 
           Zq = Z_0*EXP(-KARMAN*CZIL*SQRT(restar))
-          Zq = MIN( Zq, Z_0/2.)
+          Zq = MIN( Zq, 0.75*Z_0)
 
-          !Zq = Zt
+! stochastically perturb thermal and moisture roughness length.
+! currently set to half the amplitude: 
+          if (spp_pbl==1) then
+             Zt = Zt + Zt * 0.5 * rstoch
+             Zt = MAX(Zt, 0.0001)
+             Zq = Zt
+          endif
+
        ENDIF
                    
        return
 
    END SUBROUTINE zilitinkevich_1995
 !--------------------------------------------------------------------
-   SUBROUTINE Pan_etal_1994(PSIQ,PSIQ2,ustar,psih,psih2,KARMAN,Z1)
-
-       ! This subroutine returns the resistance (PSIQ) for moisture
-       ! exchange. This is a modified form originating from Pan et al. 
-       ! (1994) but modified according to tests in both the RUC model 
-       ! and WRF-ARW. Note that it is very similar to Carlson and
-       ! Boland (1978) model (include below in comments) but has an
-       ! extra molecular layer (a third layer) instead of two layers. 
-
-       IMPLICIT NONE
-       REAL, INTENT(IN) :: Z1,ustar,KARMAN,psih,psih2
-       REAL, INTENT(OUT) :: psiq,psiq2
-       REAL, PARAMETER :: Cpan=1.0 !was 20.8 in Pan et al 1994
-       REAL, PARAMETER :: ZL=0.01  
-       REAL, PARAMETER :: ZMUs=0.2E-3
-       REAL, PARAMETER :: XKA = 2.4E-5
-
-         !PAN et al. (1994): 3-layer model, as in paper:
-         !ZMU = Cpan*XKA/(KARMAN*UST(I)) 
-         !PSIQ =MAX(KARMAN*ustar*ZMU/XKA + LOG((KARMAN*ustar*ZL + XKA)/XKA + &
-         !     & Z1/ZL) - PSIH,2.0)
-         !PSIQ2=MAX(KARMAN*ustar*ZMU/XKA + LOG((KARMAN*ustar*ZL + XKA)/XKA + &
-         !     & 2./ZL) - PSIH2,2.0)                                       
-         !MODIFIED FORM:
-         PSIQ =MAX(KARMAN*ustar*ZMUs/XKA + LOG((KARMAN*ustar*Z1)/XKA + &
-              & Z1/ZL) - PSIH,2.0)
-         PSIQ2=MAX(KARMAN*ustar*ZMUs/XKA + LOG((KARMAN*ustar*2.0)/XKA + &
-              & 2./ZL) - PSIH2,2.0)
-
-         !CARLSON AND BOLAND (1978): 2-layer model
-         !PSIQ =MAX(LOG(KARMAN*ustar*Z1/XKA + Z1/ZL)-PSIH  ,2.0)
-         !PSIQ2=MAX(LOG(KARMAN*ustar*2./XKA + 2./ZL)-PSIH2 ,2.0)
-
-    END SUBROUTINE Pan_etal_1994
-!--------------------------------------------------------------
    SUBROUTINE davis_etal_2008(Z_0,ustar)
 
+    !a.k.a. : Donelan et al. (2004)
     !This formulation for roughness length was designed to match 
     !the labratory experiments of Donelan et al. (2004).
     !This is an update version from Davis et al. 2008, which
@@ -1389,7 +1373,7 @@ END SUBROUTINE SFCLAY1D_mynn
 
    END SUBROUTINE Taylor_Yelland_2001
 !--------------------------------------------------------------------
-   SUBROUTINE charnock_1955(Z_0,ustar,wsp10,visc)
+   SUBROUTINE charnock_1955(Z_0,ustar,wsp10,visc,zu)
  
     !This version of Charnock's relation employs a varying
     !Charnock parameter, similar to COARE3.0 [Fairall et al. (2003)].
@@ -1397,13 +1381,16 @@ END SUBROUTINE SFCLAY1D_mynn
     !between 10-m wsp = 10 and 18. 
 
        IMPLICIT NONE
-       REAL, INTENT(IN)  :: ustar, visc, wsp10
+       REAL, INTENT(IN)  :: ustar, visc, wsp10, zu
        REAL, INTENT(OUT) :: Z_0
        REAL, PARAMETER   :: G=9.81, CZO2=0.011
        REAL              :: CZC    !variable charnock "constant"   
+       REAL              :: wsp10m ! logarithmically calculated 10 m
 
-       CZC = CZO2 + 0.007*MIN(MAX((wsp10-10.)/8., 0.), 1.0)
-       Z_0 = CZC*ustar*ustar/G + (0.11*visc/MAX(ustar,0.1))
+       wsp10m = wsp10*log(10./1e-4)/log(zu/1e-4)
+       CZC = CZO2 + 0.007*MIN(MAX((wsp10m-10.)/8., 0.), 1.0)
+
+       Z_0 = CZC*ustar*ustar/G + (0.11*visc/MAX(ustar,0.05))
        Z_0 = MAX( Z_0, 1.27e-7)  !These max/mins were suggested by
        Z_0 = MIN( Z_0, 2.85e-3)  !Davis et al. (2008)
 
@@ -1411,9 +1398,39 @@ END SUBROUTINE SFCLAY1D_mynn
 
    END SUBROUTINE charnock_1955
 !--------------------------------------------------------------------
+   SUBROUTINE edson_etal_2013(Z_0,ustar,wsp10,visc,zu)
+
+     !This version of Charnock's relation employs a varying
+     !Charnock parameter, taken from COARE 3.5 [Edson et al. (2001, JPO)].
+     !The Charnock parameter CZC is varied from about .005 to .028
+     !between 10-m wind speeds of 6 and 19 m/s.
+     !11 Nov 2021: Note that this was finally fixed according to the
+     !             Edson et al (2014) corrigendum, where "m" was corrected.
+
+       IMPLICIT NONE
+       REAL, INTENT(IN)  :: ustar, visc, wsp10, zu
+       REAL, INTENT(OUT) :: Z_0
+       REAL, PARAMETER   :: G=9.81
+       REAL, PARAMETER   :: m=0.0017, b=-0.005
+       REAL              :: CZC    ! variable charnock "constant"
+       REAL              :: wsp10m ! logarithmically calculated 10 m
+
+       wsp10m = wsp10*log(10/1e-4)/log(zu/1e-4)
+       wsp10m = MIN(19., wsp10m)
+       CZC    = m*wsp10m + b
+       CZC    = MAX(CZC, 0.0)
+
+       Z_0 = CZC*ustar*ustar/G + (0.11*visc/MAX(ustar,0.07))
+       Z_0 = MAX( Z_0, 1.27e-7)  !These max/mins were suggested by
+       Z_0 = MIN( Z_0, 2.85e-3)  !Davis et al. (2008)
+
+       return
+
+   END SUBROUTINE edson_etal_2013
+!--------------------------------------------------------------------
    SUBROUTINE garratt_1992(Zt,Zq,Z_0,Ren,landsea)
 
-    !This formulation for the thermal and moisture roughness lengths 
+    !This formulation for the thermal and moisture roughness lengths
     !(Zt and Zq) relates them to Z0 via the roughness Reynolds number (Ren).
     !This formula comes from Fairall et al. (2003). It is modified from
     !the original Garratt-Brutsaert model to better fit the COARE/HEXMAX
@@ -1444,52 +1461,82 @@ END SUBROUTINE SFCLAY1D_mynn
 
     END SUBROUTINE garratt_1992
 !--------------------------------------------------------------------
-    SUBROUTINE fairall_2001(Zt,Zq,Ren,ustar,visc)
+    SUBROUTINE fairall_etal_2003(Zt,Zq,Ren,ustar,visc,rstoch,spp_pbl)
 
-    !This formulation for thermal and moisture roughness length (Zt and Zq) 
-    !as a function of the roughness Reynolds number (Ren) comes from the 
+    !This formulation for thermal and moisture roughness length (Zt and Zq)
+    !as a function of the roughness Reynolds number (Ren) comes from the
     !COARE3.0 formulation, empirically derived from COARE and HEXMAX data
     ![Fairall et al. (2003)]. Edson et al. (2004; JGR) suspected that this
-    !relationship overestimated roughness lengths for low Reynolds number 
-    !flows, so a smooth flow relationship, taken from Garrattt (1992, p. 102),
-    !is used for flows with Ren < 2. 
-    !
-    !Note that this formulation should not be used with the Davis et al. 
-    !(2008) formulation for Zo, because that formulation produces much 
-    !smaller u* (Ren), resulting in a large Zt and Zq. It works best with
-    !the Charnock or the Taylor and Yelland relationships.
+    !relationship overestimated the scalar roughness lengths for low Reynolds
+    !number flows, so an optional smooth flow relationship, taken from Garratt
+    !(1992, p. 102), is available for flows with Ren < 2.
     !
     !This is for use over water only.
 
        IMPLICIT NONE
-       REAL, INTENT(IN)  :: Ren,ustar,visc
-       REAL, INTENT(OUT) :: Zt,Zq
+       REAL, INTENT(IN)   :: Ren,ustar,visc,rstoch
+       INTEGER, INTENT(IN):: spp_pbl
+       REAL, INTENT(OUT)  :: Zt,Zq
 
        IF (Ren .le. 2.) then
 
           Zt = (5.5e-5)*(Ren**(-0.60))
           Zq = Zt
-          !FOR SMOOTH SEAS, USE GARRATT
+          !FOR SMOOTH SEAS, CAN USE GARRATT
           !Zq = 0.2*visc/MAX(ustar,0.1)
           !Zq = 0.3*visc/MAX(ustar,0.1)
 
        ELSE
-          
-          !FOR ROUGH SEAS, USE FAIRALL
+
+          !FOR ROUGH SEAS, USE COARE
           Zt = (5.5e-5)*(Ren**(-0.60))
           Zq = Zt
- 
+
        ENDIF
+
+       if (spp_pbl==1) then
+          Zt = Zt + Zt * 0.5 * rstoch
+          Zq = Zt
+       endif
 
        Zt = MIN(Zt,1.0e-4)
        Zt = MAX(Zt,2.0e-9)
 
        Zq = MIN(Zt,1.0e-4)
-       Zq = MAX(Zt,2.0e-9) 
-                   
+       Zq = MAX(Zt,2.0e-9)
+
        return
 
-    END SUBROUTINE fairall_2001
+    END SUBROUTINE fairall_etal_2003
+!--------------------------------------------------------------------
+    SUBROUTINE fairall_etal_2014(Zt,Zq,Ren,ustar,visc,rstoch,spp_pbl)
+
+    !This formulation for thermal and moisture roughness length (Zt and Zq)
+    !as a function of the roughness Reynolds number (Ren) comes from the
+    !COARE 3.5/4.0 formulation, empirically derived from COARE and HEXMAX data
+    ![Fairall et al. (2014? coming soon, not yet published as of July 2014)].
+    !This is for use over water only.
+
+       IMPLICIT NONE
+       REAL, INTENT(IN)  :: Ren,ustar,visc,rstoch
+       INTEGER, INTENT(IN):: spp_pbl
+       REAL, INTENT(OUT) :: Zt,Zq
+
+       !Zt = (5.5e-5)*(Ren**(-0.60))
+       Zt = MIN(1.6E-4, 5.8E-5/(Ren**0.72))
+       Zq = Zt
+
+       IF (spp_pbl ==1) THEN
+          Zt = MAX(Zt + Zt*0.5*rstoch,2.0e-9)
+          Zq = MAX(Zt + Zt*0.5*rstoch,2.0e-9)
+       ELSE
+          Zt = MAX(Zt,2.0e-9)
+          Zq = MAX(Zt,2.0e-9)
+       ENDIF
+
+       return
+
+    END SUBROUTINE fairall_etal_2014
 !--------------------------------------------------------------------
     SUBROUTINE Yang_2008(Z_0,Zt,Zq,ustar,tstar,qst,Ren,visc,landsea)
 
@@ -1508,44 +1555,57 @@ END SUBROUTINE SFCLAY1D_mynn
     !to 7.2 (in 2008 paper). Their form typically varies the
     !ratio Z0/Zt by a few orders of magnitude (1-1E4).
     !
-    !This modified form uses beta = 0.5 and Renc = 350, so zt generally 
-    !varies similarly to the Zilitinkevich form for small/moderate heat 
-    !fluxes but can become ~O(1/2 Zilitinkevich) for very large negative T*.
-    !Also, the exponent (0.25) on tstar was changed to 1.0, since we found                                      
-    !Zt was reduced too much for low-moderate positive heat fluxes.                                             
+    !This modified form uses beta = 1.5 and a variable Renc (function of Z_0),
+    !so zt generally varies similarly to the Zilitinkevich form (with Czil ~ 0.1)
+    !for very small or negative surface heat fluxes but can become close to the
+    !Zilitinkevich with Czil = 0.2 for very large HFX (large negative T*).
+    !Also, the exponent (0.25) on tstar was changed to 1.0, since we found
+    !Zt was reduced too much for low-moderate positive heat fluxes.
     !
     !This should only be used over land!
 
        IMPLICIT NONE
        REAL, INTENT(IN)  :: Z_0, Ren, ustar, tstar, qst, visc, landsea
-       REAL              :: ht, tstar2
+       REAL              :: ht,     &! roughness height at critical Reynolds number
+                            tstar2, &! bounded T*, forced to be non-positive
+                            qstar2, &! bounded q*, forced to be non-positive
+                            Z_02,   &! bounded Z_0 for variable Renc2 calc
+                            Renc2    ! variable Renc, function of Z_0
        REAL, INTENT(OUT) :: Zt,Zq
-       REAL, PARAMETER  :: Renc=350., beta=0.5, e=2.71828183
+       REAL, PARAMETER  :: Renc=300., & !old constant Renc
+                           beta=1.5,  & !important for diurnal variation
+                           m=170.,    & !slope for Renc2 function
+                           b=691.       !y-intercept for Renc2 function
 
-       ht     = Renc*visc/MAX(ustar,0.01)
+       Z_02 = MIN(Z_0,0.5)
+       Z_02 = MAX(Z_02,0.04)
+       Renc2= b + m*log(Z_02)
+       ht     = Renc2*visc/MAX(ustar,0.01)
        tstar2 = MIN(tstar, 0.0)
+       qstar2 = MIN(qst,0.0)
 
        Zt     = ht * EXP(-beta*(ustar**0.5)*(ABS(tstar2)**1.0))
-       !Zq     = ht * EXP(-beta*(ustar**0.5)*(ABS(qst)**1.0))
-       Zq     = Zt
-                   
-       Zt = MIN(Zt, Z_0/2.0)  !(e**2.))   !limit from Garratt (1980,1992)
-       Zq = MIN(Zq, Z_0/2.0)  !(e**2.))   !limit from Garratt (1980,1992)
+       Zq     = ht * EXP(-beta*(ustar**0.5)*(ABS(qstar2)**1.0))
+       !Zq     = Zt
+
+       Zt = MIN(Zt, Z_0/2.0)
+       Zq = MIN(Zq, Z_0/2.0)
 
        return
 
     END SUBROUTINE Yang_2008
 !--------------------------------------------------------------------
-    SUBROUTINE Andreas_2002(Z_0,Ren,Zt,Zq)
+    SUBROUTINE Andreas_2002(Z_0,bvisc,ustar,Zt,Zq)
 
-    !This is taken from Andreas (2002; J. of Hydromet).
+    ! This is taken from Andreas (2002; J. of Hydromet) and 
+    ! Andreas et al. (2005; BLM).
     !
-    !This should only be used over snow/ice!
+    ! This should only be used over snow/ice!
 
        IMPLICIT NONE
-       REAL, INTENT(IN)  :: Z_0, Ren
+       REAL, INTENT(IN)  :: Z_0, bvisc, ustar
        REAL, INTENT(OUT) :: Zt, Zq
-       REAL :: Ren2 
+       REAL :: Ren2, zntsno
 
        REAL, PARAMETER  :: bt0_s=1.25,  bt0_t=0.149,  bt0_r=0.317,  &
                            bt1_s=0.0,   bt1_t=-0.55,  bt1_r=-0.565, &
@@ -1554,26 +1614,31 @@ END SUBROUTINE SFCLAY1D_mynn
        REAL, PARAMETER  :: bq0_s=1.61,  bq0_t=0.351,  bq0_r=0.396,  &
                            bq1_s=0.0,   bq1_t=-0.628, bq1_r=-0.512, &
                            bq2_s=0.0,   bq2_t=0.0,    bq2_r=-0.180
-          
-       Ren2 = Ren
+
+      !Calculate zo for snow (Andreas et al. 2005, BLM)                                                                     
+       zntsno = 0.135*bvisc/ustar + &
+               (0.035*(ustar*ustar)/9.8) * &
+               (5.*exp(-1.*(((ustar - 0.18)/0.1)*((ustar - 0.18)/0.1))) + 1.)                                                
+       Ren2 = ustar*zntsno/bvisc
+
        ! Make sure that Re is not outside of the range of validity
        ! for using their equations
        IF (Ren2 .gt. 1000.) Ren2 = 1000. 
 
        IF (Ren2 .le. 0.135) then
 
-          Zt = Z_0*EXP(bt0_s + bt1_s*LOG(Ren2) + bt2_s*LOG(Ren2)**2)
-          Zq = Z_0*EXP(bq0_s + bq1_s*LOG(Ren2) + bq2_s*LOG(Ren2)**2)
+          Zt = zntsno*EXP(bt0_s + bt1_s*LOG(Ren2) + bt2_s*LOG(Ren2)**2)
+          Zq = zntsno*EXP(bq0_s + bq1_s*LOG(Ren2) + bq2_s*LOG(Ren2)**2)
 
        ELSE IF (Ren2 .gt. 0.135 .AND. Ren2 .lt. 2.5) then
 
-          Zt = Z_0*EXP(bt0_t + bt1_t*LOG(Ren2) + bt2_t*LOG(Ren2)**2)
-          Zq = Z_0*EXP(bq0_t + bq1_t*LOG(Ren2) + bq2_t*LOG(Ren2)**2)
+          Zt = zntsno*EXP(bt0_t + bt1_t*LOG(Ren2) + bt2_t*LOG(Ren2)**2)
+          Zq = zntsno*EXP(bq0_t + bq1_t*LOG(Ren2) + bq2_t*LOG(Ren2)**2)
 
        ELSE
 
-          Zt = Z_0*EXP(bt0_r + bt1_r*LOG(Ren2) + bt2_r*LOG(Ren2)**2)
-          Zq = Z_0*EXP(bq0_r + bq1_r*LOG(Ren2) + bq2_r*LOG(Ren2)**2)
+          Zt = zntsno*EXP(bt0_r + bt1_r*LOG(Ren2) + bt2_r*LOG(Ren2)**2)
+          Zq = zntsno*EXP(bq0_r + bq1_r*LOG(Ren2) + bq2_r*LOG(Ren2)**2)
 
        ENDIF
 
@@ -1783,6 +1848,25 @@ END SUBROUTINE SFCLAY1D_mynn
 
     END SUBROUTINE PSI_Suselj_Sood_2010
 !--------------------------------------------------------------------
+    SUBROUTINE PSI_CB2005(psim1,psih1,zL,z0L)
+
+    ! This subroutine returns the stability functions based off
+    ! of Cheng and Brutseart (2005, BLM), for use in stable conditions only.
+    ! The returned values are the combination of psi((za+zo)/L) - psi(z0/L)
+
+       IMPLICIT NONE
+       REAL, INTENT(IN)  :: zL,z0L
+       REAL, INTENT(OUT) :: psim1,psih1
+
+       psim1 = -6.1*LOG(zL  + (1.+ zL **2.5)**0.4) &
+               -6.1*LOG(z0L + (1.+ z0L**2.5)**0.4)
+       psih1 = -5.5*LOG(zL  + (1.+ zL **1.1)**0.90909090909) &
+               -5.5*LOG(z0L + (1.+ z0L**1.1)**0.90909090909)
+
+       return
+
+    END SUBROUTINE PSI_CB2005
+!--------------------------------------------------------------------
     SUBROUTINE Li_etal_2010(zL, Rib, zaz0, z0zt)
 
     !This subroutine returns a more robust z/L that best matches
@@ -1843,6 +1927,397 @@ END SUBROUTINE SFCLAY1D_mynn
        return
 
     END SUBROUTINE Li_etal_2010
-!--------------------------------------------------------------------
+!-------------------------------------------------------------------
+      REAL function zolri(ri,za,z0,zt,zol1,psi_opt)
+
+      ! This iterative algorithm is a two-point secant method taken from the revised 
+      ! surface layer scheme in WRF-ARW, written by Pedro Jimenez and Jimy Dudhia and 
+      ! summarized in Jimenez et al. (2012, MWR). This function was adapted
+      ! to input the thermal roughness length, zt, (as well as z0) and use initial
+      ! estimate of z/L.
+
+      IMPLICIT NONE
+      REAL, INTENT(IN) :: ri,za,z0,zt,zol1
+      INTEGER, INTENT(IN) :: psi_opt
+      REAL :: x1,x2,fx1,fx2
+      INTEGER :: n
+      INTEGER, PARAMETER :: nmax = 20
+
+      if (ri.lt.0.)then
+         x1=zol1 - 0.02  !-5.
+         x2=0.
+      else
+         x1=0.
+         x2=zol1 + 0.02 !5.
+      endif
+
+      n=0
+      fx1=zolri2(x1,ri,za,z0,zt,psi_opt)
+      fx2=zolri2(x2,ri,za,z0,zt,psi_opt)
+        
+      Do While (abs(x1 - x2) > 0.01 .and. n < nmax)
+        if(abs(fx2) .lt. abs(fx1))then
+          x1=x1-fx1/(fx2-fx1)*(x2-x1)
+          fx1=zolri2(x1,ri,za,z0,zt,psi_opt)
+          zolri=x1
+        else
+          x2=x2-fx2/(fx2-fx1)*(x2-x1)
+          fx2=zolri2(x2,ri,za,z0,zt,psi_opt)
+          zolri=x2
+        endif
+        n=n+1
+      enddo
+
+      if (n==nmax .and. abs(x1 - x2) >= 0.01) then
+         !if convergence fails, use approximate values:
+         CALL Li_etal_2010(zolri, ri, za/z0, z0/zt)
+         !print*,"FAILED, n=",n," Ri=",ri," zt=",zt
+      else
+         !print*,"SUCCESS,n=",n," Ri=",ri," z/L=",zolri
+      endif
+
+      return
+      end function
+!-------------------------------------------------------------------
+      REAL function zolri2(zol2,ri2,za,z0,zt,psi_opt)
+
+      ! INPUT: =================================
+      ! zol2 - estimated z/L
+      ! ri2  - calculated bulk Richardson number
+      ! za   - 1/2 depth of first model layer
+      ! z0   - aerodynamic roughness length
+      ! zt   - thermal roughness length
+      ! OUTPUT: ================================
+      ! zolri2 - delta Ri
+
+      IMPLICIT NONE
+      INTEGER, INTENT(IN) :: psi_opt
+      REAL, INTENT(IN) :: ri2,za,z0,zt
+      REAL, INTENT(INOUT) :: zol2
+      REAL :: zol20,zol3,psim1,psih1,psix2,psit2,zolt
+
+      if(zol2*ri2 .lt. 0.) THEN
+         !print*,"WRONG QUADRANTS: z/L=",zol2," ri=",ri2
+         zol2=0.
+      endif 
+
+      zol20=zol2*z0/za ! z0/L
+      zol3=zol2+zol20  ! (z+z0)/L
+      zolt=zol2*zt/za  ! zt/L 
+
+      if (ri2.lt.0) then
+         psit2=MAX(log((za+z0)/zt)-(psih_unstable(zol3,psi_opt)-psih_unstable(zolt,psi_opt)), 1.0)
+         psix2=MAX(log((za+z0)/z0)-(psim_unstable(zol3,psi_opt)-psim_unstable(zol20,psi_opt)),1.0)
+      else
+         psit2=MAX(log((za+z0)/zt)-(psih_stable(zol3,psi_opt)-psih_stable(zolt,psi_opt)), 1.0)
+         psix2=MAX(log((za+z0)/z0)-(psim_stable(zol3,psi_opt)-psim_stable(zol20,psi_opt)),1.0)
+      endif
+
+      zolri2=zol2*psit2/psix2**2 - ri2
+      !print*,"  target ri=",ri2," est ri=",zol2*psit2/psix2**2
+
+      return
+      end function
+!====================================================================
+
+      REAL function zolrib(ri,za,z0,zt,logz0,logzt,zol1,psi_opt)
+
+      ! This iterative algorithm to compute z/L from bulk-Ri
+
+      IMPLICIT NONE
+      REAL, INTENT(IN) :: ri,za,z0,zt,logz0,logzt
+      INTEGER, INTENT(IN) :: psi_opt
+      REAL, INTENT(INOUT) :: zol1
+      REAL :: zol20,zol3,zolt,zolold
+      INTEGER :: n
+      INTEGER, PARAMETER :: nmax = 20
+      !REAL, DIMENSION(nmax):: zLhux
+      REAL :: psit2,psix2
+
+      if(zol1*ri .lt. 0.) THEN
+         !print*,"WRONG QUADRANTS: z/L=",zol1," ri=",ri
+         zol1=0.
+      endif
+
+      if (ri .lt. 0.) then
+        zolold=-99999.
+        zolrib=-66666.
+      else
+        zolold=99999.
+        zolrib=66666.
+      endif
+      n=1
+
+      DO While (abs(zolold - zolrib) > 0.01 .and. n < nmax)
+
+        if(n==1)then
+          zolold=zol1
+        else
+          zolold=zolrib
+        endif
+        zol20=zolold*z0/za ! z0/L
+        zol3=zolold+zol20  ! (z+z0)/L
+        zolt=zolold*zt/za  ! zt/L
+
+        if (ri.lt.0) then
+           psit2=MAX(logzt-(psih_unstable(zol3,psi_opt)-psih_unstable(zolt,psi_opt)), 1.0)
+           psix2=MAX(logz0-(psim_unstable(zol3,psi_opt)-psim_unstable(zol20,psi_opt)), 1.0)
+        else
+           psit2=MAX(logzt-(psih_stable(zol3,psi_opt)-psih_stable(zolt,psi_opt)), 1.0)
+           psix2=MAX(logz0-(psim_stable(zol3,psi_opt)-psim_stable(zol20,psi_opt)), 1.0)
+        endif
+
+        zolrib=ri*psix2**2/psit2
+        !zLhux(n)=zolrib
+        n=n+1
+      enddo
+
+      if (n==nmax .and. abs(zolold - zolrib) > 0.01 ) then
+         !if convergence fails, use approximate values:
+         CALL Li_etal_2010(zolrib, ri, za/z0, z0/zt)
+         if (debug_code) then
+            print*,"iter FAIL, n=",n," Ri=",ri," z/L=",zolrib
+            !zLhux(n)=zolri
+            print*," zt=",zt," psit=",psit2," psix=",psix2
+         endif
+      else
+         !print*,"SUCCESS,n=",n," Ri=",ri," z/L=",zolrib
+      endif
+
+      return
+      end function
+!====================================================================
+
+   SUBROUTINE psi_init(psi_opt)
+
+    ! Define tables from -10 <= z/L <= 10
+
+    INTEGER                   ::      N,psi_opt
+    REAL                      ::      zolf
+
+    if (psi_opt == 0) then
+       DO N=0,1000
+          ! stable function tables
+          zolf = float(n)*0.01
+          psim_stab(n)=psim_stable_full(zolf)
+          psih_stab(n)=psih_stable_full(zolf)
+
+          ! unstable function tables
+          zolf = -float(n)*0.01
+          psim_unstab(n)=psim_unstable_full(zolf)
+          psih_unstab(n)=psih_unstable_full(zolf)
+       ENDDO
+    else
+       DO N=0,1000
+          ! stable function tables
+          zolf = float(n)*0.01
+          psim_stab(n)=psim_stable_full_gfs(zolf)
+          psih_stab(n)=psih_stable_full_gfs(zolf)
+
+          ! unstable function tables
+          zolf = -float(n)*0.01
+          psim_unstab(n)=psim_unstable_full_gfs(zolf)
+          psih_unstab(n)=psih_unstable_full_gfs(zolf)
+       ENDDO
+    endif
+
+    !simple test to see if initialization worked:                                                                                                                
+    if (psim_stab(1) < 0. .and. psih_stab(1) < 0. .and. &
+        psim_unstab(1) > 0. .and. psih_unstab(1) > 0.) then
+       print*,'in psi_init, psi tables have been initialized'
+    else
+       print*,'error in psi_init: problem initializing psi tables'
+    endif
+
+   END SUBROUTINE psi_init
+! ==================================================================
+! ... Full equations for the integrated similarity functions ...
+! ==================================================================
+   REAL function psim_stable_full(zolf)
+        REAL :: zolf   
+
+        psim_stable_full=-6.1*log(zolf+(1+zolf**2.5)**(1./2.5))
+
+        return
+   end function
+
+   REAL function psih_stable_full(zolf)
+        REAL :: zolf
+
+        psih_stable_full=-5.3*log(zolf+(1+zolf**1.1)**(1./1.1))
+
+        return
+   end function
+
+   REAL function psim_unstable_full(zolf)
+        REAL :: zolf,x,ym,psimc,psimk
+
+        x=(1.-16.*zolf)**.25
+        psimk=2*ALOG(0.5*(1+X))+ALOG(0.5*(1+X*X))-2.*ATAN(X)+2.*ATAN(1.)
+
+        ym=(1.-10.*zolf)**0.33
+        psimc=(3./2.)*log((ym**2.+ym+1.)/3.)-sqrt(3.)*ATAN((2.*ym+1)/sqrt(3.))+4.*ATAN(1.)/sqrt(3.)
+
+        psim_unstable_full=(psimk+zolf**2*(psimc))/(1+zolf**2.)
+
+        return
+   end function
+
+   REAL function psih_unstable_full(zolf)
+        REAL :: zolf,y,yh,psihc,psihk
+
+        y=(1.-16.*zolf)**.5
+        psihk=2.*log((1+y)/2.)
+
+        yh=(1.-34.*zolf)**0.33
+        psihc=(3./2.)*log((yh**2.+yh+1.)/3.)-sqrt(3.)*ATAN((2.*yh+1)/sqrt(3.))+4.*ATAN(1.)/sqrt(3.)
+
+        psih_unstable_full=(psihk+zolf**2*(psihc))/(1+zolf**2.)
+
+        return
+   end function
+
+! ==================================================================
+! ... integrated similarity functions from GFS...
+!
+   REAL function psim_stable_full_gfs(zolf)
+        REAL :: zolf
+        REAL, PARAMETER :: alpha4 = 20.
+        REAL :: aa
+
+        aa     = sqrt(1. + alpha4 * zolf)
+        psim_stable_full_gfs  = -1.*aa + log(aa + 1.)
+
+        return
+   end function
+
+   REAL function psih_stable_full_gfs(zolf)
+        REAL :: zolf
+        REAL, PARAMETER :: alpha4 = 20.
+        REAL :: bb
+
+        bb     = sqrt(1. + alpha4 * zolf)
+        psih_stable_full_gfs  = -1.*bb + log(bb + 1.)
+
+        return
+   end function
+
+   REAL function psim_unstable_full_gfs(zolf)
+        REAL :: zolf
+        REAL :: hl1,tem1
+        REAL, PARAMETER :: a0=-3.975,  a1=12.32,  &
+                           b1=-7.755,  b2=6.041
+
+        if (zolf .ge. -0.5) then
+           hl1   = zolf
+           psim_unstable_full_gfs  = (a0  + a1*hl1)  * hl1   / (1.+ (b1+b2*hl1)  *hl1)
+        else
+           hl1   = -zolf
+           tem1  = 1.0 / sqrt(hl1)
+           psim_unstable_full_gfs  = log(hl1) + 2. * sqrt(tem1) - .8776
+        end if
+
+        return
+   end function
+
+   REAL function psih_unstable_full_gfs(zolf)
+        REAL :: zolf
+        REAL :: hl1,tem1
+        REAL, PARAMETER :: a0p=-7.941, a1p=24.75, &
+                           b1p=-8.705, b2p=7.899
+
+        if (zolf .ge. -0.5) then
+           hl1   = zolf
+           psih_unstable_full_gfs  = (a0p + a1p*hl1) * hl1   / (1.+ (b1p+b2p*hl1)*hl1)
+        else
+           hl1   = -zolf
+           tem1  = 1.0 / sqrt(hl1)
+           psih_unstable_full_gfs  = log(hl1) + .5 * tem1 + 1.386
+        end if
+
+        return
+   end function
+
+!=================================================================
+! These functions use the look-up table functions when |z/L| <= 10
+! but default to the full equations when |z/L| > 10.  
+!=================================================================
+   REAL function psim_stable(zolf,psi_opt)
+        integer :: nzol,psi_opt
+        real    :: rzol,zolf
+
+        nzol = int(zolf*100.)
+        rzol = zolf*100. - nzol
+        if(nzol+1 .le. 1000)then
+           psim_stable = psim_stab(nzol) + rzol*(psim_stab(nzol+1)-psim_stab(nzol))
+        else
+           if (psi_opt == 0) then
+              psim_stable = psim_stable_full(zolf)
+           else
+              psim_stable = psim_stable_full_gfs(zolf)
+           endif
+        endif
+
+      return
+   end function
+
+   REAL function psih_stable(zolf,psi_opt)
+        integer :: nzol,psi_opt
+        real    :: rzol,zolf
+
+        nzol = int(zolf*100.)
+        rzol = zolf*100. - nzol
+        if(nzol+1 .le. 1000)then
+           psih_stable = psih_stab(nzol) + rzol*(psih_stab(nzol+1)-psih_stab(nzol))
+        else
+           if (psi_opt == 0) then
+              psih_stable = psih_stable_full(zolf)
+           else
+              psih_stable = psih_stable_full_gfs(zolf)
+           endif
+        endif
+
+      return
+   end function
+
+   REAL function psim_unstable(zolf,psi_opt)
+        integer :: nzol,psi_opt
+        real    :: rzol,zolf
+
+        nzol = int(-zolf*100.)
+        rzol = -zolf*100. - nzol
+        if(nzol+1 .le. 1000)then
+           psim_unstable = psim_unstab(nzol) + rzol*(psim_unstab(nzol+1)-psim_unstab(nzol))
+        else
+           if (psi_opt == 0) then
+              psim_unstable = psim_unstable_full(zolf)
+           else
+              psim_unstable = psim_unstable_full_gfs(zolf)
+           endif
+        endif
+
+      return
+   end function
+
+   REAL function psih_unstable(zolf,psi_opt)
+        integer :: nzol,psi_opt
+        real    :: rzol,zolf
+
+        nzol = int(-zolf*100.)
+        rzol = -zolf*100. - nzol
+        if(nzol+1 .le. 1000)then
+           psih_unstable = psih_unstab(nzol) + rzol*(psih_unstab(nzol+1)-psih_unstab(nzol))
+        else
+           if (psi_opt == 0) then
+              psih_unstable = psih_unstable_full(zolf)
+           else
+              psih_unstable = psih_unstable_full_gfs(zolf)
+           endif
+        endif
+
+      return
+   end function
+!========================================================================
 
 END MODULE module_sf_mynn
+


### PR DESCRIPTION
This is an update to the MYNN-EDMF, bringing in the "universal" k-only scheme, which will also go into WRF and CCPP eventually but probably in the form of a submodule. This also updates the MYNN sfclayer, making it more consistent with WRF and it also contains some coupling of the MYNN subgrid clouds to radiation (Thanks to Larissa Reames, NSSL).

Testing has only been done for a single case, so beware, but it also runs when compiled with DEBUG=true.

See the below examples for more information.
https://github.com/MPAS-Dev/MPAS/pull/930
https://github.com/MPAS-Dev/MPAS/pull/931

