### PR TITLE
Bugfix for calculation of 1km-AGL model level for reflectivity calculation in microphysics driver

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
@@ -885,7 +885,7 @@
 
           do k = kts,kte
              dBZ1d(k) = -10._RKIND
-             zp(k) = z_p(i,k,j) - z_p(i,1,j)+0.5*dz_p(i,k,j) ! height AGL
+             zp(k) = z_p(i,k,j) - z_p(i,1,j)+0.5*dz_p(i,k,j) ! height AGL at mid-layer
           enddo
 
           kp = 1
@@ -927,7 +927,7 @@
              qs1d(k)  = qs_p(i,k,j)
              qg1d(k)  = qg_p(i,k,j)
              dBZ1d(k) = -35._RKIND
-             zp(k) = z_p(i,k,j) - z_p(i,1,j)+0.5*dz_p(i,k,j) ! height AGL
+             zp(k) = z_p(i,k,j) - z_p(i,1,j)+0.5*dz_p(i,k,j) ! height AGL at mid-layer
           enddo
 
           call refl10cm_wsm6(qv1d,qr1d,qs1d,qg1d,t1d,p1d,dBZ1d,kts,kte)
@@ -978,7 +978,7 @@
              qg1d(k)  = qg_p(i,k,j)
              nr1d(k)  = nr_p(i,k,j)
              dBZ1d(k) = refl10cm_p(i,k,j)
-             zp(k) = z_p(i,k,j) - z_p(i,1,j)+0.5*dz_p(i,k,j) ! height AGL
+             zp(k) = z_p(i,k,j) - z_p(i,1,j)+0.5*dz_p(i,k,j) ! height AGL at mid-layer
           enddo
           
           ! AAJ This function is called directly from the microphysics
@@ -1062,7 +1062,7 @@ subroutine compute_hourly_max_radar_reflectivity(configs,diag_physics,its,ite)
 
           !do k = kts,kte
           !   dBZ1d(k) = -10._RKIND
-          !   zp(k) = z_p(i,k,j) - z_p(i,1,j)+0.5*dz_p(i,k,j) ! height AGL
+          !   zp(k) = z_p(i,k,j) - z_p(i,1,j)+0.5*dz_p(i,k,j) ! height AGL at mid-layer
           !enddo
 
           !kp = 1

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
@@ -885,7 +885,7 @@
 
           do k = kts,kte
              dBZ1d(k) = -10._RKIND
-             zp(k) = z_p(i,k,j) - z_p(i,1,j)+0.5*dz_p(i,1,j) ! height AGL
+             zp(k) = z_p(i,k,j) - z_p(i,1,j)+0.5*dz_p(i,k,j) ! height AGL
           enddo
 
           kp = 1
@@ -927,7 +927,7 @@
              qs1d(k)  = qs_p(i,k,j)
              qg1d(k)  = qg_p(i,k,j)
              dBZ1d(k) = -35._RKIND
-             zp(k) = z_p(i,k,j) - z_p(i,1,j)+0.5*dz_p(i,1,j) ! height AGL
+             zp(k) = z_p(i,k,j) - z_p(i,1,j)+0.5*dz_p(i,k,j) ! height AGL
           enddo
 
           call refl10cm_wsm6(qv1d,qr1d,qs1d,qg1d,t1d,p1d,dBZ1d,kts,kte)
@@ -978,7 +978,7 @@
              qg1d(k)  = qg_p(i,k,j)
              nr1d(k)  = nr_p(i,k,j)
              dBZ1d(k) = refl10cm_p(i,k,j)
-             zp(k) = z_p(i,k,j) - z_p(i,1,j)+0.5*dz_p(i,1,j) ! height AGL
+             zp(k) = z_p(i,k,j) - z_p(i,1,j)+0.5*dz_p(i,k,j) ! height AGL
           enddo
           
           ! AAJ This function is called directly from the microphysics
@@ -1062,7 +1062,7 @@ subroutine compute_hourly_max_radar_reflectivity(configs,diag_physics,its,ite)
 
           !do k = kts,kte
           !   dBZ1d(k) = -10._RKIND
-          !   zp(k) = z_p(i,k,j) - z_p(i,1,j)+0.5*dz_p(i,1,j) ! height AGL
+          !   zp(k) = z_p(i,k,j) - z_p(i,1,j)+0.5*dz_p(i,k,j) ! height AGL
           !enddo
 
           !kp = 1


### PR DESCRIPTION
There was a small bug in 'physics/mpas_atmphys_driver_microphysics.F' in the calculation of the model level corresponding to the 1km-AGL height for the calculation of radar reflectivity at this level.  The variable 'dz_p' (model layer thickness in meters) was hardwired to level 'k=1'.  Correction was to replace the '1' with the level index 'k' so that the relevant layer thickness is used at each level.

Model was compiled and tested in both debug and non-debug on Jet.

Plots of effects on 'refl10cm' on global 240km uniform mesh run (48 hour forecast):
[refl10cm_plots.pdf](https://github.com/user-attachments/files/16241003/refl10cm_plots.pdf)


