### PR TITLE
Fix TEMPO aerosol initialization

### DIFF
--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -321,6 +321,11 @@
                      description="Whether to use monthly climatology for water- and ice-friendly aerosols"
                      possible_values="true or false"/>
 
+		<nml_option name="config_tempo_rap"            type="logical"       default_value="false"
+                     units="-"
+                     description="Whether to use aerosols from RAP for TEMPO microphysics instead of the monthly climatology"
+                     possible_values="true or false"/>
+
                 <nml_option name="config_input_sst"             type="logical"       default_value="false"
                      units="-"
                      description="Whether to re-compute SST and sea-ice fields from surface input data set; should be set to .true. when running case 8"

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -318,7 +318,7 @@ module init_atm_cases
             if (config_met_interp) then
                rap_aerosols = use_rap_aerosols(block_ptr % configs, block_ptr, mesh, state)
                if (rap_aerosols) then
-                  call mpas_log_write('Using interpolated aerosols from first guess for ICs. Skipping monthly climatolgy interpolation')
+                  call mpas_log_write('Using interpolated aerosols from first guess for ICs. Skipping monthly climatology interpolation')
                else
                   call init_atm_thompson_aerosols(block_ptr, mesh, block_ptr % configs, diag, state)
                endif
@@ -411,7 +411,7 @@ module init_atm_cases
                call mpas_get_time(start_time, dateTimeString=timeStart)
                rap_aerosols = use_rap_aerosols(block_ptr % configs, block_ptr, mesh, state, lbc_state)
                if (rap_aerosols) then
-                  call mpas_log_write('Using interpolated aerosols from first guess for LBCs. Skipping monthly climatolgy interpolation')
+                  call mpas_log_write('Using interpolated aerosols from first guess for LBCs. Skipping monthly climatology interpolation')
                else
                   call init_atm_thompson_aerosols_lbc(timeString, timeStart, block_ptr, mesh, diag, state, lbc_state)
                endif

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -101,6 +101,10 @@ module init_atm_cases
       real (kind=RKIND), dimension(1), TARGET :: dummyn1
       integer, dimension(1), TARGET :: idummyn1
 
+      logical :: rap_aerosols
+
+      rap_aerosols = .false.
+
       latCell => dummyn1
       lonCell => dummyn1
       ter     => dummyn1
@@ -9864,6 +9868,79 @@ call mpas_log_write('Done with soil consistency check')
       ierr = 0
 
    end function read_text_array
+
+   !-----------------------------------------------------------------------
+   !  logical function
+   !
+   !> \brief Whether to use RAP aerosols or monthly climo with TEMPO
+   !> \author Anders Jensen
+   !> \date   08 November 2024
+   !> \details
+   !>  This function returns .true. if RAP aerosols will be used with TEMPO
+   !>  microphysics, meaning that RAP values of nwfa and nifa will be in
+   !>  the initial and boundary condition files. For this function to
+   !>  be .true., config_tempo_rap must be .true. in the core_init_atmosphere
+   !>  Registry and aerosols from the parent model must have both global max
+   !>  values of nwfa and nifa that are non-zero.
+   !
+   !-----------------------------------------------------------------------
+   logical function use_rap_aerosols(configs, block, mesh, state)
+
+     implicit none
+
+     type(block_type), intent(in), target :: block
+     type (mpas_pool_type), intent(in):: mesh
+     type (mpas_pool_type), intent(in):: state
+     type (mpas_pool_type), intent(in):: configs
+
+     type(dm_info), pointer:: dminfo
+
+     integer, pointer :: index_nwfa
+     integer, pointer :: index_nifa
+     integer, pointer :: nCellsSolve
+     logical, pointer :: config_tempo_rap
+     real(kind=RKIND), dimension(:,:), pointer :: nifa,nwfa
+     real(kind=RKIND), dimension(:,:,:), pointer :: scalars
+
+     real(kind=RKIND) :: nifa_max,global_nifa_max
+     real(kind=RKIND) :: nwfa_max,global_nwfa_max
+
+     use_rap_aerosols = .false.
+
+     dminfo => block%domain%dminfo
+
+     call mpas_pool_get_config(configs,'config_tempo_rap',config_tempo_rap)
+     if (.not. config_tempo_rap) then
+        call mpas_log_write('config_tempo_rap is false, monthly climatology will be used for nwfa and nifa')
+        return
+     else
+        call mpas_pool_get_dimension(mesh,'nCellsSolve',nCellsSolve)
+        call mpas_pool_get_dimension(state, 'index_nwfa', index_nwfa)
+        call mpas_pool_get_dimension(state, 'index_nifa', index_nifa)
+        call mpas_pool_get_array(state, 'scalars', scalars)
+
+        nifa => scalars(index_nifa,:,:)
+        nwfa => scalars(index_nwfa,:,:)
+
+        global_nwfa_max = 0._RKIND
+        nwfa_max = maxval(nwfa(:,1:nCellsSolve))
+        call mpas_dmpar_max_real(dminfo,nwfa_max,global_nwfa_max)
+
+        global_nifa_max = 0._RKIND
+        nifa_max = maxval(nifa(:,1:nCellsSolve))
+        call mpas_dmpar_max_real(dminfo,nifa_max,global_nifa_max)
+
+        call mpas_log_write('--- global_nwfa_max = $r',realArgs=(/global_nwfa_max/))
+        call mpas_log_write('--- global_nifa_max = $r',realArgs=(/global_nifa_max/))
+
+        if (global_nwfa_max /= 0._RKIND .and. global_nifa_max /= 0._RKIND) then
+           call mpas_log_write('config_tempo_rap is true and non-zero global values found for nwfa and nifa')
+           call mpas_log_write('...aerosols from parent model (likely the RAP) will be used')
+           use_rap_aerosols = .true.
+        endif
+     endif
+
+   end function use_rap_aerosols
 
    !-----------------------------------------------------------------------
    !  routine init_microphysics_aerosols

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -9929,7 +9929,7 @@ call mpas_log_write('Done with soil consistency check')
         call mpas_pool_get_dimension(state, 'index_nwfa', index_nwfa)
         call mpas_pool_get_dimension(state, 'index_nifa', index_nifa)
 
