### PR TITLE
Allow GSL atmosphere_model to run with NCAR init files

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -3943,12 +3943,14 @@
                      description="dominant soil category"/>
 
 		<var name="soilf" type="real" dimensions="nscat nCells" units="unitless"
+                     packages="lsm_ruc_in"
                      description="fraction of each soil category present"/>
 
                 <var name="ivgtyp" type="integer" dimensions="nCells" units="unitless"
                      description="dominant vegetation category"/>
 
 		<var name="landusef" type="real" dimensions="nlcat nCells" units="unitless"
+                     packages="lsm_ruc_in"
 		     description="fraction of each vegetation category present"/>
 
                 <var name="mminlu" type="text" dimensions="" units="unitless"
@@ -3979,6 +3981,7 @@
                      description="monthly-mean climatological surface albedo"/>
 
 		<var name="lai12m" type="real" dimensions="nMonths nCells" units="unitless"
+                     packages="lsm_ruc_in"
                      description="monthly-mean climatological leaf area index"/>
 
                 <var name="greenfrac" type="real" dimensions="nMonths nCells" units="unitless"

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F
@@ -34,7 +34,7 @@
  logical,parameter:: rdmaxalb = .false. !use snow albedo from geogrid;false use table values
  logical,parameter:: myj      = .false. !true if using Mellor-Yamada PBL scheme.
  logical,parameter:: frpcpn   = .false.
- logical,parameter:: rdlai2d  = .true.
+ logical          :: rdlai2d  = .false.
 
 !urban physics: MPAS does not plan to run the urban physics option.
  integer,parameter:: sf_urban_physics = 0 !activate urban canopy model (=0: no urban canopy) 
@@ -970,6 +970,7 @@
     case("sf_ruc")
        call mpas_timer_start('sf_ruc')
        myjpbl = .false.
+       rdlai2d = .true.
 
        call mpas_log_write('--- call subroutine ruc_land:')
        call ruc_land( spp_lsm      = spp_lsm_loc   , lakemodel    = lakemodel   , lakemask  = lakemask_p,  &

--- a/src/core_atmosphere/physics/mpas_atmphys_update_surface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_update_surface.F
@@ -89,11 +89,11 @@
  call mpas_pool_get_array(sfc_input,'sfc_albbck', sfc_albbck)
 
  call mpas_pool_get_array(sfc_input,'greenfrac' , greenfrac )
- call mpas_pool_get_array(sfc_input,'lai12m'    , lai12m    )
- call mpas_pool_get_array(diag_physics,'lai   '    , lai    )
  call mpas_pool_get_array(sfc_input,'vegfra'    , vegfra    )
  call mpas_pool_get_array(sfc_input,'shdmin'    , shdmin    )
  call mpas_pool_get_array(sfc_input,'shdmax'    , shdmax    )
+ call mpas_pool_get_array(sfc_input,'lai12m'    , lai12m    )
+ call mpas_pool_get_array(diag_physics,'lai   '    , lai    )
 
 !updates the surface background albedo for the current date as a function of the monthly-mean
 !surface background albedo valid on the 15th day of the month, if config_sfc_albedo is true:
@@ -117,13 +117,17 @@
  endif
 
 !updates the leaf area index for the current date as a function of the leaf area index
-!valid on the 15th day of the month :
- call monthly_interp_to_date(nCellsSolve,current_date,lai12m,lai)
 
-  call mpas_pool_get_array(mesh,'indexToCellID',globalCells)
-  do iCell = 1,nCellsSolve
-    lai(iCell) = lai(iCell) / 10.
-  enddo
+ if(associated(lai12m)) then 
+
+   call monthly_interp_to_date(nCellsSolve,current_date,lai12m,lai)
+
+   do iCell = 1,nCellsSolve
+     lai(iCell) = lai(iCell) / 10.
+   enddo
+
+ end if
+
  end subroutine physics_update_surface
 
 !=================================================================================================================


### PR DESCRIPTION
Fixes #65 

GSL code will be able to run with NCAR created init files.

When running hrrrv5 suite, the answers are unchanged.

```
nccmp -dsSqf bar-455a5a9fa.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_19.00.00.nc dev-ade085636.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_19.00.00.nc
Files "bar-455a5a9fa.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_19.00.00.nc" and "dev-ade085636.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_19.00.00.nc" are identical.
```

This does not fix all reproducibility issues. See #66 