### PR TITLE
CMakeList changes for UFS dycore only build

### DIFF
--- a/src/core_atmosphere/CMakeLists.txt
+++ b/src/core_atmosphere/CMakeLists.txt
@@ -151,13 +151,18 @@ set(ATMOSPHERE_CORE_INCLUDES
         structs_and_variables.inc)
 
 
-add_library(core_atmosphere ${ATMOSPHERE_CORE_SOURCES}
-        ${ATMOSPHERE_CORE_PHYSICS_SOURCES}
-        ${ATMOSPHERE_CORE_PHYSICS_MMM_SOURCES}
-        ${ATMOSPHERE_CORE_PHYSICS_WRF_SOURCES}
-        ${ATMOSPHERE_CORE_DIAGNOSTIC_SOURCES}
-        ${ATMOSPHERE_CORE_DYNAMICS_SOURCES})
-
+if (${DO_PHYSICS})
+  add_library(core_atmosphere ${ATMOSPHERE_CORE_SOURCES}
+                              ${ATMOSPHERE_CORE_PHYSICS_SOURCES}
+			      ${ATMOSPHERE_CORE_PHYSICS_MMM_SOURCES}
+			      ${ATMOSPHERE_CORE_PHYSICS_WRF_SOURCES}
+			      ${ATMOSPHERE_CORE_DIAGNOSTIC_SOURCES}
+			      ${ATMOSPHERE_CORE_DYNAMICS_SOURCES})
+else ()
+  add_library(core_atmosphere ${ATMOSPHERE_CORE_SOURCES}
+                              ${ATMOSPHERE_CORE_DIAGNOSTIC_SOURCES}
+                              ${ATMOSPHERE_CORE_DYNAMICS_SOURCES})
+endif ()
 set(CORE_ATMOSPHERE_COMPILE_DEFINITIONS
         mpas=1
         MPAS_NATIVE_TIMERS
@@ -170,31 +175,33 @@ set_MPAS_DEBUG_flag(core_atmosphere)
 mpas_core_target(CORE atmosphere TARGET core_atmosphere INCLUDES ${ATMOSPHERE_CORE_INCLUDES})
 
 #Get physics_wrf tables from MPAS-Data
-include(FetchContent)
-if (${PROJECT_VERSION} VERSION_GREATER_EQUAL 7.0)
+if (${DO_PHYSICS})
+  include(FetchContent)
+  if (${PROJECT_VERSION} VERSION_GREATER_EQUAL 7.0)
     set(MPAS_DATA_GIT_TAG v${PROJECT_VERSION_MAJOR}.0)
-else ()
+  else ()
     set(MPAS_DATA_GIT_TAG master)
-endif ()
+  endif ()
 
-FetchContent_Declare(mpas_data
-        GIT_REPOSITORY https://github.com/MPAS-Dev/MPAS-Data.git
-        GIT_TAG ${MPAS_DATA_GIT_TAG}
-        GIT_PROGRESS True
-        GIT_SHALLOW True)
-FetchContent_Populate(mpas_data)
-message(STATUS "MPAS-Data source dir: ${mpas_data_SOURCE_DIR}")
-set(PHYSICS_WRF_DATA_DIR ${mpas_data_SOURCE_DIR}/atmosphere/physics_wrf/files)
-file(GLOB PHYSICS_WRF_DATA RELATIVE ${PHYSICS_WRF_DATA_DIR} "${PHYSICS_WRF_DATA_DIR}/*")
-file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/${PROJECT_NAME}/core_atmosphere)
-foreach (data_file IN LISTS PHYSICS_WRF_DATA)
+  FetchContent_Declare(mpas_data
+          GIT_REPOSITORY https://github.com/MPAS-Dev/MPAS-Data.git
+          GIT_TAG ${MPAS_DATA_GIT_TAG}
+          GIT_PROGRESS True
+          GIT_SHALLOW True)
+  FetchContent_Populate(mpas_data)
+  message(STATUS "MPAS-Data source dir: ${mpas_data_SOURCE_DIR}")
+  set(PHYSICS_WRF_DATA_DIR ${mpas_data_SOURCE_DIR}/atmosphere/physics_wrf/files)
+  file(GLOB PHYSICS_WRF_DATA RELATIVE ${PHYSICS_WRF_DATA_DIR} "${PHYSICS_WRF_DATA_DIR}/*")
+  file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/${PROJECT_NAME}/core_atmosphere)
+  foreach (data_file IN LISTS PHYSICS_WRF_DATA)
     execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${PHYSICS_WRF_DATA_DIR}/${data_file}