-        if present(lbc_state) then
+        if (present(lbc_state)) then
            call mpas_log_write('Checking for aerosols from parent model in LBCs')
            call mpas_pool_get_array(lbc_state, 'lbc_scalars', scalars)
         else

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -316,7 +316,12 @@ module init_atm_cases
                                    diag, diag_physics, block_ptr % dimensions, block_ptr % configs)
 
             if (config_met_interp) then
-               call init_atm_thompson_aerosols(block_ptr, mesh, block_ptr % configs, diag, state)
+               rap_aerosols = use_rap_aerosols(block_ptr % configs, block_ptr, mesh, state)
+               if (rap_aerosols) then
+                  call mpas_log_write('Using interpolated aerosols from first guess for ICs. Skipping monthly climatolgy interpolation')
+               else
+                  call init_atm_thompson_aerosols(block_ptr, mesh, block_ptr % configs, diag, state)
+               endif
                call physics_initialize_real(mesh, fg, domain % dminfo, block_ptr % dimensions, block_ptr % configs)
             end if
 
@@ -404,7 +409,12 @@ module init_atm_cases
                                       diag, lbc_state, block_ptr % dimensions, block_ptr % configs)
 
                call mpas_get_time(start_time, dateTimeString=timeStart)
-               call init_atm_thompson_aerosols_lbc(timeString, timeStart, block_ptr, mesh, diag, state, lbc_state)
+               rap_aerosols = use_rap_aerosols(block_ptr % configs, block_ptr, mesh, state)
+               if (rap_aerosols) then
+                  call mpas_log_write('Using interpolated aerosols from first guess for LBCs. Skipping monthly climatolgy interpolation')
+               else
+                  call init_atm_thompson_aerosols_lbc(timeString, timeStart, block_ptr, mesh, diag, state, lbc_state)
+               endif
                block_ptr => block_ptr % next
             end do
 

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -7497,20 +7497,20 @@ call mpas_log_write('Done with soil consistency check')
       call mpas_pool_get_dimension(dims, 'nCellsSolve', nCellsSolve)
       nVertLevelsP1 = nVertLevels + 1
 
-      call mpas_pool_get_dimension(state, 'index_qv', index_qv)
+      call mpas_pool_get_dimension(lbc_state, 'index_lbc_qv', index_qv)
 
