### PR TITLE
Bug fix and refactor nwfa emissions for MP

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
@@ -356,7 +356,11 @@
 
      case("mp_thompson")
         call thompson_init(l_mp_tables, thompson_hail_aware, thompson_aerosol_aware)
-        call init_thompson_clouddroplets_forMPAS(mesh,sfc_input,diag,diag_physics,state,configs)
+        if (thompson_aerosol_aware) then
+           call init_thompson_nwfa_emissions(mesh,state,diag_physics)
+        else
+           call init_thompson_clouddroplets_forMPAS(mesh,sfc_input,diag_physics)
+        endif
 
      case("mp_wsm6")
         call mp_wsm6_init(den0=rho_a,denr=rho_r,dens=rho_s,cl=cliq,cpv=cpv, &

--- a/src/core_atmosphere/physics/mpas_atmphys_init_microphysics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_init_microphysics.F
@@ -12,17 +12,14 @@
  use mpas_kind_types
  use mpas_pool_routines
 
- use mpas_atmphys_vars
- use mpas_atmphys_constants
  use mpas_atmphys_utilities
  use module_mp_thompson_params, only: Nt_c_l, Nt_c_o, aero_max, nwfa_default
- use module_mp_thompson_utils, only: make_hydrometeor_number_concentrations
 !use module_mp_thompson, only: is_aerosol_aware,naCCN0,naCCN1,naIN0,naIN1,ntb_arc,ntb_arw,ntb_art,ntb_arr, &
 !                              ntb_ark,tnccn_act
 
  implicit none
  private
- public:: init_thompson_clouddroplets_forMPAS
+ public:: init_thompson_clouddroplets_forMPAS, init_thompson_nwfa_emissions
 
 !MPAS main initialization of the Thompson parameterization of cloud microphysics with nucleation of cloud
 !droplets based on distributions of CCNs and INs (aerosol-aware parameterization).
@@ -39,46 +36,39 @@
 
 
 !=================================================================================================================
- subroutine init_thompson_clouddroplets_forMPAS(mesh,sfc_input,diag,diag_physics,state,configs)
+ !  routine init_thompson_nwfa_emissions
+ !
+ !> \brief Initialize nwfa emissions for thompson microphysics
+ !> \author Anders Jensen
+ !> \date   13 June 2024
+ !> \details
+ !>  This routine sets surface emssions for water-friendly aerosols
+ !>  based on the lowest-model level value of 3D aerosols and the 
+ !>  vertical grid space at the lowest-model level as is done in CCPP.
+ !
+ subroutine init_thompson_nwfa_emissions(mesh,state,diag_physics)
 !=================================================================================================================
 
 !input variables:
  type(mpas_pool_type),intent(in):: mesh
- type(mpas_pool_type),intent(in):: sfc_input
+ type(mpas_pool_type),intent(in):: state
 
 !inout variables:
  type(mpas_pool_type),intent(inout):: diag_physics
- type(mpas_pool_type),intent(inout):: state
- type(mpas_pool_type),intent(in):: diag
- type(mpas_pool_type),intent(in):: configs
 
 !local variables and pointers:
- integer,pointer:: index_qc, index_nc, index_qr, index_nr
- integer,pointer:: index_qi, index_ni, index_qv, index_nwfa
  integer,pointer:: nCellsSolve
- integer,pointer:: nVertLevels
- integer,dimension(:),pointer:: landmask
-
- logical,pointer:: thompson_aerosol_aware
-
- real(kind=RKIND),dimension(:),pointer:: nt_c,mu_c,nwfa_emissions
- real(kind=RKIND),dimension(:,:),pointer:: pressure_b, pressure_p, theta_m, exner, zgrid
- real(kind=RKIND),dimension(:,:),pointer  :: qv,qc,qr,qi,nc,nr,ni,nwfa
+ integer,pointer:: index_nwfa
  real(kind=RKIND),dimension(:,:,:),pointer:: scalars
+ real(kind=RKIND),dimension(:,:),pointer:: zgrid
+ real(kind=RKIND),dimension(:),pointer:: nwfa_emissions
 
- ! local variables:
- integer:: i,k,j,iCell
- logical:: do_init_number_concentrations
+  ! local variables:
  integer,parameter:: k_sfc = 1
  real(kind=RKIND):: deltaz
+ integer:: iCell, i
 
- do_init_number_concentrations = .false.
 !-----------------------------------------------------------------------------------------------------------------
-!call mpas_log_write('')
-!call mpas_log_write('--- enter subroutine init_thompson_clouddroplets_forMPAS:')
-
- call mpas_pool_get_config(configs,'config_thompson_aerosol_aware',thompson_aerosol_aware)
-
  call mpas_pool_get_dimension(mesh,'nCellsSolve',nCellsSolve)
 
  call mpas_pool_get_array(mesh,'zgrid',zgrid)
@@ -87,7 +77,7 @@
  call mpas_pool_get_array(diag_physics,'nwfa_emissions',nwfa_emissions)
  
  do iCell = 1, nCellsSolve
-    deltaz = zgrid(k_sfc+1,i)-zgrid(k_sfc,i)
+    deltaz = zgrid(k_sfc+1,iCell)-zgrid(k_sfc,iCell)
     if (deltaz < 9.0) then
        deltaz = 9.0
     endif
@@ -96,127 +86,48 @@
  enddo
  call physics_message('Setting surface wfa emissions for tempo microphysics')
 
- if ((thompson_aerosol_aware) .and. (do_init_number_concentrations)) then
-    call mpas_pool_get_array(state,'scalars',scalars)
-    call mpas_pool_get_dimension(mesh,'nVertLevels',nVertLevels)
+end subroutine init_thompson_nwfa_emissions
 
-    call mpas_pool_get_array(diag,'exner',exner)
-    call mpas_pool_get_array(diag,'pressure_p',pressure_p)
-    call mpas_pool_get_array(diag,'pressure_base',pressure_b)
-    call mpas_pool_get_array(state,'theta_m',theta_m,1)
+!=================================================================================================================
+ subroutine init_thompson_clouddroplets_forMPAS(mesh,sfc_input,diag_physics)
+!=================================================================================================================
 
-    call mpas_pool_get_dimension(state,'index_qc',index_qc)
-    call mpas_pool_get_dimension(state,'index_nc',index_nc)
-    call mpas_pool_get_dimension(state,'index_qr',index_qr)
-    call mpas_pool_get_dimension(state,'index_nr',index_nr)
-    call mpas_pool_get_dimension(state,'index_qi',index_qi)
-    call mpas_pool_get_dimension(state,'index_ni',index_ni)
-    call mpas_pool_get_dimension(state,'index_qv',index_qv)
-    call mpas_pool_get_dimension(state,'index_nwfa',index_nwfa)
+!input variables:
+ type(mpas_pool_type),intent(in):: mesh
+ type(mpas_pool_type),intent(in):: sfc_input
 
-    if(.not.allocated(pres_p) ) allocate(pres_p(ims:ime,kms:kme,jms:jme) )
-    if(.not.allocated(qv_p) ) allocate(qv_p(ims:ime,kms:kme,jms:jme) )
-    if(.not.allocated(th_p) ) allocate(th_p(ims:ime,kms:kme,jms:jme) )
-    if(.not.allocated(t_p) ) allocate(t_p(ims:ime,kms:kme,jms:jme) )
-    if(.not.allocated(rho_p) ) allocate(rho_p(ims:ime,kms:kme,jms:jme) )
+!inout variables:
+ type(mpas_pool_type),intent(inout):: diag_physics
 
-    if(.not.allocated(qc_p) ) allocate(qc_p(ims:ime,kms:kme,jms:jme) )
-    if(.not.allocated(nc_p) ) allocate(nc_p(ims:ime,kms:kme,jms:jme) )
-    if(.not.allocated(qr_p) ) allocate(qr_p(ims:ime,kms:kme,jms:jme) )
-    if(.not.allocated(nr_p) ) allocate(nr_p(ims:ime,kms:kme,jms:jme) )
-    if(.not.allocated(qi_p) ) allocate(qi_p(ims:ime,kms:kme,jms:jme) )
-    if(.not.allocated(ni_p) ) allocate(ni_p(ims:ime,kms:kme,jms:jme) )
-    if(.not.allocated(qv_p) ) allocate(qv_p(ims:ime,kms:kme,jms:jme) )
-    if(.not.allocated(nwfa_p) ) allocate(nwfa_p(ims:ime,kms:kme,jms:jme) )
+!local variables and pointers:
+ integer,pointer:: nCellsSolve
+ integer,dimension(:),pointer:: landmask
 
-    qc => scalars(index_qc,:,:)
-    nc => scalars(index_nc,:,:)
-    qr => scalars(index_qr,:,:)
-    nr => scalars(index_nr,:,:)
-    qi => scalars(index_qi,:,:)
-    ni => scalars(index_ni,:,:)
-    qv => scalars(index_qv,:,:)
-    nwfa => scalars(index_nwfa,:,:)
+ real(kind=RKIND),dimension(:),pointer:: nt_c,mu_c
 
-    do j = jts, jte
-       do k = kts, kte
-          do i = its, ite
-             pres_p(i,k,j) = pressure_p(k,i) + pressure_b(k,i)
-             qv_p(i,k,j) = qv(k,i)
-             th_p(i,k,j) = theta_m(k,i) / (1._RKIND + R_v/R_d * qv_p(i,k,j))
-             t_p(i,k,j) = th_p(i,k,j)*exner(k,i)
-             rho_p(i,k,i) = ep_2*pres_p(i,k,j) / (R_d*t_p(i,k,j)*(qv_p(i,k,j)+ep_2))
+ integer:: iCell
 
-             qc_p(i,k,j) = qc(k,i)
-             nc_p(i,k,j) = nc(k,i)
-             qr_p(i,k,j) = qr(k,i)
-             nr_p(i,k,j) = nr(k,i)
-             qi_p(i,k,j) = qi(k,i)
-             ni_p(i,k,j) = ni(k,i)
-             qv_p(i,k,j) = qv(k,i)
-             nwfa_p(i,k,j) = nwfa(k,i)
+!-----------------------------------------------------------------------------------------------------------------
+!call mpas_log_write('')
+!call mpas_log_write('--- enter subroutine init_thompson_clouddroplets_forMPAS:')
 
-          enddo
-       enddo
-    enddo
+ call mpas_pool_get_dimension(mesh,'nCellsSolve',nCellsSolve)
 
-    call make_hydrometeor_number_concentrations(qc_p, qr_p, qi_p, nwfa_p, t_p, rho_p, nc_p, nr_p, ni_p)
-
-     do j = jts, jte
-       do k = kts, kte
-          do i = its, ite
-             nc(k,i) = nc_p(i,k,j)
-             nr(k,i) = nr_p(i,k,j)
-             ni(k,i) = ni_p(i,k,j)
-          enddo
-       enddo
-    enddo
-
-    if(allocated(pres_p)  ) deallocate(pres_p  )
-    if(allocated(qv_p)  ) deallocate(qv_p  )
-    if(allocated(th_p)  ) deallocate(th_p  )
-    if(allocated(t_p)  ) deallocate(t_p  )
-    if(allocated(rho_p)  ) deallocate(rho_p  )
-
-    if(allocated(qc_p)  ) deallocate(qc_p  )
-    if(allocated(nc_p)  ) deallocate(nc_p  )
-    if(allocated(qr_p)  ) deallocate(qr_p  )
-    if(allocated(nr_p)  ) deallocate(nr_p  )
-    if(allocated(qi_p)  ) deallocate(qi_p  )
-    if(allocated(nr_p)  ) deallocate(ni_p  )
-    if(allocated(qv_p)  ) deallocate(qv_p  )
-    if(allocated(nwfa_p)  ) deallocate(nwfa_p  )
-
- else ! non aerosol-aware initial number concentrations
-
-    call mpas_pool_get_array(sfc_input,'landmask',landmask)
-    call mpas_pool_get_array(diag_physics,'nt_c',nt_c)
-    call mpas_pool_get_array(diag_physics,'mu_c',mu_c)
+ call mpas_pool_get_array(sfc_input,'landmask',landmask)
+ call mpas_pool_get_array(diag_physics,'nt_c',nt_c)
+ call mpas_pool_get_array(diag_physics,'mu_c',mu_c)
 
 !... initialize the prescribed number of cloud droplets, and mu_c (parameter in the exponential of the generalized
 !gamma distribution) as a function of the land-cean mask. as set in the thompson cloud microphysics scheme, nt_c
 !is set to 100 per cc (100.E6 m^-3) for maritime cases and 300 per cc (300.E6 m^-3) for continental cases.
-    do iCell = 1, nCellsSolve
-       if(landmask(iCell) .eq. 1) then
-          nt_c(iCell) = Nt_c_l
-       elseif(landmask(iCell) .eq. 0) then
-          nt_c(iCell) = Nt_c_o
-       endif
-       mu_c(iCell) = MIN(15., (1000.e6/nt_c(iCell) + 2.))
-    enddo
-
-    call physics_message('calling init_thompson_clouddroplets_forMPAS() without aerosols')
- endif
-
-! AAJ - Set initial value of nc to 10% of the available WFA.
-! This is a quick fix (01 April 2024) since the values of nc
-! that are set above are to high to use as intial conditions
-! with the aerosol-aware scheme.
-! do k = 1, nVertLevels
-!    do iCell = 1, nCellsSolve
-!       scalars(index_nc,k,iCell) = max(10.e6, min(500.e6, (0.1 * scalars(index_nwfa,k,iCell))))
-!    enddo
-! enddo
+ do iCell = 1, nCellsSolve
+    if(landmask(iCell) .eq. 1) then
+       nt_c(iCell) = Nt_c_l
+    elseif(landmask(iCell) .eq. 0) then
+       nt_c(iCell) = Nt_c_o
+    endif
+    mu_c(iCell) = MIN(15., (1000.e6/nt_c(iCell) + 2.))
+ enddo
 
 !call mpas_log_write('--- end subroutine init_thompson_clouddroplets_forMPAS.')
 


### PR DESCRIPTION
1. First reverts mpas_atmphys_init_microphysics.F to the original NCAR version
2. Creates a submodule `init_thompson_nwfa_emissions()` in mpas_atmphys_driver_microphysics.F
3. Transfers control over aerosol emissions to mpas_atmphys_driver_microphysics.F90
  - If aerosol_aware call `init_thompson_nwfa_emissions()`, else call `init_thompson_clouddroplets_forMPAS()`
  - Modifies `init_thompson_clouddroplets_forMPAS()` to use number concentrations from TEMPO submodule parameter file
4. Bug fix to the aerosol emissions code (found by @tanyasmirnova) change index i to iCell.