-            ${CMAKE_BINARY_DIR}/${PROJECT_NAME}/core_atmosphere/${data_file})
-endforeach ()
-install(DIRECTORY ${PHYSICS_WRF_DATA_DIR}/ DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/core_atmosphere)
+          ${CMAKE_BINARY_DIR}/${PROJECT_NAME}/core_atmosphere/${data_file})
+  endforeach ()
+  install(DIRECTORY ${PHYSICS_WRF_DATA_DIR}/ DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/core_atmosphere)
 
-add_executable(mpas_atmosphere_build_tables ${ATMOSPHERE_CORE_UTILS_SOURCES})
-target_link_libraries(mpas_atmosphere_build_tables PUBLIC core_atmosphere)
-mpas_fortran_target(mpas_atmosphere_build_tables)
-install(TARGETS mpas_atmosphere_build_tables EXPORT ${PROJECT_NAME}ExportsCore
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+  add_executable(mpas_atmosphere_build_tables ${ATMOSPHERE_CORE_UTILS_SOURCES})
+  target_link_libraries(mpas_atmosphere_build_tables PUBLIC core_atmosphere)
+  mpas_fortran_target(mpas_atmosphere_build_tables)
+  install(TARGETS mpas_atmosphere_build_tables EXPORT ${PROJECT_NAME}ExportsCore
+          RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif ()

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -3090,7 +3090,7 @@
                 <!-- ================================================================================================== -->
 
                 <var name="cldfrac" type="real" dimensions="nVertLevels nCells Time" units="unitless"
-                     description="horizontal cloud fraction" packages="mp_thompson_in;mp_wsm6_in"/>
+                     description="horizontal cloud fraction"/>
 
 
                 <!-- ================================================================================================== -->

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1143,7 +1143,7 @@
                         <var_array name="lbc_scalars" />
 
                 </stream>
-
+#ifdef DO_MPASDA
 		<stream name="da_state"
                         type="input;output"
                         filename_template="mpasout.$Y-$M-$D_$h.$m.$s.nc"
@@ -1210,6 +1210,7 @@
 			<var name="tslb"/>
 			<var name="h_oml_initial"/>
                 </stream>
+#endif
 	</streams>
 
 
@@ -3089,7 +3090,7 @@
                 <!-- ================================================================================================== -->
 
                 <var name="cldfrac" type="real" dimensions="nVertLevels nCells Time" units="unitless"
-                     description="horizontal cloud fraction"/>
+                     description="horizontal cloud fraction" packages="mp_thompson_in;mp_wsm6_in"/>
 
 
                 <!-- ================================================================================================== -->
@@ -3588,6 +3589,8 @@
 <!-- **************************************************************************************** -->
 
 #include "diagnostics/Registry_diagnostics.xml"
+#ifdef DO_PHYSICS
 #include "physics/Registry_noahmp.xml"
+#endif
 
 </registry>


### PR DESCRIPTION
This PR contains changes to two MPAS files to facilitate an "MPAS dycore only build in the UFS"

1) Expand the role of the MPAS native pre-processor directives, DO_PHYSICS, in the CMakeLists to build the atmospheric dynamical core only. No native MPAS physics included, linking to ccpp-physics is external to this step in the UFS atmospheric component build system.

2) Modify the core_atmosphere Registry file to 
- Remove references to MPAS's native physics noahmp lsm.
- Add new PP directive to not build the DA "state".
We do not need these pieces in the UFS.