-      call mpas_pool_get_dimension(state, 'index_nwfa', index_nwfa)
-      call mpas_pool_get_dimension(state, 'index_nifa', index_nifa)
-      call mpas_pool_get_dimension(state, 'index_qc', index_qc)
-      call mpas_pool_get_dimension(state, 'index_qi', index_qi)
-      call mpas_pool_get_dimension(state, 'index_qs', index_qs)
-      call mpas_pool_get_dimension(state, 'index_qg', index_qg)
-      call mpas_pool_get_dimension(state, 'index_qr', index_qr)
-      call mpas_pool_get_dimension(state, 'index_nc', index_nc)
-      call mpas_pool_get_dimension(state, 'index_ni', index_ni)
-      call mpas_pool_get_dimension(state, 'index_nr', index_nr)
-      call mpas_pool_get_dimension(state, 'index_ns', index_ns)
-      call mpas_pool_get_dimension(state, 'index_ng', index_ng)
+      call mpas_pool_get_dimension(lbc_state, 'index_lbc_nwfa', index_nwfa)
+      call mpas_pool_get_dimension(lbc_state, 'index_lbc_nifa', index_nifa)
+      call mpas_pool_get_dimension(lbc_state, 'index_lbc_qc', index_qc)
+      call mpas_pool_get_dimension(lbc_state, 'index_lbc_qi', index_qi)
+      call mpas_pool_get_dimension(lbc_state, 'index_lbc_qs', index_qs)
+      call mpas_pool_get_dimension(lbc_state, 'index_lbc_qg', index_qg)
+      call mpas_pool_get_dimension(lbc_state, 'index_lbc_qr', index_qr)
+      call mpas_pool_get_dimension(lbc_state, 'index_lbc_nc', index_nc)
+      call mpas_pool_get_dimension(lbc_state, 'index_lbc_ni', index_ni)
+      call mpas_pool_get_dimension(lbc_state, 'index_lbc_nr', index_nr)
+      call mpas_pool_get_dimension(lbc_state, 'index_lbc_ns', index_ns)
+      call mpas_pool_get_dimension(lbc_state, 'index_lbc_ng', index_ng)
 
       etavs = (1.0_RKIND - 0.252_RKIND) * pii / 2.0_RKIND
       rcv = rgas / (cp - rgas)
@@ -9926,14 +9926,16 @@ call mpas_log_write('Done with soil consistency check')
         return
      else
         call mpas_pool_get_dimension(mesh,'nCellsSolve',nCellsSolve)
-        call mpas_pool_get_dimension(state, 'index_nwfa', index_nwfa)
-        call mpas_pool_get_dimension(state, 'index_nifa', index_nifa)
 
         if (present(lbc_state)) then
            call mpas_log_write('Checking for aerosols from parent model in LBCs')
+           call mpas_pool_get_dimension(lbc_state, 'index_lbc_nwfa', index_nwfa)
+           call mpas_pool_get_dimension(lbc_state, 'index_lbc_nifa', index_nifa)
            call mpas_pool_get_array(lbc_state, 'lbc_scalars', scalars)
         else
            call mpas_log_write('Checking for aerosols from parent model in ICs')
+           call mpas_pool_get_dimension(state, 'index_nwfa', index_nwfa)
+           call mpas_pool_get_dimension(state, 'index_nifa', index_nifa)
            call mpas_pool_get_array(state, 'scalars', scalars)
         endif
 

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -409,7 +409,7 @@ module init_atm_cases
                                       diag, lbc_state, block_ptr % dimensions, block_ptr % configs)
 
                call mpas_get_time(start_time, dateTimeString=timeStart)
-               rap_aerosols = use_rap_aerosols(block_ptr % configs, block_ptr, mesh, state)
+               rap_aerosols = use_rap_aerosols(block_ptr % configs, block_ptr, mesh, state, lbc_state)
                if (rap_aerosols) then
                   call mpas_log_write('Using interpolated aerosols from first guess for LBCs. Skipping monthly climatolgy interpolation')
                else
@@ -9894,13 +9894,14 @@ call mpas_log_write('Done with soil consistency check')
    !>  values of nwfa and nifa that are non-zero.
    !
    !-----------------------------------------------------------------------
-   logical function use_rap_aerosols(configs, block, mesh, state)
+   logical function use_rap_aerosols(configs, block, mesh, state, lbc_state)
 
      implicit none
 
      type(block_type), intent(in), target :: block
      type (mpas_pool_type), intent(in):: mesh
      type (mpas_pool_type), intent(in):: state
+     type (mpas_pool_type), intent(in), optional :: lbc_state
      type (mpas_pool_type), intent(in):: configs
 
      type(dm_info), pointer:: dminfo
@@ -9927,7 +9928,14 @@ call mpas_log_write('Done with soil consistency check')
         call mpas_pool_get_dimension(mesh,'nCellsSolve',nCellsSolve)
         call mpas_pool_get_dimension(state, 'index_nwfa', index_nwfa)
         call mpas_pool_get_dimension(state, 'index_nifa', index_nifa)
-        call mpas_pool_get_array(state, 'scalars', scalars)
+
+        if present(lbc_state) then
+           call mpas_log_write('Checking for aerosols from parent model in LBCs')
+           call mpas_pool_get_array(lbc_state, 'lbc_scalars', scalars)
+        else
+           call mpas_log_write('Checking for aerosols from parent model in ICs')
+           call mpas_pool_get_array(state, 'scalars', scalars)
+        endif
 
         nifa => scalars(index_nifa,:,:)
         nwfa => scalars(index_nwfa,:,:)

--- a/src/core_init_atmosphere/mpas_init_atm_core_interface.F
+++ b/src/core_init_atmosphere/mpas_init_atm_core_interface.F
@@ -121,6 +121,7 @@ module init_atm_core_interface
       logical, pointer :: config_native_gwd_gsl_static
       logical, pointer :: first_guess_field
       logical, pointer :: mp_thompson_aers_in
+      logical, pointer :: tempo_aerosolaware_in
       integer, pointer :: config_init_case
 
 
@@ -169,6 +170,9 @@ module init_atm_core_interface
       nullify(mp_thompson_aers_in)
       call mpas_pool_get_package(packages, 'mp_thompson_aers_inActive', mp_thompson_aers_in)
 
+      nullify(tempo_aerosolaware_in)
+      call mpas_pool_get_package(packages, 'tempo_aerosolaware_inActive', tempo_aerosolaware_in)
+
       if (.not. associated(initial_conds) .or. &
           .not. associated(sfc_update) .or. &
           .not. associated(gwd_stage_in) .or. &
@@ -179,6 +183,7 @@ module init_atm_core_interface
           .not. associated(vertical_stage_out) .or. &
           .not. associated(met_stage_in) .or. &
           .not. associated(met_stage_out) .or. &
+          .not. associated(tempo_aerosolaware_in) .or. &
           .not. associated(mp_thompson_aers_in)) then
          call mpas_log_write('********************************************************************************', messageType=MPAS_LOG_ERR)
          call mpas_log_write('* Error while setting up packages for init_atmosphere core.',                      messageType=MPAS_LOG_ERR)
@@ -197,11 +202,13 @@ module init_atm_core_interface
 
       if (config_init_case == 9) then
          lbcs = .true.
+         tempo_aerosolaware_in = .true.
          mp_thompson_aers_in = .false.
          inquire(file="QNWFA_QNIFA_SIGMA_MONTHLY.dat",exist=lexist)
          if(lexist) mp_thompson_aers_in = .true.
       else
          lbcs = .false.
+         tempo_aerosolaware_in = .false.
          mp_thompson_aers_in = .false.
       end if
 
@@ -228,9 +235,11 @@ module init_atm_core_interface
                         (.not. config_vertical_grid)
          met_stage_out = config_met_interp
 
+         tempo_aerosolaware_in = .false.
          mp_thompson_aers_in = .false.
          inquire(file="QNWFA_QNIFA_SIGMA_MONTHLY.dat",exist=lexist)
          if((lexist .and. met_stage_out) .or. (lexist .and. met_stage_in)) mp_thompson_aers_in = .true.
+         if((met_stage_out) .or. (met_stage_in)) tempo_aerosolaware_in = .true.
 
       else if (config_init_case == 8) then
          gwd_stage_in = .false.
@@ -256,9 +265,11 @@ module init_atm_core_interface
          met_stage_in = .true.
          met_stage_out = .true.
 
+         tempo_aerosolaware_in = .false.
          mp_thompson_aers_in = .false.
          inquire(file="QNWFA_QNIFA_SIGMA_MONTHLY.dat",exist=lexist)
          if((lexist .and. met_stage_out) .or. (lexist .and. met_stage_in)) mp_thompson_aers_in = .true.
+         if((met_stage_out) .or. (met_stage_in)) tempo_aerosolaware_in = .true.
 
          initial_conds = .false.   ! Also, turn off the initial_conds package to avoid writing the IC "output" stream
 

--- a/src/core_init_atmosphere/mpas_init_atm_thompson_aerosols.F
+++ b/src/core_init_atmosphere/mpas_init_atm_thompson_aerosols.F
@@ -771,8 +771,8 @@
  call mpas_pool_get_dimension(mesh,'nVertLevels'  ,nVertLevels  )
  call mpas_pool_get_dimension(mesh,'nMonths'      ,nMonths      )
 
- call mpas_pool_get_dimension(state,'index_nifa',index_nifa)
- call mpas_pool_get_dimension(state,'index_nwfa',index_nwfa)
+ call mpas_pool_get_dimension(lbc_state,'index_lbc_nifa',index_nifa)
+ call mpas_pool_get_dimension(lbc_state,'index_lbc_nwfa',index_nwfa)
 
  call mpas_pool_get_array(diag,'pressure_base',pressure)
 


### PR DESCRIPTION
This PR fixes issue where initial water- and ice-friendly aerosol values from the RAP model are being overwritten by the monthly climatology. This PR adds logic to allow users to use either initial aerosols from a first guess model field if they exist or values from a monthly climatology.

To use RAP aerosol initial conditions, set `config_tempo_rap = .true.` in preproc_stages. If first guess values do not exist (global max values of zero), then the monthly climatology will be used as a backup. 

