### PR TITLE
A new scale-aware approach for GF convection with subsidence spreading

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -429,6 +429,7 @@
                 <package name="ugwp_orog_stream" description="Input stream (and variables) for UGWP orography"/>
                 <package name="ugwp_ngw_stream"  description="Input stream (and variables) for UGWP NGW lookup table"/>
                 <package name="ugwp_diags_stream" description="Output stream (and variables) for UGWP output diagnostics"/>
+		<package name="gf_sub3d" description="GF 3d lateral spreading of the env subsidence"/>
         </packages>
 
 
@@ -872,6 +873,12 @@
 			<var name="rnwfablten"/>
 			<var name="rthratensw"/>
 			<var name="rthratenlw"/>
+			<var name="vcpool" packages="cu_grell_freitas_in"/>
+                        <var name="sub3d_rthcuten" packages="cu_grell_freitas_in"/>
+                        <var name="sub3d_rqvcuten" packages="cu_grell_freitas_in"/>
+                        <var name="sub3d_rucuten" packages="cu_grell_freitas_in"/>
+                        <var name="sub3d_rvcuten" packages="cu_grell_freitas_in"/>
+                        <var name="sigma_deep" packages="cu_grell_freitas_in"/>
 			<var name="isltyp"/>
 			<var name="soilf"/>
 			<var name="ivgtyp"/>
@@ -1138,6 +1145,7 @@
                         <var name="swupt"/>
 			<var name="rainc"/>
 			<var name="rainnc"/>
+			<var name="vcpool"/>
 			<var name="refl10cm"/>
 			<var name="refl10cm_max"/>
 			<var name="refl10cm_1km"/>
@@ -1471,6 +1479,9 @@
                 <var name="nEdgesOnCell" type="integer" dimensions="nCells" units="-"
                      description="Number of edges forming the boundary of a cell"/>
 
+	        <var name="nCellsOnCellsOnCell" type="integer" dimensions="nCells" units="-"
+                     description="Number of cells that are outer neighbors of CellsOnCell"/>
+
                 <var name="nEdgesOnEdge" type="integer" dimensions="nEdges" units="-"
                      description="Number of edges involved in reconstruction of tangential velocity for an edge"/>
 
@@ -1521,6 +1532,9 @@
 
                 <var name="cellsOnCell" type="integer" dimensions="maxEdges nCells" units="-"
                      description="IDs of cells neighboring a cell"/>
+
+	        <var name="cellsOnCellsOnCell" type="integer" dimensions="maxEdges2 nCells" units="-"
+                     description="IDs of outer neighbors of cellsOnCell"/>
 
                 <var name="verticesOnCell" type="integer" dimensions="maxEdges nCells" units="-"
                      description="IDs of vertices (corner points) of a cell"/>
@@ -2484,6 +2498,11 @@
                      description="configuration for convection schemes"
                      possible_values="`suite',`cu_kain_fritsch',`cu_tiedtke',`cu_ntiedtke',`cu_grell_freitas',`off'"/>
 
+	        <nml_option name="config_gf_sub3d" type="integer" default_value="0" in_defaults="false"
+                     units="-"
+                     description="Option for the lateral subsidence spread for the Grell-Freitas scheme"
+                     possible_values="0,1,2"/>
+
                 <nml_option name="config_lsm_scheme" type="character" default_value="suite" in_defaults="false"
                      units="-"
                      description="configuration for land-surface schemes"
@@ -2869,6 +2888,14 @@
 
 	       <var name="refl10cm_cu" type="real" dimensions="nVertLevels nCells Time" units="dBZ"
                      description="10 cm radar reflectivity in the Grell-Freitas cloud model"
+                     packages="cu_grell_freitas_in"/>
+
+	       <var name="vcpool" type="real" dimensions="nCells Time" units="m s^{-1}"
+                     description="Cold pool gust front horizontal speed "
+                     packages="cu_grell_freitas_in"/>
+
+               <var name="sigma_deep" type="real" dimensions="nCells Time" units="-"
+                     description="scale-aware parameter for deep convection"
                      packages="cu_grell_freitas_in"/>
 
 
@@ -3915,6 +3942,23 @@
 
 	        <!-- MGD should we add packages to the field below? -->
 	        <var name="rucuten_Edge" type="real"     dimensions="nVertLevels nEdges Time"/>
+
+		<!-- GRELL FREITAS LI -->
+                <var name="sub3d_rthcuten" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+                     description="tendency of potential temperature due to the subsidence created by cumulus convection"
+                     packages="cu_grell_freitas_in;gf_sub3d"/>
+
+                <var name="sub3d_rqvcuten" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
+                     description="tendency of water vapor mixing ratio due to the subsidence created by cumulus convection"
+                     packages="cu_grell_freitas_in;gf_sub3d"/>
+
+                <var name="sub3d_rucuten" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1} s^{-1}"
+                     description="tendency of zonal wind due to the subsidence created by cumulus convection"
+                     packages="cu_grell_freitas_in;gf_sub3d"/>
+
+                <var name="sub3d_rvcuten" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1} s^{-1}"
+                     description="tendency of meridional wind due to the subsidence created by cumulus convection"
+                     packages="cu_grell_freitas_in;gf_sub3d"/>
 
 
                 <!-- ================================================================================================== -->

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -572,6 +572,8 @@ module atm_core
 
       call atm_compute_damping_coefs(mesh, block % configs)
 
+      call atm_compute_cellsOnCellsOnCell(mesh, block % configs)
+
       !
       ! Set up mask fields used in limited-area simulations
       !
@@ -1003,7 +1005,7 @@ module atm_core
       !proceed with physics if moist_physics is set to true:
       if(moist_physics) then
          call physics_timetracker(domain,dt,clock,itimestep,xtime_s)
-         call physics_driver(domain,itimestep,xtime_s)
+         call physics_driver(domain,itimestep,xtime_s,exchange_halo_group)
       endif
 #endif
 
@@ -1439,6 +1441,110 @@ module atm_core
 
    end subroutine atm_couple_coef_3rd_order
 
+   subroutine atm_compute_cellsOnCellsOnCell(mesh, configs)
+
+      implicit none
+
+      type (mpas_pool_type), intent(inout) :: mesh
+      type (mpas_pool_type), intent(in) :: configs
+
+      integer, pointer :: nCells, nCellsSolve, maxEdges, maxEdges2
+      integer, dimension(:), pointer :: nEdgesOnCell, nCellsOnCellsOnCell
+      integer, dimension(:,:), pointer :: cellsOnCell, cellsOnCellsOnCell
+
+      real (kind=RKIND), dimension(:), pointer :: xCell, yCell, zCell
+
+      integer :: iCell, jCell, candidate, i, j, k
+      logical :: isNeighbor
+      integer :: cellGroup(50), nCellsGroup, nOuterRow, nInnerRow
+      real (kind=RKIND) :: dc
+
+      logical, parameter :: debug_print = .false.
+
+      call mpas_pool_get_array(mesh, 'nEdgesOnCell', nEdgesOnCell)
+      call mpas_pool_get_array(mesh, 'nCellsOnCellsOnCell',nCellsOnCellsOnCell)
+      call mpas_pool_get_array(mesh, 'cellsOnCell', cellsOnCell)
+      call mpas_pool_get_array(mesh, 'cellsOnCellsOnCell',cellsOnCellsOnCell)
+
+      call mpas_pool_get_array(mesh, 'xCell',xCell)
+      call mpas_pool_get_array(mesh, 'yCell',yCell)
+      call mpas_pool_get_array(mesh, 'zCell',zCell)
+
+      call mpas_pool_get_dimension(mesh, 'nCells', nCells)
+      call mpas_pool_get_dimension(mesh, 'nCellsSolve', nCellsSolve)
+      call mpas_pool_get_dimension(mesh, 'maxEdges',maxEdges)
+      call mpas_pool_get_dimension(mesh, 'maxEdges2',maxEdges2)
+
+      if(debug_print) then
+         call mpas_log_write('computing cellsOnCellsOnCell')
+         call mpas_log_write('nCells, nCellsSolve $i $i ',intArgs=(/nCells, nCellsSolve/))
+      end if
+
+      do iCell = 1, nCellsSolve  ! for each owned cell
+
+         cellGroup(:) = 0
+         nCellsGroup = 1 + nEdgesOnCell(iCell)
+         nInnerRow = nCellsGroup
+         cellGroup(1) = iCell
+         cellGroup(2:nCellsGroup) = cellsOnCell(1:nCellsGroup-1,iCell)
+
+         ! here cellGroup is a list of cells including iCell and its neighbors.
+         ! we'll add the neighbors of the neighbors next
+
+         do i = 1, nEdgesOnCell(iCell)
+
+            jCell = cellsOnCell(i,iCell)
+            do j=1,nEdgesOnCell(jCell)
+
+               candidate = cellsOnCell(j,jCell)
+               isNeighbor = .true.
+
+               do k=1,nCellsGroup
+                if(cellGroup(k) .eq. candidate) isNeighbor = .false.
+               end do
+               if(isNeighbor) then
+                  cellGroup(nCellsGroup+1) = candidate
+                  nCellsGroup = nCellsGroup +1
+               end if
+            end do
+         end do
+
+         nOuterRow = nCellsGroup - nInnerRow
+
+         if (nOuterRow .gt. maxEdges2) then
+            call mpas_log_write('MaxEdges2 < nOuterRow in CellsOnCellsOnCell ', messageType=MPAS_LOG_ERR)
+            call mpas_log_write('MaxEdges2 = $i', intArgs=(/MaxEdges2/), messageType=MPAS_LOG_ERR)
+            call mpas_log_write('nOuterRow = $i', intArgs=(/nOuterRow/), messageType=MPAS_LOG_ERR)
+            call mpas_log_write('Critical Error', messageType=MPAS_LOG_CRIT)
+         end if
+
+         do i=1,nOuterRow
+            cellsOnCellsOnCell(i,iCell) = cellGroup(i+nInnerRow)
+         end do
+
+         nCellsOnCellsOnCell(iCell) = nOuterRow
+
+         if(debug_print .and. (iCell .lt. 10)) then
+            call mpas_log_write('cellsOnCell for cell  $i $i', intArgs=(/iCell,nEdgesOnCell(iCell)/))
+            call mpas_log_write('cellsOnCell, $i $i $i $i $i $i', \
+              intArgs=(/cellsOnCell(1,iCell),cellsOnCell(2,iCell),cellsOnCell(3,iCell),cellsOnCell(4,iCell),cellsOnCell(5,iCell),cellsOnCell(6,iCell)/))
+            call mpas_log_write('cellsOnCellsOnCell for cell  $i $i', intArgs=(/iCell,nOuterRow/))
+            call mpas_log_write('cells, $i $i $i $i $i $i', \
+            intArgs=(/cellsOnCellsOnCell(1,iCell),cellsOnCellsOnCell(2,iCell),cellsOnCellsOnCell(3,iCell), \
+                      cellsOnCellsOnCell(4,iCell),cellsOnCellsOnCell(5,iCell),cellsOnCellsOnCell(6,iCell)/))
+            call mpas_log_write('cells, $i $i $i $i $i $i', \
+                       intArgs=(/cellsOnCellsOnCell(7,iCell),cellsOnCellsOnCell(8,iCell),cellsOnCellsOnCell(9,iCell), \
+                       cellsOnCellsOnCell(10,iCell),cellsOnCellsOnCell(11,iCell),cellsOnCellsOnCell(12,iCell)/))
+            do i=1, nOuterRow
+               jCell = cellsOnCellsOnCell(i,iCell)
+               dc = sqrt((xCell(iCell)-xCell(jCell))**2 + (yCell(iCell)-yCell(jCell))**2 + (zCell(iCell)-zCell(jCell))**2)
+               call mpas_log_write('distance $i $i $r',intArgs=(/iCell,jCell/),realArgs=(/dc/))
+            end do
+       end if
+
+    end do
+
+   end subroutine atm_compute_cellsOnCellsOnCell
 
    !-----------------------------------------------------------------------
    !  routine mpas_atm_run_compatibility

--- a/src/core_atmosphere/mpas_atm_halos.F
+++ b/src/core_atmosphere/mpas_atm_halos.F
@@ -26,6 +26,7 @@ module mpas_atm_halos
       end subroutine halo_exchange_routine
    end interface
 
+   character(len=StrKIND), pointer, private :: config_halo_exch_method
    procedure (halo_exchange_routine), pointer :: exchange_halo_group
 
 
@@ -177,6 +178,13 @@ module mpas_atm_halos
          call mpas_dmpar_exch_group_create(domain, 'physics:cuten')
          call mpas_dmpar_exch_group_add_field(domain, 'physics:cuten', 'rucuten', timeLevel=1, haloLayers=(/1,2/))
          call mpas_dmpar_exch_group_add_field(domain, 'physics:cuten', 'rvcuten', timeLevel=1, haloLayers=(/1,2/))
+         call mpas_dmpar_exch_group_create(domain, 'physics:sub3d_cuten')
+         call mpas_dmpar_exch_group_add_field(domain, 'physics:sub3d_cuten', 'sigma_deep'   ,  timeLevel=1, haloLayers=(/1/))
+         call mpas_dmpar_exch_group_add_field(domain, 'physics:sub3d_cuten', 'sub3d_rucuten',  timeLevel=1, haloLayers=(/1/))
+         call mpas_dmpar_exch_group_add_field(domain, 'physics:sub3d_cuten', 'sub3d_rvcuten',  timeLevel=1, haloLayers=(/1/))
+         call mpas_dmpar_exch_group_add_field(domain, 'physics:sub3d_cuten', 'sub3d_rthcuten', timeLevel=1, haloLayers=(/1/))
+         call mpas_dmpar_exch_group_add_field(domain, 'physics:sub3d_cuten', 'sub3d_rqvcuten', timeLevel=1, haloLayers=(/1/))
+         !-srf
 #endif
 
          !
@@ -310,6 +318,13 @@ module mpas_atm_halos
          call mpas_halo_exch_group_add_field(domain, 'physics:cuten', 'rucuten', timeLevel=1, haloLayers=(/1,2/))
          call mpas_halo_exch_group_add_field(domain, 'physics:cuten', 'rvcuten', timeLevel=1, haloLayers=(/1,2/))
          call mpas_halo_exch_group_complete(domain, 'physics:cuten')
+         call mpas_halo_exch_group_create(domain, 'physics:sub3d_cuten')
+         call mpas_halo_exch_group_add_field(domain, 'physics:sub3d_cuten', 'sigma_deep'   ,  timeLevel=1, haloLayers=(/1/))
+         call mpas_halo_exch_group_add_field(domain, 'physics:sub3d_cuten', 'sub3d_rucuten',  timeLevel=1, haloLayers=(/1/))
+         call mpas_halo_exch_group_add_field(domain, 'physics:sub3d_cuten', 'sub3d_rvcuten',  timeLevel=1, haloLayers=(/1/))
+         call mpas_halo_exch_group_add_field(domain, 'physics:sub3d_cuten', 'sub3d_rthcuten', timeLevel=1, haloLayers=(/1/))
+         call mpas_halo_exch_group_add_field(domain, 'physics:sub3d_cuten', 'sub3d_rqvcuten', timeLevel=1, haloLayers=(/1/))
+         call mpas_halo_exch_group_complete(domain, 'physics:sub3d_cuten')
 #endif
 
          !
@@ -397,6 +412,7 @@ module mpas_atm_halos
          !
          call mpas_dmpar_exch_group_destroy(domain, 'physics:blten')
          call mpas_dmpar_exch_group_destroy(domain, 'physics:cuten')
+         call mpas_dmpar_exch_group_destroy(domain, 'physics:sub3d_cuten')
 #endif
 
       else if (trim(config_halo_exch_method) == 'mpas_halo') then
@@ -433,6 +449,8 @@ module mpas_atm_halos
          !
          call mpas_halo_exch_group_destroy(domain, 'physics:blten')
          call mpas_halo_exch_group_destroy(domain, 'physics:cuten')
+         !srf
+         call mpas_halo_exch_group_destroy(domain, 'physics:sub3d_cuten')
 #endif
 
          call mpas_halo_finalize(domain)

--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -31,6 +31,21 @@
  private
  public:: physics_driver
 
+ !
+ ! Abstract interface for routine used to communicate halos of fields
+ ! in a named group
+ !
+ abstract interface
+      subroutine halo_exchange_routine(domain, halo_group, ierr)
+
+         use mpas_derived_types, only : domain_type
+
+         type (domain_type), intent(inout) :: domain
+         character(len=*), intent(in) :: halo_group
+         integer, intent(out), optional :: ierr
+
+      end subroutine halo_exchange_routine
+ end interface
 
 !MPAS top physics driver.
 !Laura D. Fowler (send comments to laura@ucar.edu).
@@ -107,12 +122,13 @@
 
 
 !=================================================================================================================
- subroutine physics_driver(domain,itimestep,xtime_s)
+ subroutine physics_driver(domain,itimestep,xtime_s,exchange_halo_group)
 !=================================================================================================================
 
 !input arguments:
  integer,intent(in):: itimestep
  real(kind=RKIND),intent(in):: xtime_s
+ procedure (halo_exchange_routine) :: exchange_halo_group
 
 !inout arguments:
  type(domain_type),intent(inout):: domain
@@ -342,8 +358,8 @@
        call allocate_convection(block%configs)
 !$OMP PARALLEL DO
        do thread=1,nThreads
-          call driver_convection(itimestep,block%configs,mesh,sfc_input,diag_physics,tend_physics, &
-                                 cellSolveThreadStart(thread),cellSolveThreadEnd(thread))
+          call driver_convection(itimestep,block%configs,mesh,sfc_input,diag_physics,tend_physics,diag,domain%dminfo, &
+                                 cellSolveThreadStart(thread),cellSolveThreadEnd(thread),exchange_halo_group,block)
        end do
 !$OMP END PARALLEL DO
        call deallocate_convection(block%configs)

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_convection.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_convection.F
@@ -24,7 +24,14 @@
  use mpas_dmpar, only : IO_NODE
 
  implicit none
- !--srf
+ private
+ public:: allocate_convection,     &
+          deallocate_convection,   &
+          init_convection,         &
+          driver_convection,       &
+          update_convection_step1, &
+          update_convection_step2
+ !
  ! Abstract interface for routine used to communicate halos of fields
  ! in a named group
  !
@@ -39,14 +46,6 @@
 
       end subroutine halo_exchange_routine
  end interface
- !--srf
- private
- public:: allocate_convection,     &
-          deallocate_convection,   &
-          init_convection,         &
-          driver_convection,       &
-          update_convection_step1, &
-          update_convection_step2
 
 
 !MPAS driver for parameterization of convection.

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_convection.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_convection.F
@@ -733,9 +733,10 @@
  integer,dimension(:),pointer:: kpbl,k22_shallow,kbcon_shallow,ktop_shallow,ktop_deep
  integer,dimension(:),pointer:: bdyMaskCell
  real(kind=RKIND),dimension(:),pointer  :: areaCell,meshDensity
- real(kind=RKIND),dimension(:),pointer  :: nca,cubot,cutop,cuprec,rainncv,raincv,vcpool
+ real(kind=RKIND),dimension(:),pointer  :: nca,cubot,cutop,cuprec,raincv
+ real(kind=RKIND),dimension(:),pointer  :: rainncv,vcpool,sigma_deep
  real(kind=RKIND),dimension(:),pointer  :: gsw,hfx,qfx,xland
- real(kind=RKIND),dimension(:),pointer  :: xmb_total,xmb_shallow,sigma_deep
+ real(kind=RKIND),dimension(:),pointer  :: xmb_total,xmb_shallow
  real(kind=RKIND),dimension(:,:),pointer:: zgrid
  real(kind=RKIND),dimension(:,:),pointer:: qc_cu,qi_cu
  real(kind=RKIND),dimension(:,:),pointer:: w0avg
@@ -985,12 +986,14 @@
  type(mpas_pool_type),intent(inout):: tend_physics
 
 !local variables:
- integer:: i,k,j,iCell,ineighbour
+ integer:: i,k,j
+ integer:: iCell,ineighbor
 
 !local pointers:
  character(len=StrKIND),pointer:: convection_scheme
  integer,dimension(:),pointer:: k22_shallow,kbcon_shallow,ktop_shallow,ktop_deep
- real(kind=RKIND),dimension(:),pointer  :: nca,cubot,cutop,cuprec,rainncv,raincv,vcpool,sigma_deep
+ real(kind=RKIND),dimension(:),pointer  :: nca,cubot,cutop,cuprec,raincv
+ real(kind=RKIND),dimension(:),pointer  :: rainncv,vcpool,sigma_deep
  real(kind=RKIND),dimension(:),pointer  :: xmb_total,xmb_shallow
  real(kind=RKIND),dimension(:,:),pointer:: qc_cu,qi_cu
  real(kind=RKIND),dimension(:,:),pointer:: w0avg
@@ -1116,21 +1119,21 @@
                  rucuten(k,iCell)  = rucuten(k,iCell)  + sigma_deep(iCell) * sub3d_rucuten(k,iCell)
                  rvcuten(k,iCell)  = rvcuten(k,iCell)  + sigma_deep(iCell) * sub3d_rvcuten(k,iCell)
                  do i = 1, nEdgesOnCell(iCell)
-                   ineighbour = cellsOnCell(i,iCell)
+                   ineighbor = cellsOnCell(i,iCell)
                    ! do not do this if there is no convection in that neighbour cell!
-                   if(sigma_deep(ineighbour) == 0.)cycle
+                   if(sigma_deep(ineighbor) == 0.)cycle
                    rthcuten(k,iCell) = rthcuten(k,iCell) + &
-                                       (1._RKIND - sigma_deep(ineighbour))*sub3d_rthcuten(k,ineighbour)/ &
-                                       real(nEdgesOnCell(ineighbour),RKIND)
+                                       (1._RKIND - sigma_deep(ineighbor))*sub3d_rthcuten(k,ineighbor)/ &
+                                       real(nEdgesOnCell(ineighbor),RKIND)
                    rqvcuten(k,iCell) = rqvcuten(k,iCell) + &
-                                       (1._RKIND - sigma_deep(ineighbour))*sub3d_rqvcuten(k,ineighbour)/ &
-                                       real(nEdgesOnCell(ineighbour),RKIND)
+                                       (1._RKIND - sigma_deep(ineighbor))*sub3d_rqvcuten(k,ineighbor)/ &
+                                       real(nEdgesOnCell(ineighbor),RKIND)
                    rucuten(k,iCell) = rucuten(k,iCell) + &
-                                       (1._RKIND - sigma_deep(ineighbour))*sub3d_rucuten(k,ineighbour)/ &
-                                       real(nEdgesOnCell(ineighbour),RKIND)
+                                       (1._RKIND - sigma_deep(ineighbor))*sub3d_rucuten(k,ineighbor)/ &
+                                       real(nEdgesOnCell(ineighbor),RKIND)
                    rvcuten(k,iCell) = rvcuten(k,iCell) + &
-                                       (1._RKIND - sigma_deep(ineighbour))*sub3d_rvcuten(k,ineighbour)/ &
-                                       real(nEdgesOnCell(ineighbour),RKIND)
+                                       (1._RKIND - sigma_deep(ineighbor))*sub3d_rvcuten(k,ineighbor)/ &
+                                       real(nEdgesOnCell(ineighbor),RKIND)
                  enddo
               enddo
             enddo

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_convection.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_convection.F
@@ -20,8 +20,26 @@
  use module_cu_kfeta
  use module_cu_tiedtke
  use module_cu_ntiedtke,only: cu_ntiedtke_driver
+ use mpas_atm_dimensions, only : nVertLevels
+ use mpas_dmpar, only : IO_NODE
 
  implicit none
+ !--srf
+ ! Abstract interface for routine used to communicate halos of fields
+ ! in a named group
+ !
+ abstract interface
+      subroutine halo_exchange_routine(domain, halo_group, ierr)
+
+         use mpas_derived_types, only : domain_type
+
+         type (domain_type), intent(inout) :: domain
+         character(len=*), intent(in) :: halo_group
+         integer, intent(out), optional :: ierr
+
+      end subroutine halo_exchange_routine
+ end interface
+ !--srf
  private
  public:: allocate_convection,     &
           deallocate_convection,   &
@@ -109,6 +127,7 @@
 !local variables and pointers:
  character(len=StrKIND),pointer:: convection_scheme
 
+ integer,pointer:: config_gf_sub3d
  integer:: i,k,j
 
 !-----------------------------------------------------------------------------------------------------------------
@@ -122,6 +141,7 @@
  if(.not.allocated(rqicuten_p) ) allocate(rqicuten_p(ims:ime,kms:kme,jms:jme))
  if(.not.allocated(pratec_p)   ) allocate(pratec_p(ims:ime,jms:jme)          )
  if(.not.allocated(raincv_p)   ) allocate(raincv_p(ims:ime,jms:jme)          )
+ if(.not.allocated(rainncv_p)  ) allocate(rainncv_p(ims:ime,jms:jme)         )
 
  do i = its,ite
  do j = jts,jte
@@ -154,6 +174,7 @@
        if(.not.allocated(kbot_shallow_p) ) allocate(kbot_shallow_p(ims:ime,jms:jme)     )
        if(.not.allocated(ktop_deep_p)    ) allocate(ktop_deep_p(ims:ime,jms:jme)        )
 
+       if(.not.allocated(bilbc_p)        ) allocate(bilbc_p(ims:ime,jms:jme)            )
        if(.not.allocated(dx_p)           ) allocate(dx_p(ims:ime,jms:jme)               )
        if(.not.allocated(area_p)         ) allocate(area_p(ims:ime,jms:jme)             )
        if(.not.allocated(gsw_p)          ) allocate(gsw_p(ims:ime,jms:jme)              )
@@ -161,6 +182,8 @@
        if(.not.allocated(qfx_p)          ) allocate(qfx_p(ims:ime,jms:jme)              )
        if(.not.allocated(maxmfbl_p)      ) allocate(maxmfbl_p(ims:ime,jms:jme)          )
        if(.not.allocated(xland_p)        ) allocate(xland_p(ims:ime,jms:jme)            )
+
+       if(.not.allocated(sigma_deep_p)   ) allocate(sigma_deep_p(ims:ime,jms:jme)       )
 
        if(.not.allocated(rthblten_p)     ) allocate(rthblten_p(ims:ime,kms:kme,jms:jme) )
        if(.not.allocated(rthdynten_p)    ) allocate(rthdynten_p(ims:ime,kms:kme,jms:jme))
@@ -176,8 +199,37 @@
        if(.not.allocated(qccu_p)         ) allocate(qccu_p(ims:ime,kms:kme,jms:jme)     )
        if(.not.allocated(qicu_p)         ) allocate(qicu_p(ims:ime,kms:kme,jms:jme)     )
 
+       if(.not.allocated(vcpool_p)       ) allocate(vcpool_p(ims:ime,jms:jme)           )
        if(.not.allocated(cldfrac_cu_p)   ) allocate(cldfrac_cu_p(ims:ime,kms:kme,jms:jme))
        if(.not.allocated(refl10cm_cu_p)  ) allocate(refl10cm_cu_p(ims:ime,kms:kme,jms:jme))
+
+       do i = its,ite
+       do j = jts,jte
+          sigma_deep_p(i,j) = 0._RKIND
+       enddo
+       enddo
+       call mpas_pool_get_config(configs,'config_gf_sub3d',config_gf_sub3d)
+!       if(config_gf_sub3d > 0) then
+            if(.not.allocated(sub3d_rthcuten_p)) allocate(sub3d_rthcuten_p(ims:ime,kms:kme,jms:jme)  )
+            if(.not.allocated(sub3d_rqvcuten_p)) allocate(sub3d_rqvcuten_p(ims:ime,kms:kme,jms:jme)  )
+            if(.not.allocated(sub3d_rucuten_p))  allocate(sub3d_rucuten_p (ims:ime,kms:kme,jms:jme)  )
+            if(.not.allocated(sub3d_rvcuten_p))  allocate(sub3d_rvcuten_p (ims:ime,kms:kme,jms:jme)  )
+            do i = its,ite
+            do k = kts,kte
+            do j = jts,jte
+               sub3d_rthcuten_p(i,k,j)  = 0._RKIND
+               sub3d_rqvcuten_p(i,k,j)  = 0._RKIND
+               sub3d_rucuten_p(i,k,j)   = 0._RKIND
+               sub3d_rvcuten_p(i,k,j)   = 0._RKIND
+            enddo
+            enddo
+            enddo
+!       else
+!            if(.not.allocated(sub3d_rthcuten_p)) allocate(sub3d_rthcuten_p(0,0,0)  )
+!            if(.not.allocated(sub3d_rqvcuten_p)) allocate(sub3d_rqvcuten_p(0,0,0)  )
+!            if(.not.allocated(sub3d_rucuten_p))  allocate(sub3d_rucuten_p (0,0,0)  )
+!            if(.not.allocated(sub3d_rvcuten_p))  allocate(sub3d_rvcuten_p (0,0,0)  )
+!       endif
 
     case ("cu_kain_fritsch")
        if(.not.allocated(dx_p)       ) allocate(dx_p(ims:ime,jms:jme)              )
@@ -289,6 +341,7 @@
  if(allocated(rqicuten_p) ) deallocate(rqicuten_p )
  if(allocated(pratec_p)   ) deallocate(pratec_p   )
  if(allocated(raincv_p)   ) deallocate(raincv_p   )
+ if(allocated(rainncv_p)  ) deallocate(rainncv_p  )
 
  convection_select: select case(convection_scheme)
 
@@ -303,6 +356,7 @@
        if(allocated(kbot_shallow_p) ) deallocate(kbot_shallow_p )
        if(allocated(ktop_deep_p)    ) deallocate(ktop_deep_p    )
 
+       if(allocated(bilbc_p)        ) deallocate(bilbc_p        )
        if(allocated(dx_p)           ) deallocate(dx_p           )
        if(allocated(area_p)         ) deallocate(area_p         )
        if(allocated(gsw_p)          ) deallocate(gsw_p          )
@@ -324,8 +378,14 @@
        if(allocated(qccu_p)         ) deallocate(qccu_p         )
        if(allocated(qicu_p)         ) deallocate(qicu_p         )
 
+       if(allocated(vcpool_p)       ) deallocate(vcpool_p       )
        if(allocated(cldfrac_cu_p)   ) deallocate(cldfrac_cu_p   )
        if(allocated(refl10cm_cu_p)  ) deallocate(refl10cm_cu_p  )
+       if(allocated(sigma_deep_p)   ) deallocate(sigma_deep_p   )
+       if(allocated(sub3d_rthcuten_p)) deallocate(sub3d_rthcuten_p)
+       if(allocated(sub3d_rqvcuten_p)) deallocate(sub3d_rqvcuten_p)
+       if(allocated(sub3d_rucuten_p) ) deallocate(sub3d_rucuten_p )
+       if(allocated(sub3d_rvcuten_p) ) deallocate(sub3d_rvcuten_p )
 
     case ("cu_kain_fritsch")
        if(allocated(dx_p)         ) deallocate(dx_p         )
@@ -366,12 +426,13 @@
  end subroutine deallocate_convection
 
 !=================================================================================================================
- subroutine init_convection(mesh,configs,diag_physics)
+ subroutine init_convection(dminfo,mesh,configs,diag_physics)
 !=================================================================================================================
 
 !input arguments:
  type(mpas_pool_type),intent(in):: mesh
  type(mpas_pool_type),intent(in):: configs
+ type(dm_info),intent(in):: dminfo
 
 !inout arguments:
  type(mpas_pool_type),intent(inout):: diag_physics
@@ -385,6 +446,10 @@
 
 !local variables:
  integer:: iCell
+
+ integer, pointer :: config_gf_sub3d
+ integer :: mynum, init_stat
+
 
 !-----------------------------------------------------------------------------------------------------------------
 
@@ -410,13 +475,18 @@
  end subroutine init_convection
 
 !=================================================================================================================
- subroutine driver_convection(itimestep,configs,mesh,sfc_input,diag_physics,tend_physics,its,ite)
+ subroutine driver_convection(itimestep,configs,mesh,sfc_input,diag_physics,tend_physics,diag,dminfo,its,ite &
+                             ,exchange_halo_group,block)
 !=================================================================================================================
 
 !input arguments:
  type(mpas_pool_type),intent(in):: configs
  type(mpas_pool_type),intent(in):: mesh
  type(mpas_pool_type),intent(in):: sfc_input
+ type(mpas_pool_type),intent(in):: diag
+ type(dm_info),intent(in):: dminfo
+ type(block_type), intent(in) :: block
+ procedure (halo_exchange_routine) :: exchange_halo_group
 
  integer,intent(in):: its,ite
  integer,intent(in):: itimestep
@@ -429,13 +499,13 @@
  logical:: log_convection
 
  integer:: i,j
- integer:: icount,initflag
+ integer:: icount,initflag,sub3d
 
  real(kind=RKIND):: dx
 
 !local pointers:
  logical,pointer:: config_do_restart
- integer,pointer:: gfconv_closure_deep,gfconv_closure_shallow
+ integer,pointer:: gfconv_closure_deep,gfconv_closure_shallow,config_gf_sub3d
  character(len=StrKIND),pointer:: convection_scheme
  character(len=StrKIND),pointer:: pbl_scheme
  real(kind=RKIND),pointer:: len_disp
@@ -460,15 +530,20 @@
  errflg = 0
 
  call mpas_pool_get_config(configs,'config_gfconv_closure_deep',gfconv_closure_deep)
+ call mpas_pool_get_config(configs,'config_gf_sub3d',config_gf_sub3d)
+ sub3d=0
+ if(config_gf_sub3d > 0)sub3d=1
  call mpas_pool_get_config(configs,'config_gfconv_closure_shallow',gfconv_closure_shallow)
  call mpas_pool_get_config(configs,'config_len_disp'         ,len_disp         )
  call mpas_pool_get_config(configs,'config_do_restart'       ,config_do_restart)
  call mpas_pool_get_config(configs,'config_convection_scheme',convection_scheme)
  call mpas_pool_get_config(configs,'config_pbl_scheme',pbl_scheme)
+!call mpas_pool_get_array(mesh, 'bdyMaskCell', bdyMaskCell)
+!call mpas_pool_get_array(mesh, 'specZoneMaskCell',specZoneMaskCell )
 
 !initialize instantaneous precipitation, and copy convective tendencies from the dynamics to
 !the physics grid:
- call convection_from_MPAS(dt_dyn,configs,mesh,sfc_input,diag_physics,tend_physics,its,ite)
+ call convection_from_MPAS(dt_dyn,configs,mesh,sfc_input,diag_physics,tend_physics,diag,its,ite)
 
 !... convert the convection time-step to minutes:
  cudt = dt_cu/60.
@@ -515,13 +590,16 @@
              rthcuten        = rthcuten_p             , rqvcuten      = rqvcuten_p      , & 
              rqccuten        = rqccuten_p             , rqicuten      = rqicuten_p      , &
              rucuten         = rucuten_p              , rvcuten       = rvcuten_p       , &
-             ichoice_deep    = gfconv_closure_deep                                      , &
-             ichoice_shallow = gfconv_closure_shallow                                   , &
-             ishallow_g3     = ishallow                                                 , &
+             sub3d_rthcuten  = sub3d_rthcuten_p       , sub3d_rqvcuten= sub3d_rqvcuten_p, &
+             sub3d_rucuten   = sub3d_rucuten_p        , sub3d_rvcuten = sub3d_rvcuten_p , &
+             ichoice_deep    = gfconv_closure_deep    , sig_deep      = sigma_deep_p    , &
+             ichoice_shallow = gfconv_closure_shallow , bilbc         = bilbc_p         , &
+             ishallow_g3     = ishallow               , sub3d         = sub3d           , &
              pbl_scheme      = pbl_scheme             , maxmf         = maxmfbl_p       , &
              qc3d            = qc_p                   , qi3d          = qi_p            , &
              qc_cu           = qccu_p                 , qi_cu         = qicu_p          , &
              cldfrac_cu      = cldfrac_cu_p           , refl10cm_cu   = refl10cm_cu_p   , &
+             rainncv         = rainncv_p              , vcpool        = vcpool_p        , &
              ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde      , &
              ims = ims , ime = ime , jms = jms , jme = jme , kms = kds , kme = kme      , &
              its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte        &
@@ -628,7 +706,7 @@
 
 !copy instantaneous and accumulated precipitation, convective tendencies, and "other" arrays
 !specific to convection parameterization back to the dynamics grid:
- call convection_to_MPAS(configs,diag_physics,tend_physics,its,ite)
+ call convection_to_MPAS(configs,mesh,diag_physics,tend_physics,its,ite,exchange_halo_group,block)
 
 !call mpas_log_write('--- end subroutine driver_convection.')
 !call mpas_log_write('')
@@ -636,7 +714,7 @@
  end subroutine driver_convection
 
 !=================================================================================================================
- subroutine convection_from_MPAS(dt_dyn,configs,mesh,sfc_input,diag_physics,tend_physics,its,ite)
+ subroutine convection_from_MPAS(dt_dyn,configs,mesh,sfc_input,diag_physics,tend_physics,diag,its,ite)
 !=================================================================================================================
 
 !input arguments:
@@ -645,6 +723,7 @@
  type(mpas_pool_type),intent(in):: sfc_input
  type(mpas_pool_type),intent(in):: diag_physics
  type(mpas_pool_type),intent(in):: tend_physics
+ type(mpas_pool_type),intent(in):: diag
 
  integer,intent(in):: its,ite
  real(kind=RKIND),intent(in):: dt_dyn
@@ -652,10 +731,11 @@
 !local pointers:
  character(len=StrKIND),pointer:: convection_scheme
  integer,dimension(:),pointer:: kpbl,k22_shallow,kbcon_shallow,ktop_shallow,ktop_deep
+ integer,dimension(:),pointer:: bdyMaskCell
  real(kind=RKIND),dimension(:),pointer  :: areaCell,meshDensity
- real(kind=RKIND),dimension(:),pointer  :: nca,cubot,cutop,cuprec,raincv
+ real(kind=RKIND),dimension(:),pointer  :: nca,cubot,cutop,cuprec,rainncv,raincv,vcpool
  real(kind=RKIND),dimension(:),pointer  :: gsw,hfx,qfx,xland
- real(kind=RKIND),dimension(:),pointer  :: xmb_total,xmb_shallow
+ real(kind=RKIND),dimension(:),pointer  :: xmb_total,xmb_shallow,sigma_deep
  real(kind=RKIND),dimension(:,:),pointer:: zgrid
  real(kind=RKIND),dimension(:,:),pointer:: qc_cu,qi_cu
  real(kind=RKIND),dimension(:,:),pointer:: w0avg
@@ -668,6 +748,8 @@
  integer:: i,j,k
  integer:: iEdge
  real(kind=RKIND),pointer:: len_disp
+ integer,pointer:: config_gf_sub3d
+ logical result
 
 !-----------------------------------------------------------------------------------------------------------------
 
@@ -675,6 +757,7 @@
 
  call mpas_pool_get_array(diag_physics,'cuprec',cuprec)
  call mpas_pool_get_array(diag_physics,'raincv',raincv)
+ call mpas_pool_get_array(diag_physics,'rainncv',rainncv)
 
  call mpas_pool_get_array(tend_physics,'rthcuten',rthcuten)
  call mpas_pool_get_array(tend_physics,'rqvcuten',rqvcuten)
@@ -684,6 +767,7 @@
  do j = jts,jte
  do i = its,ite
     raincv_p(i,j) = raincv(i)
+    rainncv_p(i,j)= rainncv(i)
     pratec_p(i,j) = cuprec(i)
     do k = kts,kte
        rthcuten_p(i,k,j) = rthcuten(k,i)
@@ -697,12 +781,13 @@
  convection_select: select case(convection_scheme)
 
     case ("cu_grell_freitas")
+       call mpas_pool_get_config(configs,'config_gf_sub3d',config_gf_sub3d)
        call mpas_pool_get_config(configs,'config_len_disp',len_disp)
 
        call mpas_pool_get_array(mesh,'areaCell'   ,areaCell   )
        call mpas_pool_get_array(mesh,'meshDensity',meshDensity)
        call mpas_pool_get_array(mesh,'zgrid'      ,zgrid      )
-
+       call mpas_pool_get_array(mesh,'bdyMaskCell',bdyMaskCell) 
        call mpas_pool_get_array(sfc_input,'xland',xland)
 
        call mpas_pool_get_array(diag_physics,'gsw'          ,gsw          )
@@ -719,8 +804,10 @@
        call mpas_pool_get_array(diag_physics,'ktop_deep'    ,ktop_deep    )
        call mpas_pool_get_array(diag_physics,'qc_cu'        ,qc_cu        )
        call mpas_pool_get_array(diag_physics,'qi_cu'        ,qi_cu        )
+       call mpas_pool_get_array(diag_physics,'vcpool'       ,vcpool       )
        call mpas_pool_get_array(diag_physics,'cldfrac_cu'   ,cldfrac_cu   )
        call mpas_pool_get_array(diag_physics,'refl10cm_cu'  ,refl10cm_cu  )
+       call mpas_pool_get_array(diag_physics,'sigma_deep'   ,sigma_deep   )
 
        call mpas_pool_get_array(tend_physics,'rqvblten'  ,rqvblten  )
        call mpas_pool_get_array(tend_physics,'rqvdynten' ,rqvdynten )
@@ -743,7 +830,7 @@
           kpbl_p(i,j)          = kpbl(i)
           cubot_p(i,j)         = cubot(i)
           cutop_p(i,j)         = cutop(i)
-
+          bilbc_p(i,j)         = bdyMaskCell(i)
           xmb_total_p(i,j)     = xmb_total(i)
           xmb_shallow_p(i,j)   = xmb_shallow(i)
 
@@ -751,6 +838,8 @@
           kbcon_shallow_p(i,j) = kbcon_shallow(i)
           ktop_shallow_p(i,j)  = ktop_shallow(i)
           ktop_deep_p(i,j)     = ktop_deep(i)
+          vcpool_p(i,j)        = vcpool(i)
+          sigma_deep_p(i,j)    = sigma_deep(i)
 
           do k = kts,kte
              qccu_p(i,k,j)      = qc_cu(k,i)
@@ -881,11 +970,14 @@
  end subroutine convection_from_MPAS
 
 !=================================================================================================================
- subroutine convection_to_MPAS(configs,diag_physics,tend_physics,its,ite)
+ subroutine convection_to_MPAS(configs,mesh,diag_physics,tend_physics,its,ite,exchange_halo_group,block)
 !=================================================================================================================
 
 !input arguments:
  type(mpas_pool_type),intent(in):: configs
+ type(mpas_pool_type),intent(in):: mesh
+ type(block_type), intent(in) :: block
+ procedure (halo_exchange_routine) :: exchange_halo_group
  integer,intent(in):: its,ite
 
 !inout arguments:
@@ -893,18 +985,23 @@
  type(mpas_pool_type),intent(inout):: tend_physics
 
 !local variables:
- integer:: i,k,j
+ integer:: i,k,j,iCell,ineighbour
 
 !local pointers:
  character(len=StrKIND),pointer:: convection_scheme
  integer,dimension(:),pointer:: k22_shallow,kbcon_shallow,ktop_shallow,ktop_deep
- real(kind=RKIND),dimension(:),pointer  :: nca,cubot,cutop,cuprec,raincv
+ real(kind=RKIND),dimension(:),pointer  :: nca,cubot,cutop,cuprec,rainncv,raincv,vcpool,sigma_deep
  real(kind=RKIND),dimension(:),pointer  :: xmb_total,xmb_shallow
  real(kind=RKIND),dimension(:,:),pointer:: qc_cu,qi_cu
  real(kind=RKIND),dimension(:,:),pointer:: w0avg
  real(kind=RKIND),dimension(:,:),pointer:: rthcuten,rqvcuten,rqccuten,rqicuten,rqrcuten,rqscuten
  real(kind=RKIND),dimension(:,:),pointer:: rucuten,rvcuten
  real(kind=RKIND),dimension(:,:),pointer:: cldfrac_cu,refl10cm_cu
+ real(kind=RKIND),dimension(:,:),pointer:: sub3d_rucuten,sub3d_rvcuten,sub3d_rthcuten,sub3d_rqvcuten
+ integer,pointer:: config_gf_sub3d,nCellsSolve
+ integer, dimension(:), pointer:: nEdgesOnCell,bdyMaskCell
+ integer, dimension(:,:), pointer:: cellsOnCell
+ logical result
 
 !-----------------------------------------------------------------------------------------------------------------
 
@@ -912,6 +1009,7 @@
 
  call mpas_pool_get_array(diag_physics,'cuprec',cuprec)
  call mpas_pool_get_array(diag_physics,'raincv',raincv)
+ call mpas_pool_get_array(diag_physics,'rainncv',rainncv)
 
  call mpas_pool_get_array(tend_physics,'rthcuten',rthcuten)
  call mpas_pool_get_array(tend_physics,'rqvcuten',rqvcuten)
@@ -947,8 +1045,11 @@
        call mpas_pool_get_array(diag_physics,'cldfrac_cu'   ,cldfrac_cu   )
        call mpas_pool_get_array(diag_physics,'refl10cm_cu'  ,refl10cm_cu  )
 
+       call mpas_pool_get_array(diag_physics,'vcpool'       ,vcpool       )
+       call mpas_pool_get_array(diag_physics,'sigma_deep'  ,sigma_deep    )
        call mpas_pool_get_array(tend_physics,'rucuten',rucuten)
        call mpas_pool_get_array(tend_physics,'rvcuten',rvcuten)
+       call mpas_pool_get_array(mesh,'bdyMaskCell',bdyMaskCell)
 
        do j = jts,jte
        do i = its,ite
@@ -960,6 +1061,8 @@
           kbcon_shallow(i) = kbcon_shallow_p(i,j)
           ktop_shallow(i)  = ktop_shallow_p(i,j)
           ktop_deep(i)     = ktop_deep_p(i,j)
+          vcpool(i)        = vcpool_p(i,j)
+          sigma_deep(i)    = sigma_deep_p(i,j)
 
           do k = kts,kte
              qc_cu(k,i)    = qccu_p(i,k,j)
@@ -972,6 +1075,77 @@
           enddo
        enddo
        enddo
+
+       !-- including option of the env subsidence lateral spreading
+       call mpas_pool_get_config(configs,'config_gf_sub3d',config_gf_sub3d)
+       call mpas_pool_get_array(tend_physics,'sub3d_rucuten'  ,sub3d_rucuten )
+       call mpas_pool_get_array(tend_physics,'sub3d_rvcuten'  ,sub3d_rvcuten )
+       call mpas_pool_get_array(tend_physics,'sub3d_rqvcuten' ,sub3d_rqvcuten)
+       call mpas_pool_get_array(tend_physics,'sub3d_rthcuten' ,sub3d_rthcuten)
+
+            do j = jts,jte
+            do i = its,ite
+               do k = kts,kte
+                  sub3d_rthcuten(k,i) = sub3d_rthcuten_p(i,k,j)
+                  sub3d_rqvcuten(k,i) = sub3d_rqvcuten_p(i,k,j)
+                  sub3d_rucuten(k,i)  = sub3d_rucuten_p(i,k,j)
+                  sub3d_rvcuten(k,i)  = sub3d_rvcuten_p(i,k,j)
+               enddo
+            enddo
+            enddo
+            !
+            !
+       call mpas_pool_get_array(mesh, 'cellsOnCell', cellsOnCell)
+       call mpas_pool_get_array(mesh, 'nEdgesOnCell', nEdgesOnCell)
+       call mpas_pool_get_dimension(mesh, 'nCellsSolve', nCellsSolve)
+              if(config_gf_sub3d > 0) then
+            !
+!
+            !--- part 2: broadcast the subsidence tendencies
+
+            call exchange_halo_group(block % domain, 'physics:sub3d_cuten')
+
+            !-- part 3: spread the subsidence tendencies to the 1st neighbours
+!               print *,'sub3d1 = '
+            do iCell = 1, nCellsSolve
+            ! do not do this at the boundary of the regional domain!
+            if(bdyMaskCell(icell) == 7 )cycle
+              do k = 1, nVertLevels
+                 rthcuten(k,iCell) = rthcuten(k,iCell) + sigma_deep(iCell) * sub3d_rthcuten(k,iCell)
+                 rqvcuten(k,iCell) = rqvcuten(k,iCell) + sigma_deep(iCell) * sub3d_rqvcuten(k,iCell)
+                 rucuten(k,iCell)  = rucuten(k,iCell)  + sigma_deep(iCell) * sub3d_rucuten(k,iCell)
+                 rvcuten(k,iCell)  = rvcuten(k,iCell)  + sigma_deep(iCell) * sub3d_rvcuten(k,iCell)
+                 do i = 1, nEdgesOnCell(iCell)
+                   ineighbour = cellsOnCell(i,iCell)
+                   ! do not do this if there is no convection in that neighbour cell!
+                   if(sigma_deep(ineighbour) == 0.)cycle
+                   rthcuten(k,iCell) = rthcuten(k,iCell) + &
+                                       (1._RKIND - sigma_deep(ineighbour))*sub3d_rthcuten(k,ineighbour)/ &
+                                       real(nEdgesOnCell(ineighbour),RKIND)
+                   rqvcuten(k,iCell) = rqvcuten(k,iCell) + &
+                                       (1._RKIND - sigma_deep(ineighbour))*sub3d_rqvcuten(k,ineighbour)/ &
+                                       real(nEdgesOnCell(ineighbour),RKIND)
+                   rucuten(k,iCell) = rucuten(k,iCell) + &
+                                       (1._RKIND - sigma_deep(ineighbour))*sub3d_rucuten(k,ineighbour)/ &
+                                       real(nEdgesOnCell(ineighbour),RKIND)
+                   rvcuten(k,iCell) = rvcuten(k,iCell) + &
+                                       (1._RKIND - sigma_deep(ineighbour))*sub3d_rvcuten(k,ineighbour)/ &
+                                       real(nEdgesOnCell(ineighbour),RKIND)
+                 enddo
+              enddo
+            enddo
+       else  ! no subsidence spreading
+               !print *,'sub3d0 = '
+            do i = 1, nCellsSolve
+            do k = 1, nVertLevels
+                 rucuten(k,i)  = rucuten(k,i)  + sub3d_rucuten(k,i)
+                 rvcuten(k,i)  = rvcuten(k,i)  + sub3d_rvcuten(k,i)
+                 rthcuten(k,i) = rthcuten(k,i) + sub3d_rthcuten(k,i)
+                 rqvcuten(k,i) = rqvcuten(k,i) + sub3d_rqvcuten(k,i)
+            enddo
+            enddo
+
+       endif
 
     case ("cu_kain_fritsch")
        call mpas_pool_get_array(diag_physics,'cubot',cubot)

--- a/src/core_atmosphere/physics/mpas_atmphys_init.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_init.F
@@ -383,7 +383,7 @@ use mpas_stream_manager
 
 !initialization of parameterized convective processes:
  if(config_convection_scheme .ne. 'off') &
-    call init_convection(mesh,configs,diag_physics)
+    call init_convection(dminfo,mesh,configs,diag_physics)
 
 !initialization of cloud microphysics processes:
  if(config_microp_scheme .ne. 'off') &

--- a/src/core_atmosphere/physics/mpas_atmphys_vars.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_vars.F
@@ -344,6 +344,7 @@
     integer, parameter:: ishallow  = 1 !shallow convection used with grell scheme.
 
  integer,dimension(:,:),allocatable:: &
+    bilbc_p,          &!
     k22_shallow_p,    &!
     kbcon_shallow_p,  &!
     ktop_shallow_p,   &!
@@ -352,7 +353,8 @@
 
  real(kind=RKIND),dimension(:,:),allocatable:: &
     xmb_total_p,      &!
-    xmb_shallow_p      !
+    xmb_shallow_p,    &!
+    sigma_deep_p       !
 
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     rthdynten_p,      &!
@@ -367,6 +369,17 @@
     rqvdynten_p,      &!
     rqvdynblten_p,    &!
     rthdynblten_p      !
+
+ real(kind=RKIND),dimension(:,:,:),allocatable:: &
+    sub3d_rthcuten_p,        &!
+    sub3d_rqvcuten_p,        &!
+    sub3d_rucuten_p,         &!
+    sub3d_rvcuten_p           !
+
+ real(kind=RKIND),dimension(:,:),allocatable:: &
+    !wlpool_p,     &!
+    sgsgustcu_p,    &
+    vcpool_p
 
 !... ntiedtke specific arrays:
  real(kind=RKIND),dimension(:,:,:),allocatable:: &

--- a/src/core_atmosphere/physics/physics_wrf/module_cu_gf_deep.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_cu_gf_deep.F
@@ -17,6 +17,7 @@ MODULE module_cu_gf_deep
      real(kind=kind_phys), parameter:: c1= 0.003 !.002 ! .0005
 !> parameter to turn on or off evaporation of rainwater as done in sas
      integer, parameter :: irainevap=1
+     integer, parameter :: use_fct=1
 !> max allowed fractional coverage (frh_thresh)
      real(kind=kind_phys), parameter::frh_thresh = .9
 !> rh threshold. if fractional coverage ~ frh_thres, do not use cupa any further
@@ -38,10 +39,10 @@ MODULE module_cu_gf_deep
 !> still 16 ensembles for clousres
      integer, parameter:: maxens3=16
 !>  which coldpool version to use
-     integer, parameter:: icoldpool=1  ! 1 = momentum impact
+     integer, parameter:: icoldpool=0  ! 1 = momentum impact
                                        ! 2 = sf flx impact
                                        ! 3 = both, (1) and (2)
-                                       ! 4 = full implement, not working yet
+                                       ! 4 = full implement, not working yet...
 
 !---meltglac-------------------------------------------------
  logical, parameter :: melt_glac      = .true.  !<- turn on/off ice phase/melting
@@ -84,7 +85,7 @@ contains
 !>Driver for the deep or congestus GF routine.
 !! \section general_gf_deep Grell-Freitas Deep Convection General Algorithm
    subroutine cu_gf_deep_run(        &          
-               itf,ktf,its,ite, kts,kte  &
+               itf,ktf,its,ite, kts,kte,sub3d  &
               ,dicycle       &  ! diurnal cycle flag
               ,ichoice       &  ! choice of closure, use "0" for ensemble average
               ,ipr           &  ! this flag can be used for debugging prints
@@ -141,6 +142,12 @@ contains
               ,chem3d        &
               ,wetdpc_deep   &
               ,do_smoke_transport   &
+              ,vcpool        &
+              ,subten_h      &  ! subsudence tendency for h
+              ,subten_q      &  ! subsudence tendency for t
+              ,subten_t      &  ! subsudence tendency for q
+              ,subten_u      &  ! subsudence tendency for u
+              ,subten_v      &  ! subsudence tendency for v
               ,rand_mom      &  ! for stochastics mom, if temporal and spatial patterns exist
               ,rand_vmas     &  ! for stochastics vertmass, if temporal and spatial patterns exist
               ,rand_clos     &  ! for stochastics closures, if temporal and spatial patterns exist
@@ -159,7 +166,7 @@ contains
 
      integer                                                &
         ,intent (in   )                   ::                &
-        nranflag,itf,ktf,its,ite, kts,kte,ipr,imid
+        sub3d,nranflag,itf,ktf,its,ite, kts,kte,ipr,imid
      integer, intent (in   )              ::                &
         ichoice,nchem
      real(kind=kind_phys),  dimension (its:ite,4)                 &
@@ -185,7 +192,10 @@ contains
         cnvwt,outu,outv,outt,outq,outqc,cupclw
      real(kind=kind_phys),    dimension (its:ite)                      &
         ,intent (out    )                   ::                         &
-        frh_out
+        frh_out, vcpool
+     real(kind=kind_phys),    dimension (its:ite,kts:kte)              &
+        ,intent (out    )                   ::                         &
+        subten_h,subten_q,subten_t,subten_u,subten_v
      real(kind=kind_phys),    dimension (its:ite)                      &
         ,intent (inout  )                   ::                         &
         pre,xmb_out
@@ -323,7 +333,7 @@ contains
      real(kind=kind_phys), dimension (its:ite,nchem)   ::                 &
          chem_pwav,chem_psum
      real(kind=kind_phys):: dtime_max,sum1,sum2
-     real(kind=kind_phys), dimension (kts:kte) :: trac,trcflx_in,trcflx_out,trc,trco
+     real(kind=kind_phys), dimension (kts:kte) :: trac,trcflx_in,sub_tend,trc,trco
      real(kind=kind_phys), dimension (its:ite,kts:kte) :: pwdper, massflx
      integer :: nv
 !$acc declare create(chem,chem_cup,chem_up,chem_down,dellac,dellac2,chem_c,chem_pw,chem_pwd,   &
@@ -450,19 +460,21 @@ contains
 !---meltglac-------------------------------------------------
 
      real(kind=kind_phys),    dimension (its:ite,kts:kte) ::  p_liq_ice,melting_layer,melting
-! coldpool
-     real(kind=kind_phys),    dimension (its:ite) ::  beta_x,vcpool, wlpool,umcl,vmcl,slope_pool
+     real(kind=kind_phys),    dimension (its:ite) ::  beta_x, wlpool,umcl,vmcl,slope_pool
      real(kind=kind_phys),    dimension (its:ite,kts:kte) ::  buoysrc,dellat_d
      real(kind=kind_phys) :: aux,mcl_speed,total_dz,mx_buoy2,h_env,dpsum
+     real(kind=kind_phys),    dimension (kts:kte) ::  p_local, zd_local
 
 !$acc declare create(p_liq_ice,melting_layer,melting,buoysrc,beta_x,vcpool,wlpool,umcl,vmcl)
 
      integer :: itemp
-
+      !:print *,'sub3d =', sub3d
 !---meltglac-------------------------------------------------
 !$acc kernels
       melting_layer(:,:)=0.
       melting(:,:)=0.
+      p_local(:)=0.
+      zd_local(:)=0.
       flux_tun(:)=fluxtune
 !$acc end kernels
 !      if(imid.eq.1)flux_tun(:)=fluxtune+.5
@@ -596,9 +608,10 @@ contains
 !$acc loop private(radius,frh)
       do i=its,ite
          c1d(i,:)= 0. !c1 ! 0. ! c1 ! max(.003,c1+float(csum(i))*.0001)
-         entr_rate(i)=7.e-5 - min(20.,float(csum(i))) * 3.e-6
+         entr_rate(i)=7.e-5  !- min(20.,float(csum(i))) * 3.e-6
          if(xland1(i) == 0)entr_rate(i)=7.e-5
-         if(dx(i)<dx_thresh) entr_rate(i)=2.e-4
+         entr_rate(i)=1.e-4  !- min(20.,float(csum(i))) * 3.e-6
+         !if(dx(i)<dx_thresh) entr_rate(i)=2.e-4
          if(imid.eq.1)entr_rate(i)=3.e-4
          radius=.2/entr_rate(i)
          frh=min(1.,3.14*radius*radius/dx(i)/dx(i))
@@ -611,7 +624,10 @@ contains
          !frh_out(i) = frh
          !if(forcing(i,7).eq.0.)sig(i)=1.
          frh_out(i) = frh !*sig(i)
+         if(imid == 0 .and. sub3d == 1) sig(i)=1.
          sig_init(i)=sig(i)
+         ! frh_out(i)=.001
+         ! sig(i)=1.
       enddo
 !$acc end kernels
       sig_thresh = (1.-frh_thresh)**2
@@ -656,7 +672,7 @@ contains
 !
       depth_min=3000.
 !---  for RRFS allow only very deep convection
-      if(dx(its)<dx_thresh)depth_min=5000.
+      !if(dx(its)<dx_thresh)depth_min=5000.
       if(imid.eq.1)depth_min=2500.
 !
 !--- maximum depth (mb) of capping 
@@ -823,7 +839,7 @@ contains
          if(ierr(i) == 0)then
            frh = min(qo_cup(i,kbcon(i))/qeso_cup(i,kbcon(i)),1.)
            if(frh >= rh_thresh .and. sig(i) <= sig_thresh )then
-             ierr(i)=231
+             !ierr(i)=231
              cycle
            endif
 !
@@ -926,7 +942,7 @@ contains
           zu (i,k)= zuo(i,k)
           tot_clw=tot_clw+qc(i,k)+qi(i,k)
          enddo
-         if(tot_clw <= 0.)sig(i)=1.
+!         if(tot_clw <= 0.)sig(i)=1.
          sig_init(i)=sig(i)
 !$acc loop independent
          do k=ktop(i)+1,kte
@@ -1264,8 +1280,11 @@ contains
         cdd(i,jmin(i))=0.
         dd_massdetro(i,:)=0.
         dd_massentro(i,:)=0.
-        call get_zu_zd_pdf_fim(0,po_cup(i,:),rand_vmas(i),0.0_kind_phys,ipr,xland1(i),zuh2,4, &
-            ierr(i),kdet(i),jmin(i)+1,zdo(i,:),kts,kte,ktf,beta,kpbl(i),csum(i),pmin_lev(i))
+        p_local(kts:kte)=po_cup(i,kts:kte)
+        zd_local(kts:kte)=zdo(i,kts:kte)
+        call get_zu_zd_pdf_fim(0,p_local,rand_vmas(i),0.0_kind_phys,ipr,xland1(i),zuh2,4, &
+            ierr(i),kdet(i),jmin(i)+1,zd_local,kts,kte,ktf,beta,kpbl(i),csum(i),pmin_lev(i))
+        zdo(i,kts:kte)=zd_local(kts:kte)
         if(zdo(i,jmin(i)) .lt.1.e-8)then
           zdo(i,jmin(i))=0.
           jmin(i)=jmin(i)-1
@@ -1600,6 +1619,11 @@ contains
         dellat_d (i,k)=0.
         dellaq (i,k)  =0.
         dellaqc(i,k)  =0.
+        subten_h(i,k)=0.
+        subten_q(i,k)=0.
+        subten_t(i,k)=0.
+        subten_u(i,k)=0.
+        subten_v(i,k)=0.
       enddo
       enddo
 !$acc end kernels
@@ -1642,17 +1666,10 @@ contains
 !----------------------------------------------  cloud level 2
 !
 !- - - - - - - - - - - - - - - - - - - - - - - - model level 1
-!$acc kernels
-      do i=its,itf
-        if(ierr(i)/=0)cycle
-         dp=100.*(po_cup(i,1)-po_cup(i,2))
-         dellu(i,1)=pgcd*(edto(i)*zdo(i,2)*ucd(i,2)   &
-                         -edto(i)*zdo(i,2)*u_cup(i,2))*g/dp &
-                      -zuo(i,2)*(uc (i,2)-u_cup(i,2)) *g/dp
-         dellv(i,1)=pgcd*(edto(i)*zdo(i,2)*vcd(i,2)   &
-                         -edto(i)*zdo(i,2)*v_cup(i,2))*g/dp &
-                      -zuo(i,2)*(vc (i,2)-v_cup(i,2)) *g/dp
-
+!!$acc kernels
+! MASS check
+       do i=its,itf
+         if(ierr(i)/=0)cycle
          do k=kts+1,ktop(i)
             ! these three are only used at or near mass detrainment and/or entrainment levels
             pgc=pgcon
@@ -1686,44 +1703,51 @@ contains
                write(0,123)'totmas=',k22(i),kbcon(i),k,entup,detup,edto(i),zdo(i,k+1),dd_massdetro(i,k),dd_massentro(i,k)
 123     format(a7,1x,3i3,2e12.4,1(1x,f5.2),3e12.4)
 #endif
-            endif
+             endif
+            enddo
+! END MASS check
+      call dellas_nosub(itf,ktf, its,ite, kts,kte,ierr,                       &
+                      po_cup,us, u_cup,ucd,uc,                                  &
+                      up_massentro,up_massdetro,dd_massentro,dd_massdetro,      &
+                      edto,zuo,zdo,k22,jmin,ktop,dellu)
+      call dellas_nosub(itf,ktf, its,ite, kts,kte,ierr,                       &
+                      po_cup,vs, v_cup,vcd,vc,                                  &
+                      up_massentro,up_massdetro,dd_massentro,dd_massdetro,      &
+                      edto,zuo,zdo,k22,jmin,ktop,dellv)
+
+
+         do k=kts+1,ktop(i)
             dp=100.*(po_cup(i,k)-po_cup(i,k+1))
              pgc=pgcon
             if(k.ge.ktop(i))pgc=0.
 
-             dellu(i,k) =-(zuo(i,k+1)*(uc (i,k+1)-u_cup(i,k+1) ) -                               &
-                            zuo(i,k  )*(uc (i,k  )-u_cup(i,k  ) ) )*g/dp                         &
-                          +(zdo(i,k+1)*(ucd(i,k+1)-u_cup(i,k+1) ) -                              &
-                            zdo(i,k  )*(ucd(i,k  )-u_cup(i,k  ) ) )*g/dp*edto(i)*pgcd
-             dellv(i,k) =-(zuo(i,k+1)*(vc (i,k+1)-v_cup(i,k+1) ) -                               &
-                            zuo(i,k  )*(vc (i,k  )-v_cup(i,k  ) ) )*g/dp                         &
-                         +(zdo(i,k+1)*(vcd(i,k+1)-v_cup(i,k+1) ) -                               &
-                            zdo(i,k  )*(vcd(i,k  )-v_cup(i,k  ) ) )*g/dp*edto(i)*pgcd
- 
+            subten_u(i,k) = -(zuo(i,k+1)*(-u_cup(i,k+1)) - zuo(i,k)*(-u_cup(i,k)))*g/dp       &
+                           +(zdo(i,k+1)*(-u_cup(i,k+1)) - zdo(i,k)*(-u_cup(i,k)))*g/dp*edto(i)*pgcd
+            subten_v(i,k) = -(zuo(i,k+1)*(-v_cup(i,k+1)) - zuo(i,k)*(-v_cup(i,k)))*g/dp       &
+                           +(zdo(i,k+1)*(-v_cup(i,k+1)) - zdo(i,k)*(-v_cup(i,k)))*g/dp*edto(i)*pgcd
        enddo   ! k
+     enddo    !i
 
-    enddo
-
-
+      call dellas_nosub(itf,ktf, its,ite, kts,kte,ierr,             &
+                      po_cup,heo, heo_cup,hcdo,hco,      &
+                      up_massentro,up_massdetro,dd_massentro,dd_massdetro,      &
+                      edto,zuo,zdo,k22,jmin,ktop,dellah)
+      call dellas_nosub(itf,ktf, its,ite, kts,kte,ierr,             &
+                      po_cup,qo, qo_cup,qcdo,qco,      &
+                      up_massentro,up_massdetro,dd_massentro,dd_massdetro,      &
+                      edto,zuo,zdo,k22,jmin,ktop,dellaq)
     do i=its,itf
-        !trash  = 0.0
-        !trash2 = 0.0
         if(ierr(i).eq.0)then
 
-         dp=100.*(po_cup(i,1)-po_cup(i,2))
-
-         dellah(i,1)=(edto(i)*zdo(i,2)*hcdo(i,2)          &
-                     -edto(i)*zdo(i,2)*heo_cup(i,2))*g/dp &
-                   -zuo(i,2)*(hco(i,2)-heo_cup(i,2))*g/dp
-
-         dellaq (i,1)=(edto(i)*zdo(i,2)*qcdo(i,2)         &
-                      -edto(i)*zdo(i,2)*qo_cup(i,2))*g/dp &
-                    -zuo(i,2)*(qco(i,2)-qo_cup(i,2))*g/dp
-
-         g_rain=  0.5*(pwo (i,1)+pwo (i,2))*g/dp
-         e_dn  = -0.5*(pwdo(i,1)+pwdo(i,2))*g/dp*edto(i)  ! pwdo < 0 and e_dn must > 0
-         dellaq(i,1) = dellaq(i,1)+ e_dn-g_rain
-         dellat_d(i,1)=zdo(i,2)*edto(i)*(hcdo(i,2)-heo_cup(i,2))*g/dp
+          dp=100.*(po_cup(i,1)-po_cup(i,2))
+!
+!         dellaq (i,1)=(edto(i)*zdo(i,2)*qcdo(i,2)         &
+!                      -edto(i)*zdo(i,2)*qo_cup(i,2))*g/dp &
+!                    -zuo(i,2)*(qco(i,2)-qo_cup(i,2))*g/dp
+!         g_rain=  0.5*(pwo (i,1)+pwo (i,2))*g/dp
+!         e_dn  = -0.5*(pwdo(i,1)+pwdo(i,2))*g/dp*edto(i)  ! pwdo < 0 and e_dn must > 0
+!         dellaq(i,1) = dellaq(i,1)+ e_dn-g_rain
+          dellat_d(i,1)=zdo(i,2)*edto(i)*(hcdo(i,2)-heo_cup(i,2))*g/dp
 
          
          !--- conservation check
@@ -1733,27 +1757,57 @@ contains
          !trash2 = trash2+ (dellah(i,1))*dp/g
          
 
+         !--- moist static energy : flux form + source/sink terms + time explicit
+         !
+         !   if(use_fct == 0 .or. adjustl(cumulus) == 'shallow') then
+       if(use_fct == 0 ) then
          do k=kts+1,ktop(i)
             dp=100.*(po_cup(i,k)-po_cup(i,k+1))
             ! these three are only used at or near mass detrainment and/or entrainment levels
 
-            dellah(i,k) =-(zuo(i,k+1)*(hco (i,k+1)-heo_cup(i,k+1) ) -                 &
-                           zuo(i,k  )*(hco (i,k  )-heo_cup(i,k  ) ) )*g/dp            &
-                         +(zdo(i,k+1)*(hcdo(i,k+1)-heo_cup(i,k+1) ) -                 &
-                           zdo(i,k  )*(hcdo(i,k  )-heo_cup(i,k  ) ) )*g/dp*edto(i)
-                        
 !---meltglac-------------------------------------------------
-
            dellah(i,k) = dellah(i,k) + xlf*((1.-p_liq_ice(i,k))*0.5*(qrco(i,k+1)+qrco(i,k)) &
                                      - melting(i,k))*g/dp
+           subten_h(i,k) = -(zuo(i,k+1)*(-heo_cup(i,k+1)) - zuo(i,k)*(-heo_cup(i,k)))*g/dp       &
+                           +(zdo(i,k+1)*(-heo_cup(i,k+1)) - zdo(i,k)*(-heo_cup(i,k)))*g/dp*edto(i)
+           dellah(i,k) = dellah(i,k) + subten_h(i,k)
+         enddo
+       else
+                        !-- FCT scheme for the subsidence transport: d(M_env*S_env)/dz
+               sub_tend (:) = 0. ! dummy array
+               trcflx_in(:) = 0. ! dummy array
+               massflx  (i,:) = 0.
+               dtime_max      = dtime
+
+               do k=kts,ktop(i)
+                  dp=100.*(po_cup(i,k)-po_cup(i,k+1))
+                  massflx   (i,k) =-(zuo(i,k)  -edto(i)*zdo(i,k))
+                  trcflx_in (k) =massflx(i,k)*heo_cup(i,k)
+                  dtime_max=min(dtime_max,.5*dp)
+               enddo
+               call fct1d3 (ktop(i),kte,dtime_max,po_cup(i,:),heo(i,:),massflx(i,:),trcflx_in(:),sub_tend(:),g)
+
+               do k=kts,ktop(i)
+                  dp=100.*(po_cup(i,k)-po_cup(i,k+1))
+!                  dellah(i,k) = dellah(i,k) + xlf*((1.-p_liq_ice(i,k))* &
+!                              0.5*(qrco(i,k+1)+qrco(i,k)) - melting(i,k))*g/dp
+                  !- update with subsidence term from the FCT scheme
+                  dellah(i,k) = dellah(i,k) + sub_tend(k)
+                  !--- for output only
+                  subten_h(i,k) = sub_tend(k)
+               enddo   ! k
+            endif
+
+
 
 !---meltglac-------------------------------------------------
 
             !- check h conservation 
             ! trash2 = trash2+ (dellah(i,k))*dp/g
         
-        
+            do k=kts+1,ktop(i)     
             !-- take out cloud liquid water for detrainment
+            dp=100.*(po_cup(i,k)-po_cup(i,k+1))
             detup=up_massdetro(i,k)
             dz=zo_cup(i,k)-zo_cup(i,k-1)
             if(k.lt.ktop(i)) then
@@ -1762,28 +1816,63 @@ contains
                 dellaqc(i,k)=  detup*0.5*(qrco(i,k+1)+qrco(i,k)) *g/dp
             endif
             !---
-            g_rain=  0.5*(pwo (i,k)+pwo (i,k+1))*g/dp
-            e_dn  = -0.5*(pwdo(i,k)+pwdo(i,k+1))*g/dp*edto(i) ! pwdo < 0 and e_dn must > 0
+!            g_rain=  0.5*(pwo (i,k)+pwo (i,k+1))*g/dp
+!            e_dn  = -0.5*(pwdo(i,k)+pwdo(i,k+1))*g/dp*edto(i) ! pwdo < 0 and e_dn must > 0
             !-- condensation source term = detrained + flux divergence of
             !-- cloud liquid water (qrco) + converted to rain
         
-            c_up = dellaqc(i,k)+(zuo(i,k+1)* qrco(i,k+1) -                           &
-                                zuo(i,k  )* qrco(i,k  )  )*g/dp + g_rain
-!            c_up = dellaqc(i,k)+ g_rain
+!            c_up = dellaqc(i,k)+(zuo(i,k+1)* qrco(i,k+1) -                           &
+!        /                        zuo(i,k  )* qrco(i,k  )  )*g/dp + g_rain
             !-- water vapor budget
             !-- = flux divergence z*(q_c - q_env)_up_and_down                        &
             !--   - condensation term + evaporation
-            dellaq(i,k) =-(zuo(i,k+1)*(qco (i,k+1)-qo_cup(i,k+1) ) -                 &
-                           zuo(i,k  )*(qco (i,k  )-qo_cup(i,k  ) ) )*g/dp            &
-                         +(zdo(i,k+1)*(qcdo(i,k+1)-qo_cup(i,k+1) ) -                 &
-                           zdo(i,k  )*(qcdo(i,k  )-qo_cup(i,k  ) ) )*g/dp*edto(i)    &
-                         - c_up + e_dn
-            if(k.le.jmin(i)-1)dellat_d(i,k)= &
-               edto(i)*dd_massdetro(i,k)*(.5*(hcdo(i,k+1)+hcdo(i,k))-heo(i,k))*g/dp
+!            dellaq(i,k) =-(zuo(i,k+1)*qco (i,k+1) - zuo(i,k)*qco (i,k))*g/dp     &
+!                         +(zdo(i,k+1)*qcdo(i,k+1) - zdo(i,k)*qcdo(i,k))*g/dp*edto(i)    &
+!                         - C_up + E_dn
+            enddo
+!            k=ktop(i)
+!            dp=100.*(po_cup(i,k)-po_cup(i,k+1))
+!            detup=up_massdetro(i,k)
+!            g_rain=  pwo (i,k)*g/dp
+!            c_up = dellaqc(i,k)+(zuo(i,k+1)* qrco(i,k+1) -                           &
+!                   zuo(i,k  )* qrco(i,k  )  )*g/dp + g_rain
 
-            !- check water conservation liq+condensed (including rainfall)
-            ! trash= trash+ (dellaq(i,k)+dellaqc(i,k)+ g_rain-e_dn)*dp/g
+!            dellaqc(i,k)=  detup*0.5*(qrco(i,k+1)+qrco(i,k)) *g/dp
+!            dellaq(i,k) =-(zuo(i,k+1)*(qco (i,k+1)-qo_cup(i,k+1) ) -                               &
+!                        zuo(i,k  )*(qco (i,k  )-qo_cup(i,k  ) ) )*g/dp - C_up
+            ! subsidence terms
+            if(use_fct == 0 ) then
+               do k=kts+1,ktop(i)
+                  dp=100.*(po_cup(i,k)-po_cup(i,k+1))
+                  sub_tend(k) =-(zuo(i,k+1)*(-qo_cup(i,k+1)) - zuo(i,k)*(-qo_cup(i,k)))*g/dp       &
+                                 +(zdo(i,k+1)*(-qo_cup(i,k+1)) - zdo(i,k)*(-qo_cup(i,k)))*g/dp*edto(i)
+                  subten_q(i,k) = sub_tend(k)
+               enddo
+            else
+               !-- FCT scheme for the subsidence transport: d(M_env*S_env)/dz
+               sub_tend (:) = 0. ! dummy array
+               trcflx_in(:) = 0. ! dummy array
+               massflx  (i,:) = 0.
+               dtime_max      = dtime
 
+               do k=kts,ktop(i)
+                  dp=100.*(po_cup(i,k)-po_cup(i,k+1))
+                  massflx   (i,k) =-(zuo(i,k)  -edto(i)*zdo(i,k))
+                  trcflx_in (k) =massflx(i,k)*qo_cup(i,k)
+                  dtime_max=min(dtime_max,.5*dp)
+               enddo
+               call fct1d3 (ktop(i),kte,dtime_max,po_cup(i,:),qo(i,:),massflx(i,:),trcflx_in,sub_tend(:),g)
+            endif
+
+            !--- add the contribuition from the environ subsidence
+            subten_q(i,kts:ktop(i)) = sub_tend(kts:ktop(i))
+            dellaq(i,kts:ktop(i)) = dellaq(i,kts:ktop(i)) + sub_tend(kts:ktop(i))
+!
+!
+! for cold pool calcs
+         do k=2,jmin(i)-1
+            dp=100.*(po_cup(i,k)-po_cup(i,k+1))
+            dellat_d(i,k)= edto(i)*dd_massdetro(i,k)*(.5*(hcdo(i,k+1)+hcdo(i,k))-heo(i,k))*g/dp
          enddo   ! k
         endif
 
@@ -1807,6 +1896,7 @@ contains
 !            xq(i,k)=max(1.e-16,(dellaqc(i,k)+dellaq(i,k))*mbdt+qo(i,k))
             xq(i,k)=max(1.e-16,dellaq(i,k)*mbdt+qo(i,k))
             dellat(i,k)=(1./cp)*(dellah(i,k)-xlv*dellaq(i,k))
+            subten_t(i,k)=(1./cp)*(subten_h(i,k)-xlv*subten_q(i,k))
 !            xt(i,k)= (dellat(i,k)-xlv/cp*dellaqc(i,k))*mbdt+tn(i,k)
             xt(i,k)= dellat(i,k)*mbdt+tn(i,k)
             xt(i,k)=max(190.,xt(i,k))
@@ -1996,8 +2086,8 @@ contains
 !$acc atomic update
           mconv(i)=mconv(i)+omeg(i,k)*dq/g
         enddo
-        if (mconv(i) < 5.*0.001) ierr(i)=42
       enddo
+      !if (mconv(i) < 5.*0.001) ierr(i)=42
 !$acc end kernels
       call cup_forcing_ens_3d(closure_n,xland1,aa0,aa1,xaa0_ens,mbdt,dtime, &
            ierr,ierr2,ierr3,xf_ens,axx,forcing,                             &
@@ -2056,6 +2146,7 @@ contains
        endif
        call cup_output_ens_3d(xff_mid,xf_ens,ierr,dellat_ens,dellaq_ens, &
             dellaqc_ens,outt,outq,outqc,dx,                              &
+            subten_h,subten_q,subten_t,subten_u,subten_v,                &
             zuo,pre,pwo_ens,xmb,ktop,                                    &
             edto,pwdo,'deep',ierr2,ierr3,                                &
             po_cup,pr_ens,maxens3,                                       &
@@ -2083,9 +2174,11 @@ contains
               do k = kts,jmin(i)-1
                  buoysrc(i,k)=-dellat_d(i,k)*xmb(i)*dtime
               end do
-              vcpool(i) = min(20., Kfr *sqrt(vcpool(i)))
+              !if(total_dz .gt.0.)then
+              vcpool(i) = min(10., Kfr *sqrt(vcpool(i)))
               slope_pool(i) = alpha_dd
               wlpool(i) = min(10.,  Kfr *sin( slope_pool(i)*pi/180. )* sqrt(wlpool(i)))
+              !endif
           enddo ! i-loop
           endif ! icoldpool
 
@@ -2286,9 +2379,15 @@ contains
              outu(i,1)=dellu(i,1)*xmb(i) 
              outv(i,1)=dellv(i,1)*xmb(i)
              do k=kts+1,ktop(i)
-               outu(i,k)=.25*(dellu(i,k-1)+2.*dellu(i,k)+dellu(i,k+1))*xmb(i) 
-               outv(i,k)=.25*(dellv(i,k-1)+2.*dellv(i,k)+dellv(i,k+1))*xmb(i) 
+               outu(i,k)=.25*((dellu(i,k-1)-subten_u(i,k-1))    &
+                         +2.*(dellu(i,k)-subten_u(i,k))     &
+                         +(dellu(i,k+1)-subten_u(i,k+1)))*xmb(i) 
+               outv(i,k)=.25*((dellv(i,k-1)-subten_v(i,k-1))    &
+                         +2.*(dellv(i,k)-subten_v(i,k))     &
+                         +(dellv(i,k+1)-subten_v(i,k+1)))*xmb(i) 
              enddo
+             subten_u(i,kts:ktop(i))=subten_u(i,kts:ktop(i))*xmb(i)
+             subten_v(i,kts:ktop(i))=subten_v(i,kts:ktop(i))*xmb(i)
           elseif(ierr(i).ne.0 .or. pre(i).eq.0.)then
              ktop(i)=0
              pre(i)=0.
@@ -2303,6 +2402,11 @@ contains
                outv(i,k)=0.
                cupclw(i,k)=0.
                cnvwt(i,k)=0.
+               subten_h(i,k)=0.
+               subten_q(i,k)=0.
+               subten_t(i,k)=0.
+               subten_u(i,k)=0.
+               subten_v(i,k)=0.
              enddo
           endif
       enddo
@@ -2318,40 +2422,40 @@ contains
            do k=kts+1,ktop(i)-1
              trash =-(po_cup(i,k)-po_cup(i,kts))
              if(trash.gt.300. .and. trash.lt.600.)then
-               dp=100.*(po_cup(i,k)-po_cup(i,k+1))
-               umcl(i)=umcl(i)+us(i,k)*dp
-               vmcl(i)=vmcl(i)+us(i,k)*dp
-               dpsum=dpsum+dp
+             dp=100.*(po_cup(i,k)-po_cup(i,k+1))
+             umcl(i)=umcl(i)+us(i,k)*dp
+             vmcl(i)=vmcl(i)+us(i,k)*dp
+             dpsum=dpsum+dp
              endif
            enddo
-           if(dpsum > 0.) then
-             umcl(i)=umcl(i)/dpsum
-             vmcl(i)=vmcl(i)/dpsum
-             MCL_speed= sqrt( umcl(i)**2 + vmcl(i)**2 )
-             aux =  (MCL_speed + vcpool(i))/(MCL_speed+1.e-6)
-             umcl(i) = aux * umcl(i)
-             vmcl(i) = aux * vmcl(i)
-           endif
+           umcl(i)=umcl(i)/dpsum
+           vmcl(i)=vmcl(i)/dpsum
+
+           MCL_speed= sqrt( umcl(i)**2 + vmcl(i)**2 )
+           aux =  (MCL_speed + vcpool(i))/(MCL_speed+1.e-6)
+           umcl(i) = aux * umcl(i)
+           vmcl(i) = aux * vmcl(i)
       enddo
       ! --- gust front momentum impact
       do i=its,itf
-        if(ierr(i) > 0 .or. vcpool(i) .le.0.) cycle
-        k=kts
-        dp=100.*(po_cup(i,k)-po_cup(i,k+1))
-        outu(i,k) = outu(i,k) + edto(i)*zdo(i,k+1)*umcl(i)*g/dp*xmb(i)
-        outv(i,k) = outv(i,k) + edto(i)*zdo(i,k+1)*vmcl(i)*g/dp*xmb(i)
-        do k=kts+1,kdet(i)
-          dp=100.*(po_cup(i,k)-po_cup(i,k+1))
-          outu(i,k) = outu(i,k) + edto(i)*dd_massdetro(i,k)*umcl(i)*g/dp*xmb(i)
-          outv(i,k) = outv(i,k) + edto(i)*dd_massdetro(i,k)*vmcl(i)*g/dp*xmb(i)
-        enddo
+          if(ierr(i) > 0 .or. vcpool(i) .le.0.) cycle
+             k=kts
+             dp=100.*(po_cup(i,k)-po_cup(i,k+1))
+             outu(i,k) = outu(i,k) + edto(i)*zdo(i,k+1)*umcl(i)*g/dp*xmb(i)
+             outv(i,k) = outv(i,k) + edto(i)*zdo(i,k+1)*vmcl(i)*g/dp*xmb(i)
+                do k=kts+1,kdet(i)
+                  dp=100.*(po_cup(i,k)-po_cup(i,k+1))
+                  outu(i,k) = outu(i,k) + edto(i)*dd_massdetro(i,k)*umcl(i)*g/dp*xmb(i)
+                  outv(i,k) = outv(i,k) + edto(i)*dd_massdetro(i,k)*vmcl(i)*g/dp*xmb(i)
+           enddo
       enddo
      endif ! icoldpool
+     if(icoldpool == 1)vcpool(:)=0.
 
 !$acc end kernels
 ! rain evaporation as in sas
 !
-      if(irainevap.eq.1)then
+      if(irainevap == 1)then
 !$acc kernels
       do i = its,itf
        rntot(i) = 0.
@@ -3442,6 +3546,7 @@ contains
                      endif
              enddo
              if(kk.gt.0)xff_ens3(4)=xomg/float(kk)
+             if(xff_ens3(4) < 0.)ierr(i)=42
             
 !
 ! max below kbcon
@@ -3483,6 +3588,8 @@ contains
 !gtest
              if(ichoice.eq.0)then
                 if(xff0.lt.0.)then
+                        ierr(i)=142
+                        xff_ens3(:)=0.
                      xff_ens3(1)=0.
                      xff_ens3(2)=0.
                      xff_ens3(3)=0.
@@ -4039,7 +4146,7 @@ endif
 
 !> Checks for negative or excessive tendencies and corrects in a mass
 !! conversing way by adjusting the cloud base mass-flux.
-   subroutine neg_check(name,j,dt,q,outq,outt,outu,outv,                      &
+   subroutine neg_check(name,j,dt,q,outq,sq,outt,st,outu,su,outv,sv,          &
                         outqc,pret,its,ite,kts,kte,itf,ktf,ktop)
 
    integer,      intent(in   ) ::            j,its,ite,kts,kte,itf,ktf
@@ -4047,7 +4154,7 @@ endif
 
      real(kind=kind_phys), dimension (its:ite,kts:kte  )                    ,                 &
       intent(inout   ) ::                                                     &
-       outq,outt,outqc,outu,outv
+       outq,outt,outqc,outu,outv,sq,st,su,sv
      real(kind=kind_phys), dimension (its:ite,kts:kte  )                    ,                 &
       intent(inout   ) ::                                                     &
        q
@@ -4065,7 +4172,7 @@ endif
 !
 ! first do check on vertical heating rate
 !
-      thresh=300.01
+      thresh=800.01
 !      thresh=200.01        !ss
 !      thresh=250.01
       names=1.
@@ -4074,6 +4181,8 @@ endif
         names=1.
       endif
       scalef=86400.
+      icheck = 0
+      !if(icheck > 0 ) then
 !$acc kernels
 !$acc loop private(qmemf,qmem,icheck)
       do i=its,itf
@@ -4083,7 +4192,7 @@ endif
       qmem=0.
 !$acc loop reduction(min:qmemf)
       do k=kts,ktop(i)
-         qmem=(outt(i,k))*86400.
+         qmem=(outt(i,k)+st(i,k))*86400.
          if(qmem.gt.thresh)then
            qmem2=thresh/qmem
            qmemf=min(qmemf,qmem2)
@@ -4102,13 +4211,18 @@ endif
       enddo
       do k=kts,ktop(i)
          outq(i,k)=outq(i,k)*qmemf
+         sq(i,k)=sq(i,k)*qmemf
          outt(i,k)=outt(i,k)*qmemf
+         st(i,k)=st(i,k)*qmemf
          outu(i,k)=outu(i,k)*qmemf
+         su(i,k)=su(i,k)*qmemf
          outv(i,k)=outv(i,k)*qmemf
+         sv(i,k)=sv(i,k)*qmemf
          outqc(i,k)=outqc(i,k)*qmemf
       enddo
       pret(i)=pret(i)*qmemf 
       enddo
+      !endif
 !$acc end kernels
 !      return
 !
@@ -4127,14 +4241,14 @@ endif
       qmemf=1.
 !$acc loop reduction(min:qmemf)
       do k=kts,ktop(i)
-         qmem=outq(i,k)
+         qmem=outq(i,k)+sq(i,k)
          if(abs(qmem).gt.0. .and. q(i,k).gt.1.e-6)then
-         qtest=q(i,k)+(outq(i,k))*dt
+         qtest=q(i,k)+(outq(i,k)+sq(i,k))*dt
          if(qtest.lt.thresh)then
 !
 ! qmem2 would be the maximum allowable tendency
 !
-           qmem1=abs(outq(i,k))
+           qmem1=abs(outq(i,k)+sq(i,k))
            qmem2=abs((thresh-q(i,k))/dt)
            qmemf=min(qmemf,qmem2/qmem1)
            qmemf=max(0.,qmemf)
@@ -4143,9 +4257,13 @@ endif
       enddo
       do k=kts,ktop(i)
          outq(i,k)=outq(i,k)*qmemf
+         sq(i,k)=sq(i,k)*qmemf
          outt(i,k)=outt(i,k)*qmemf
+         st(i,k)=st(i,k)*qmemf
          outu(i,k)=outu(i,k)*qmemf
+         su(i,k)=su(i,k)*qmemf
          outv(i,k)=outv(i,k)*qmemf
+         sv(i,k)=sv(i,k)*qmemf
          outqc(i,k)=outqc(i,k)*qmemf
       enddo
       pret(i)=pret(i)*qmemf 
@@ -4157,6 +4275,7 @@ endif
 !! physical tendencies, precipitation, and mass-flux.
    subroutine cup_output_ens_3d(xff_mid,xf_ens,ierr,dellat,dellaq,dellaqc,  &
               outtem,outq,outqc,dx,                                         &
+              subten_h,subten_q,subten_t,subten_u,subten_v,                 &
               zu,pre,pw,xmb,ktop,                                           &
               edt,pwd,name,ierr2,ierr3,p_cup,pr_ens,                        &
               maxens3,                                                      &
@@ -4196,7 +4315,7 @@ endif
        xf_ens,pr_ens
      real(kind=kind_phys),    dimension (its:ite,kts:kte)                              &
         ,intent (inout  )                 ::                           &
-        outtem,outq,outqc
+        outtem,outq,outqc,subten_h,subten_q,subten_t,subten_u,subten_v
      real(kind=kind_phys),    dimension (its:ite,kts:kte)                              &
         ,intent (in  )                    ::                           &
         zu,pwd,p_cup
@@ -4354,57 +4473,31 @@ endif
              dtpw=0.
              do k=kts,ktop(i)
                dtpw=dtpw+pw(i,k,1)
-               outtem(i,k)= xmb(i)* dellat  (i,k,1)
-               outq  (i,k)= xmb(i)* dellaq  (i,k,1)
+               outtem(i,k)= xmb(i)* (dellat (i,k,1)-subten_t(i,k))
+               outq  (i,k)= xmb(i)* (dellaq  (i,k,1)-subten_q(i,k))
+               subten_t(i,k)=subten_t(i,k)*xmb(i)
+               subten_q(i,k)=subten_q(i,k)*xmb(i)
+               subten_h(i,k)=subten_h(i,k)*xmb(i)
                outqc (i,k)= xmb(i)* dellaqc(i,k,1)
             enddo
             PRE(I)=PRE(I)+XMB(I)*dtpw
-          endif
+        else
+             do k=kts,ktf
+               outtem(i,k)=0. 
+               outq(i,k)  = 0.
+               subten_t(i,k)=0.
+               subten_q(i,k)=0.
+               subten_h(i,k)=0.
+               outqc(i,k) = 0.
+             enddo
+             pre(i)=0.
+        endif
        enddo
 !$acc end kernels
- return
-
-!$acc kernels
-      do i=its,itf
-        pwtot(i)=0.
-        pre2(i)=0.
-        if(ierr(i).eq.0)then
-            do k=kts,ktop(i)
-              pwtot(i)=pwtot(i)+pw(i,k,1)
-            enddo
-            do k=kts,ktop(i)
-            dp=100.*(p_cup(i,k)-p_cup(i,k+1))/g
-            dtt =dellat  (i,k,1)
-            dtq =dellaq  (i,k,1)
-! necessary to drive downdraft
-            dtpwd=-pwd(i,k)*edt(i)
-! take from dellaqc first
-            dtqc=dellaqc (i,k,1)*dp - dtpwd
-! if this is negative, use dellaqc first, rest needs to come from rain
-           if(dtqc < 0.)then
-             dtpwd=dtpwd-dellaqc(i,k,1)*dp
-             dtqc=0.
-! if this is positive, can come from clw detrainment
-           else
-             dtqc=dtqc/dp
-             dtpwd=0.
-           endif
-           outtem(i,k)= xmb(i)* dtt
-           outq  (i,k)= xmb(i)* dtq
-           outqc (i,k)= xmb(i)* dtqc
-           xf_ens(i,:)=sig(i)*xf_ens(i,:)
-! what is evaporated
-           pre(i)=pre(i)-xmb(i)*dtpwd
-           pre2(i)=pre2(i)+xmb(i)*(pw(i,k,1)+edt(i)*pwd(i,k))
-!           write(15,124)k,dellaqc(i,k,1),dtqc,-pwd(i,k)*edt(i),dtpwd
-          enddo
-          pre(i)=-pre(i)+xmb(i)*pwtot(i)
-        endif
 #ifndef _OPENACC
 124     format(1x,i3,4e13.4)
 125     format(1x,2e13.4)
 #endif
-      enddo
 !$acc end kernels
 
    end subroutine cup_output_ens_3d
@@ -4856,6 +4949,7 @@ endif
 
      !-local vars
      real(kind=kind_phys), dimension (its:ite,kts:kte) :: hcot
+     real(kind=kind_phys), dimension (kts:kte) :: p_local, zu_local
 !$acc declare create(hcot)
      real(kind=kind_phys) :: entr_init,beta_u,dz,dbythresh,dzh2,zustart,zubeg,massent,massdetr
      real(kind=kind_phys) :: dby(kts:kte),dbm(kts:kte),zux(kts:kte)
@@ -4870,6 +4964,8 @@ endif
      if(name == 'shallow' .or. name == 'mid') dbythresh=1.
 
      !dby(:)=0.
+     p_local(:)=0.
+     zu_local(:)=0.
 
       is_deep = (name .eq. 'deep')
       is_mid = (name .eq. 'mid')
@@ -4883,6 +4979,8 @@ endif
       zuo(i,:)=0.
       dby(:)=0.
       dbm(:)=0.
+      p_local (kts:kte)=p_cup(i,kts:kte)
+      zu_local(kts:kte)=zuo(i,kts:kte)
       kbcon(i)=max(kbcon(i),2)
        start_level(i)=max(1,k22(i))
        zuo(i,start_level(i))=zustart
@@ -4936,8 +5034,9 @@ endif
               ierr(i)=41
               ktop(i)= 0
         else
-           call get_zu_zd_pdf_fim(kklev,p_cup(i,kts:kte),rand_vmas(i),zubeg,ipr,xland(i),zuh2,1,ierr(i),k22(i), &
-            kfinalzu+1,zuo(i,kts:kte),kts,kte,ktf,beta_u,kbcon(i),csum(i),pmin_lev(i))
+           call get_zu_zd_pdf_fim(kklev,p_local,rand_vmas(i),zubeg,ipr,xland(i),zuh2,1,ierr(i),k22(i), &
+            kfinalzu+1,zu_local,kts,kte,ktf,beta_u,kbcon(i),csum(i),pmin_lev(i))
+           zuo(i,kts:kte)=zu_local(kts:kte)
         endif
       endif ! end deep
       if ( is_mid ) then
@@ -4947,8 +5046,9 @@ endif
        else
            kfinalzu=ktop(i)
            ktopdby(i)=ktop(i)+1
-          call get_zu_zd_pdf_fim(kklev,p_cup(i,kts:kte),rand_vmas(i),zubeg,ipr,xland(i),zuh2,3, &
-            ierr(i),k22(i),ktopdby(i)+1,zuo(i,kts:kte),kts,kte,ktf,beta_u,kbcon(i),csum(i),pmin_lev(i))
+          call get_zu_zd_pdf_fim(kklev,p_local,rand_vmas(i),zubeg,ipr,xland(i),zuh2,3, &
+            ierr(i),k22(i),ktopdby(i)+1,zu_local,kts,kte,ktf,beta_u,kbcon(i),csum(i),pmin_lev(i))
+          zuo(i,kts:kte)=zu_local(kts:kte)
        endif
       endif ! mid
       if ( is_shallow ) then
@@ -4958,8 +5058,9 @@ endif
        else
            kfinalzu=ktop(i)
            ktopdby(i)=ktop(i)+1
-           call get_zu_zd_pdf_fim(kbcon(i),p_cup(i,kts:kte),rand_vmas(i),zubeg,ipr,xland(i),zuh2,2,ierr(i),k22(i), &
-             ktopdby(i)+1,zuo(i,kts:kte),kts,kte,ktf,beta_u,kbcon(i),csum(i),pmin_lev(i))
+           call get_zu_zd_pdf_fim(kbcon(i),p_local,rand_vmas(i),zubeg,ipr,xland(i),zuh2,2,ierr(i),k22(i), &
+             ktopdby(i)+1,zu_local,kts,kte,ktf,beta_u,kbcon(i),csum(i),pmin_lev(i))
+           zuo(i,kts:kte)=zu_local(kts:kte)
 
          endif
          endif ! shal
@@ -5895,5 +5996,56 @@ endif
      enddo
 !$acc end parallel
   end subroutine get_cloud_top
+      subroutine dellas_nosub(itf,ktf, its,ite, kts,kte,ierr,             &
+                      po_cup,tracer_env, tracer_cup,tracer_down,tracer_up,      &
+                      up_massentro,up_massdetro,dd_massentro,dd_massdetro,      &
+                      edto,zuo,zdo,k22,jmin,ktop,dellac)
+   implicit none
+   integer                       ,intent(in)    :: itf,ktf, its,ite, kts,kte
+   integer, dimension(its:ite)   ,intent(in)    :: ierr,k22,ktop,jmin
+   real(kind=kind_phys), dimension(:,:),intent(in)    :: tracer_env, tracer_cup,tracer_down,tracer_up
+   real(kind=kind_phys), dimension(:,:),intent(inout) :: dellac
+   real(kind=kind_phys), dimension(its:ite,kts:kte),intent(in)    :: po_cup,zuo,zdo, &
+                                 up_massentro,up_massdetro,dd_massentro,dd_massdetro
+   real(kind=kind_phys), dimension(its:ite),intent(in)    :: edto
+   integer i,k
+   real(kind=kind_phys)  :: dp,entupk,detup,detdo,entup,entdo,entdoj  
+
+      dellac(:,:)=0.
+!
+! no subsidence in dellas
+      do i=its,itf
+        if(ierr(i) /= 0)cycle
+          dp=100.*(po_cup(i,1)-po_cup(i,2))
+          dellac(i,1)=dellac(i,1)+(edto(i)*zdo(i,2)*tracer_down(i,2))*g/dp
+          if(k22(i).eq.2)then
+             entupk=zuo(i,2)
+             dellac(i,1)=dellac(i,1)-entupk*tracer_cup(i,2)*g/dp
+          endif
+          do k=kts+1,ktop(i)-1
+               detup=0.
+               detdo=0.
+               entup=0.
+               entdo=0.
+               entdoj=0.
+               dp=100.*(po_cup(i,k)-po_cup(i,k+1))
+            !  entrainment/detrainment for updraft
+               entdo=edto(i)*dd_massentro(i,k)*tracer_env(i,k)
+               detdo=edto(i)*dd_massdetro(i,k)*.5*(tracer_down(i,k+1)+tracer_down(i,k))
+               entup=up_massentro(i,k)*tracer_env(i,k)
+               detup=up_massdetro(i,k)*.5*(tracer_up(i,k+1)+tracer_up(i,k))
+            !  special levels
+               if(k == k22(i)-1) then
+                  entup=zuo(i,k+1)*tracer_cup(i,k+1)
+                  detup=0.
+               endif
+               if(k.eq.jmin(i))entdoj=edto(i)*zdo(i,k)*tracer_cup(i,k)
+! mass budget
+               dellac(i,k) =dellac(i,k) + (detup+detdo-entdo-entup-entdoj)*g/dp
+          enddo
+               dellac(i,ktop(i))=zuo(i,ktop(i))*tracer_up(i,ktop(i))*g/dp
+       enddo ! i
+  end subroutine dellas_nosub
+
 !------------------------------------------------------------------------------------
 END MODULE module_cu_gf_deep

--- a/src/core_atmosphere/physics/physics_wrf/module_cu_gf_mpas.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_cu_gf_mpas.F
@@ -53,16 +53,18 @@ CONTAINS
 
  subroutine cu_grell_freitas( &
                itimestep,dt,dxcell,areacell                     &
-              ,u,v,t,w,q,p,pi,rho,dz8w,p8w                      &
-              ,xland,ht,hfx,qfx,gsw,rqvften,rthften             &
+              ,u,v,w,t,q,rho,p,pi,p8w,dz8w                      &
+              ,ht,xland,hfx,qfx,gsw,rqvften,rthften             &
               ,rthblten,rqvblten,rthraten,kpbl,xlv,cp,g,r_v     &
               ,ichoice_deep,ichoice_shallow,ishallow_g3         &
               ,htop,hbot,k22_shallow,kbcon_shallow,ktop_shallow &
               ,xmb_total,xmb_shallow,raincv,pratec,gdc,gdc2     &
               ,rthcuten,rqvcuten,rqccuten,rqicuten              &
-              ,rucuten,rvcuten                                  &
+              ,rucuten,rvcuten,bilbc,sub3d                      &
               ,pbl_scheme, maxmf, qc3d, qi3d                    &
-              ,qc_cu, qi_cu, cldfrac_cu, refl10cm_cu            &
+              ,qc_cu, qi_cu, cldfrac_cu, vcpool ,sig_deep       &
+              ,sub3d_rthcuten,sub3d_rqvcuten,sub3d_rucuten      &
+              ,sub3d_rvcuten,rainncv,refl10cm_cu                &
               ,ims, ime, jms, jme, kms,kme                      &
               ,ids, ide, jds, jde, kds,kde                      &
               ,its, ite, jts, jte, kts,kte)
@@ -92,28 +94,33 @@ CONTAINS
                       ims,ime,jms,jme,kms,kme, & 
                       its,ite,jts,jte,kts,kte
 
- integer,intent(in):: ichoice_deep,ichoice_shallow,itimestep
+ integer,intent(in):: sub3d,ichoice_deep,ichoice_shallow,itimestep
  integer,intent(in):: ishallow_g3
 
- integer,dimension(ims:ime,jms:jme ),intent(in):: kpbl
+ integer,dimension(ims:ime,jms:jme ),intent(in):: kpbl,bilbc
 
  real,intent(in):: dt
  real,intent(in):: xlv,r_v,cp,g
  real,dimension(ims:ime,jms:jme),intent(in):: areaCell,dxCell
- real,dimension(ims:ime,jms:jme),intent(in):: hfx,qfx,gsw,ht,xland,maxmf
+ real,dimension(ims:ime,jms:jme),intent(in):: hfx,qfx,gsw,ht,xland,maxmf,rainncv
 
  real,dimension(ims:ime,kms:kme,jms:jme),intent(in):: u,v,w,p,pi,q,rho,t
  real,dimension(ims:ime,kms:kme,jms:jme),intent(in):: dz8w,p8w
  real,dimension(ims:ime,kms:kme,jms:jme),intent(in):: rqvblten,rthblten,rthraten
  real,dimension(ims:ime,kms:kme,jms:jme),intent(in),optional:: rthften,rqvften
  real,dimension(ims:ime,kms:kme,jms:jme),intent(inout):: qc3d,qi3d
+ real,dimension(ims:ime,kms:kme,jms:jme),intent(inout):: sub3d_rthcuten        &
+                                                        ,sub3d_rqvcuten        &
+                                                        ,sub3d_rucuten         &
+                                                        ,sub3d_rvcuten
+
  character(*),intent(in):: pbl_scheme
 
 
 !inout arguments:
  integer,dimension(ims:ime,jms:jme),intent(inout):: k22_shallow,kbcon_shallow,ktop_shallow
 
- real,dimension(ims:ime,jms:jme),intent(inout):: hbot,htop,raincv,pratec,xmb_total,xmb_shallow
+ real,dimension(ims:ime,jms:jme),intent(inout):: hbot,htop,raincv,pratec,xmb_total,xmb_shallow,vcpool,sig_deep
  real,dimension(ims:ime,kms:kme,jms:jme),intent(inout):: rthcuten,rqvcuten,rqccuten,rqicuten
  real,dimension(ims:ime,kms:kme,jms:jme),intent(inout):: rucuten,rvcuten
  real,dimension(ims:ime,kms:kme,jms:jme),intent(inout),optional:: gdc,gdc2
@@ -132,13 +139,15 @@ CONTAINS
  integer,dimension(its:ite):: kbcon,ktop,k22s,k22,kbcons,ktops,jmin,kbconm,ktopm,k22m,jminm
 
  real:: dp,dq,pahfs,pgeoh,pqhfl,zkhvfl,zrho,zws,psum,clwtot
- real,dimension(its:ite):: area_loc,dx_loc
- real,dimension(its:ite):: xlandi,hfxi,qfxi
+ real,dimension(its:ite):: area_loc,dx_loc,vcpool_d,vcpool_m
+ real,dimension(its:ite):: xlandi,hfxi,qfxi,factor,mc_thresh
  real,dimension(its:ite):: xmb,xmbm,xmbs,xmb_dumm
  real,dimension(its:ite):: ccn
  real,dimension(its:ite):: cuten,psur,pret,pretm,prets,ter11,zqexec,ztexec,pmean,umean,vmean
  real,dimension(its:ite,kts:kte):: zo,t2d,q2d,po,p2d,us,vs,qc,qi,rhoi,tn,qo,tshall,qshall
  real,dimension(its:ite,kts:kte):: outt,outq,outqc,phh,cupclw,outu,outv
+ real,dimension(its:ite,kts:kte):: subten_h,subten_t,subten_q,subten_u,subten_v
+ real,dimension(its:ite,kts:kte):: subtenm_h,subtenm_t,subtenm_q,subtenm_u,subtenm_v
  real,dimension(its:ite,kts:kte):: outtm,outqm,outqcm,cupclwm,outum,outvm
  real,dimension(its:ite,kts:kte):: outts,outqs,outqcs,cupclws,outus,outvs,dhdt,gf_mfx
 
@@ -157,12 +166,13 @@ CONTAINS
  real,dimension (its:ite)         :: cap_suppress_j,rand_mom,rand_vmas
  integer,  dimension (its:ite) :: csum,csum_m
  real,dimension (its:ite,4)       :: rand_clos
- logical                          :: do_smoke_transport
+ logical                          :: do_smoke_transport,result
  !
  ! local variables on output for diagnostics for new GF/C3 scheme
  !
  real,dimension (its:ite,10)       :: forcing,forcingm
  real,dimension (its:ite)          :: edto,edtd,edtm,frh_out,frhm,frhs
+ real                              :: rain_thresh
  real,dimension (its:ite,kts:kte)  :: zuo,zdo,zum,zus,zdm,zdd,cnvwt,cnvwtm,cnvwts
   
  itf = min(ite,ide-1)
@@ -178,11 +188,13 @@ CONTAINS
  ipr = ite
  jpr = jte
 
- imid     = 1
+ imid     = 0
  ishallow = ishallow_g3
+ mc_thresh(:)=0.
  if (dx_loc(its)<6500.) imid = 0
  if (trim(pbl_scheme)=="bl_mynn") ishallow = 0
-
+ ishallow=0
+ rain_thresh=0. ! (mm/hr)
  do j = jts, jte
     do i = its, ite
        hbot(i,j)      = real(kte)
@@ -190,12 +202,12 @@ CONTAINS
        xmb_total(i,j) = 0.
        raincv(i,j)    = 0.
        pratec(i,j)    = 0.
-
        !shallow convection:
        k22_shallow(i,j)   = 0
        kbcon_shallow(i,j) = 0
        ktop_shallow(i,j)  = 0
        xmb_shallow(i,j)   = 0.
+       !if(xland(i,j) < 1.)mc_thresh(i)=3.*1.e-4
     enddo
  enddo
 
@@ -286,15 +298,18 @@ CONTAINS
        prets(i)     = 0.
        zqexec(i)   = 0.
        ztexec(i)   = 0.
+       vcpool_d(i)   = 0.
+       vcpool_m(i)   = 0.
     enddo
 
-    do k = kts, ktf
+     do k = kts, ktf
        do i = its, itf
           us(i,k)      = u(i,k,j)
           vs(i,k)      = v(i,k,j)
           rhoi(i,k)    = rho(i,k,j)
           t2d(i,k)     = t(i,k,j)
           q2d(i,k)     = q(i,k,j)
+          qcheck(i,k)     = q(i,k,j)
           qc(i,k)     = max(0.,qc3d(i,k,j))
           qi(i,k)     = max(0.,qi3d(i,k,j))
           if(q2d(i,k) .lt. 1.e-08) q2d(i,k) = 1.e-08
@@ -331,8 +346,18 @@ CONTAINS
           outt(i,k)    = 0.
           outts(i,k)   = 0.
           outtm(i,k)   = 0.
+          subtenm_h(i,k)=0.
+          subtenm_q(i,k)=0.
+          subtenm_t(i,k)=0.
+          subtenm_u(i,k)=0.
+          subtenm_v(i,k)=0.
        enddo
     enddo
+          subten_h(:,:)=0.
+          subten_q(:,:)=0.
+          subten_t(:,:)=0.
+          subten_u(:,:)=0.
+          subten_v(:,:)=0.
 
     !calculation of the moisture convergence:
        do k = kts+1, ktf
@@ -348,8 +373,18 @@ CONTAINS
           enddo
        enddo
        do i = its, itf
-          if(mconv(i) .lt. 0.) mconv(i) = 0.
-          if((dx_loc(i)<6500.).and.(trim(pbl_scheme)=="bl_mynn").and.(maxmf(i,jts).gt.0.))ierr(i)=555
+          if(mconv(i) .le. mc_thresh(i)) then
+                ierr(i)=42 
+                ierrm(i)=42 
+                mconv(i) = 0.
+          endif
+       !   if((dx_loc(i)<6500.).and.(trim(pbl_scheme)=="bl_mynn").and.(maxmf(i,jts).gt.0.))ierr(i)=555
+! fore regional domain, blend in tendencies in relaxation zone
+          if(bilbc(i,j).eq.7)ierr(i)=556
+          factor(i)=(6.-float(bilbc(i,j)))/7.+1./7.
+          if(bilbc(i,j) == 0 )factor(i)=1.
+! for high resolution runs, turn off convection if there is already significant precipitation from microphysics          
+          if(rainncv(i,j)/dt*3600. > rain_thresh .and. dx_loc(i) < 6500. .and. sub3d == 1)ierr(i)=44
        enddo
 
     if(use_excess.gt.0 .or. use_excess_sh.gt.0)then
@@ -434,7 +469,7 @@ CONTAINS
 !> - Call cu_gf_deep_run() for middle GF convection
       if(imid == 1)then
        call cu_gf_deep_run(        &
-               itf,ktf,its,ite, kts,kte  &
+               itf,ktf,its,ite, kts,kte,sub3d  &
               ,dicycle       &
               ,13            &
               ,ipr           &
@@ -491,6 +526,12 @@ CONTAINS
               ,chem3d        &
               ,wetdpc_mid    &
               ,do_smoke_transport   &
+              ,vcpool_m      &
+              ,subtenm_h     &
+              ,subtenm_q     &
+              ,subtenm_t     &
+              ,subtenm_u     &
+              ,subtenm_v     &
 !    the following should be set to zero if not available
               ,rand_mom      & ! for stochastics mom, if temporal and spatial patterns exist
               ,rand_vmas     & ! for stochastics vertmass, if temporal and spatial patterns exist
@@ -505,16 +546,18 @@ CONTAINS
               ,do_capsuppress,cap_suppress_j &
               ,k22m          &
               ,jminm)
-      call neg_check('mid',j,dt,q2d,outqm,outtm,outum,outvm,outqcm,pretm   &
+      call neg_check('mid',j,dt,q2d,outqm,subtenm_q,outtm,subtenm_t,outum,subtenm_u,  &
+                       outvm,subtenm_v,outqcm,pretm   &
                      ,its,ite,kts,kte,itf,ktf,ktopm)
              do i=its,ite
+!          if(outtm(i,10)*86400. .lt.-10. .or. subtenm_t(i,10)*86400. .gt. 10)print*,'gfmpas1',outtm(i,10)*86400.,subtenm_t(i,10)*86400.
                do k=kts,kte
-                 qcheck(i,k)=q2d(i,k)+outqm(i,k)*dt
+                 qcheck(i,k)=q2d(i,k)+(subtenm_q(i,k)+outqm(i,k))*dt
                enddo
              enddo
            endif
    call cu_gf_deep_run(        &
-               itf,ktf,its,ite, kts,kte  &
+               itf,ktf,its,ite, kts,kte,sub3d  &
               ,dicycle       &  ! diurnal cycle flag
               ,ichoice_deep  &  ! choice of closure, use "0" for ensemble average
               ,ipr           &  ! this flag can be used for debugging prints
@@ -571,6 +614,12 @@ CONTAINS
               ,chem3d        &
               ,wetdpc_deep   &
               ,do_smoke_transport   &
+              ,vcpool_d        &
+              ,subten_h     &
+              ,subten_q     &
+              ,subten_t     &
+              ,subten_u     &
+              ,subten_v     &
               ,rand_mom      &  ! for stochastics mom, if temporal and spatial patterns exist
               ,rand_vmas     &  ! for stochastics vertmass, if temporal and spatial patterns exist
               ,rand_clos     &  ! for stochastics closures, if temporal and spatial patterns exist
@@ -584,9 +633,10 @@ CONTAINS
               ,do_capsuppress,cap_suppress_j    &    !         
               ,k22                              &    !
               ,jmin)                         !
-
-      call neg_check('deep',j,dt,qcheck,outq,outt,outu,outv,outqc,pret    &
+      call neg_check('deep',j,dt,qcheck,outq,subten_q,outt,subten_t,  &
+                      outu,subten_u,outv,subten_v,outqc,pret    &
                      ,its,ite,kts,kte,itf,ktf,ktop)
+
 !    !... shallow convection:
     if(ishallow == 1 )then
 !       call cup_gf_sh( &
@@ -624,36 +674,55 @@ CONTAINS
 
     do i = its, ite
        if(pret(i) .gt. 0. .or. pretm(i).gt.0. .or. prets(i).gt.0.) then
-          xmb_total(i,j) = xmb(i)+xmbm(i)+xmbs(i)
-          pratec(i,j)    = pret(i)+pretm(i)+prets(i)
-          raincv(i,j)    = (pret(i)+pretm(i)+prets(i))*dt
+          vcpool(i,j)      = vcpool_d(i)*frh_out(i)
+          xmb_total(i,j) = factor(i)*(xmb(i)+xmbm(i)+xmbs(i))
+          sig_deep(i,j)=min(.999,1.-frh_out(i))
+          !sig_deep(i,j)=min(.999,frh_out(i))
+          pratec(i,j)    = factor(i)*(pret(i)+pretm(i)+prets(i))
+          raincv(i,j)    = factor(i)*(pret(i)+pretm(i)+prets(i))*dt
+!          if(outt(i,10)*86400. .lt.-1000. .or. subten_t(i,10)*86400. .gt. 1000)print*,'gfmpas1',outt(i,10)*86400.,subten_t(i,10)*86400.
+!          if(outt(i,10)*86400. .lt.-1000. .or. subten_t(i,10)*86400. .gt. 1000)print*,'gfmpas2',outt(i,25)*86400.,subten_t(i,25)*86400.
           ktopmax=max(ktopm(i),ktop(i),ktops(i))
           kbconmax=max(kbconm(i),kbcon(i),kbcons(i))
           
           if(ktopmax > htop(i,j) ) htop(i,j) = ktopmax + .001
           if(kbconmax < hbot(i,j)) hbot(i,j) = kbconmax + .001
+       else if (ierr(i).gt.0) then
+          sig_deep(i,j)=0.
+          factor(i)=0.
        endif
     enddo
 
     !... always save the tendencies of potential temperature, water vapor, cloud water, and cloud ice:
-    do k = kts, ktf
-       do i = its, itf
-          rthcuten(i,k,j) = (outts(i,k) + outt(i,k)+outtm(i,k))/pi(i,k,j)
-          rqvcuten(i,k,j) = outqs(i,k) + outq(i,k)+outqm(i,k)
-          rucuten(i,k,j) = outu(i,k)+outum(i,k)+outus(i,k)
-          rvcuten(i,k,j) = outv(i,k)+outvm(i,k)+outvs(i,k)
-          gf_mfx(i,k) = xmb(i)*zuo(i,k)/(1.e-8+forcing(i,6))+xmbm(i)*zum(i,k)+xmbs(i)*zus(i,k)
+    do k = kts, kte
+       do i = its, ite
+          rthcuten(i,k,j) = factor(i)*(outts(i,k) + outt(i,k)+outtm(i,k))/pi(i,k,j)
+          rqvcuten(i,k,j) = factor(i)*(outqs(i,k) + outq(i,k)+outqm(i,k))
+          rucuten(i,k,j) = factor(i)*(outu(i,k)+outum(i,k)+outus(i,k))
+          rvcuten(i,k,j) = factor(i)*(outv(i,k)+outvm(i,k)+outvs(i,k))
+          sub3d_rthcuten(i,k,j) = factor(i)*subten_t(i,k)/pi(i,k,j)
+          sub3d_rqvcuten(i,k,j) = factor(i)*subten_q (i,k)
+          sub3d_rucuten (i,k,j) = factor(i)*subten_u (i,k)
+          sub3d_rvcuten (i,k,j) = factor(i)*subten_v (i,k)
 
+!---temporary setting -- must be removed once the subsidence tendencies are correct
+                  !sub3d_rthcuten(i,k,j) = 2.e-5
+                  !sub3d_rqvcuten(i,k,j) = 3.e-8 
+                  !sub3d_rucuten (i,k,j) = 4.e-7 
+                  !sub3d_rvcuten (i,k,j) = 5.e-7
+!---temporary setting -- 
+
+          gf_mfx(i,k) =xmb(i)*zuo(i,k)+xmbm(i)*zum(i,k)+xmbs(i)*zus(i,k)
           if(t2d(i,k) .lt. tcrit) then
              rqccuten(i,k,j) = 0.
-             rqicuten(i,k,j) = outqcs(i,k) + outqc(i,k) + outqcm(i,k)
-             if(present(gdc2)) gdc2(i,k,j) = frhs(i)*cupclws(i,k) + frh_out(i)*cupclw(i,k) + frhm(i)*cupclwm(i,k)
-             qi_cu(i,k,j)=gdc2(i,k,j)
+             rqicuten(i,k,j) = factor(i)*(outqcs(i,k) + outqc(i,k) + outqcm(i,k))
+             if(present(gdc2)) gdc2(i,k,j) = factor(i)*(frhs(i)*cupclws(i,k) + frh_out(i)*cupclw(i,k) + frhm(i)*cupclwm(i,k))
+             qi_cu(i,k,j)=factor(i)*gdc2(i,k,j)
           else
              rqicuten(i,k,j) = 0.
-             rqccuten(i,k,j) = outqcs(i,k) + outqc(i,k) + outqcm(i,k)
-             if(present(gdc)) gdc(i,k,j) = frhs(i)*cupclws(i,k) + frh_out(i)*cupclw(i,k) + frhm(i)*cupclwm(i,k)
-             qc_cu(i,k,j)=gdc(i,k,j)
+             rqccuten(i,k,j) = factor(i)*(outqcs(i,k) + outqc(i,k) + outqcm(i,k))
+             if(present(gdc)) gdc(i,k,j) = factor(i)*(frhs(i)*cupclws(i,k) + frh_out(i)*cupclw(i,k) + frhm(i)*cupclwm(i,k))
+             qc_cu(i,k,j)=factor(i)*gdc(i,k,j)
           endif
        enddo
     enddo

--- a/src/framework/mpas_halo.F
+++ b/src/framework/mpas_halo.F
@@ -152,7 +152,8 @@ module mpas_halo
 
         use mpas_derived_types, only : domain_type, mpas_pool_type, mpas_pool_iterator_type, MPAS_POOL_CONFIG, &
                                        MPAS_POOL_REAL, MPAS_HALO_REAL, mpas_halo_group, MPAS_LOG_CRIT, &
-                                       field1DReal, field2DReal, field3DReal
+                                       field2DReal, field3DReal, &
+                                       field1DReal
         use mpas_pool_routines, only : mpas_pool_get_subpool, mpas_pool_remove_subpool, mpas_pool_destroy_pool, &
                                        mpas_pool_begin_iteration, mpas_pool_get_next_member, mpas_pool_get_dimension, &
                                        mpas_pool_remove_field, mpas_pool_get_field
@@ -395,7 +396,8 @@ module mpas_halo
     subroutine mpas_halo_exch_group_add_field(domain, groupName, fieldName, timeLevel, haloLayers, iErr)
 
         use mpas_derived_types, only : domain_type, mpas_pool_type, mpas_pool_field_info_type, MPAS_POOL_REAL, &
-                                       field1DReal, field2DReal, field3DReal, MPAS_LOG_CRIT
+                                       field2DReal, field3DReal, MPAS_LOG_CRIT, &
+                                       field1DReal
         use mpas_pool_routines, only : mpas_pool_get_subpool, mpas_pool_add_config, mpas_pool_get_field_info, &
                                        mpas_pool_add_dimension, mpas_pool_get_field, mpas_pool_add_field
         use mpas_log, only : mpas_log_write

--- a/src/framework/mpas_halo.F
+++ b/src/framework/mpas_halo.F
@@ -152,7 +152,7 @@ module mpas_halo
 
         use mpas_derived_types, only : domain_type, mpas_pool_type, mpas_pool_iterator_type, MPAS_POOL_CONFIG, &
                                        MPAS_POOL_REAL, MPAS_HALO_REAL, mpas_halo_group, MPAS_LOG_CRIT, &
-                                       field2DReal, field3DReal
+                                       field1DReal, field2DReal, field3DReal
         use mpas_pool_routines, only : mpas_pool_get_subpool, mpas_pool_remove_subpool, mpas_pool_destroy_pool, &
                                        mpas_pool_begin_iteration, mpas_pool_get_next_member, mpas_pool_get_dimension, &
                                        mpas_pool_remove_field, mpas_pool_get_field
@@ -170,6 +170,7 @@ module mpas_halo
         integer, dimension(:), pointer :: fieldHaloInfo
         integer, dimension(:), pointer :: haloLayers
         type (mpas_halo_group), pointer :: newGroup
+        type (field1DReal), pointer :: r1d
         type (field2DReal), pointer :: r2d
         type (field3DReal), pointer :: r3d
         integer, pointer :: timeLevel
@@ -229,7 +230,14 @@ module mpas_halo
                 end select
 
                 if (fieldHaloInfo(1) == MPAS_POOL_REAL) then
-                    if (fieldHaloInfo(2) == 2) then
+                    if (fieldHaloInfo(2) == 1) then
+                        call mpas_pool_get_field(completedGroup, trim(itr % memberName)//'.field', r1d)
+                        call mpas_halo_compact_halo_info(domain, r1d % sendList, r1d % recvList, r1d % dimSizes, &
+                                                         haloLayers, &
+                                                         newGroup % fields(i) % compactHaloInfo, &
+                                                         newGroup % fields(i) % compactSendLists, &
+                                                         newGroup % fields(i) % compactRecvLists)
+                    else if (fieldHaloInfo(2) == 2) then
                         call mpas_pool_get_field(completedGroup, trim(itr % memberName)//'.field', r2d)
                         call mpas_halo_compact_halo_info(domain, r2d % sendList, r2d % recvList, r2d % dimSizes, &
                                                          haloLayers, &
@@ -387,7 +395,7 @@ module mpas_halo
     subroutine mpas_halo_exch_group_add_field(domain, groupName, fieldName, timeLevel, haloLayers, iErr)
 
         use mpas_derived_types, only : domain_type, mpas_pool_type, mpas_pool_field_info_type, MPAS_POOL_REAL, &
-                                       field2DReal, field3DReal, MPAS_LOG_CRIT
+                                       field1DReal, field2DReal, field3DReal, MPAS_LOG_CRIT
         use mpas_pool_routines, only : mpas_pool_get_subpool, mpas_pool_add_config, mpas_pool_get_field_info, &
                                        mpas_pool_add_dimension, mpas_pool_get_field, mpas_pool_add_field
         use mpas_log, only : mpas_log_write
@@ -405,6 +413,7 @@ module mpas_halo
         type (mpas_pool_field_info_type) :: info
         integer, allocatable, dimension(:) :: fieldHaloInfo
         integer :: local_timeLevel
+        type (field1DReal), pointer :: r1d
         type (field2DReal), pointer :: r2d
         type (field3DReal), pointer :: r3d
 
@@ -456,7 +465,10 @@ module mpas_halo
         ! Store a reference to the field itself in the pool
         !
         if (info % fieldType == MPAS_POOL_REAL) then
-            if (info % nDims == 2) then
+            if (info % nDims == 1) then
+                call mpas_pool_get_field(domain % blocklist % allFields, fieldName, r1d, timeLevel=local_timeLevel)
+                call mpas_pool_add_field(group, fieldName//'.field', r1d)
+            else if (info % nDims == 2) then
                 call mpas_pool_get_field(domain % blocklist % allFields, fieldName, r2d, timeLevel=local_timeLevel)
                 call mpas_pool_add_field(group, fieldName//'.field', r2d)
             else if (info % nDims == 3) then
@@ -619,6 +631,26 @@ module mpas_halo
                 maxNSendList = group % fields(i) % maxNSendList
 
                 select case (group % fields(i) % nDims)
+                !
+                ! Packing code for 1-d real-valued fields
+                !
+                case (1)
+                    call mpas_pool_get_array(domain % blocklist % allFields, trim(group % fields(i) % fieldName), &
+                                             group % fields(i) % r1arr, timeLevel=group % fields(i) % timeLevel)
+
+                    !
+                    ! Pack send buffer for all neighbors for current field
+                    !
+                    do iEndp = 1, nSendEndpts
+                        do iHalo = 1, nHalos
+                            do j = 1, maxNSendList
+                                if (j <= nSendLists(iHalo,iEndp)) then
+                                    group % sendBuf(packOffsets(iEndp) + sendListDst(j,iHalo,iEndp)) = &
+                                        group % fields(i) % r1arr(sendListSrc(j,iHalo,iEndp))
+                                end if
+                            end do
+                        end do
+                    end do
 
                 !
                 ! Packing code for 2-d real-valued fields
@@ -730,6 +762,21 @@ module mpas_halo
                     dim2 = compactHaloInfo(3)
 
                     select case (group % fields(i) % nDims)
+                    !
+                    ! Unpacking code for 1-d real-valued fields
+                    !
+                    case (1)
+                        !
+                        ! Unpack recv buffer from all neighbors for current field
+                        !
+                        do iHalo = 1, nHalos
+                            do j = 1, maxNRecvList
+                                if (j <= nRecvLists(iHalo,iEndp)) then
+                                    group % fields(i) % r1arr(recvListDst(j,iHalo,iEndp)) = &
+                                        group % recvBuf(unpackOffsets(iEndp) + recvListSrc(j,iHalo,iEndp))
+                                end if
+                            end do
+                        end do
 
                     !
                     ! Unpacking code for 2-d real-valued fields
@@ -780,7 +827,9 @@ module mpas_halo
         ! to not leave pointers to what might later be incorrect targets
         !
         do i = 1, group % nFields
-            if (group % fields(i) % nDims == 2) then
+            if (group % fields(i) % nDims == 1) then
+                nullify(group % fields(i) % r1arr)
+            else if (group % fields(i) % nDims == 2) then
                 nullify(group % fields(i) % r2arr)
             else if (group % fields(i) % nDims == 3) then
                 nullify(group % fields(i) % r3arr)

--- a/src/framework/mpas_halo_types.inc
+++ b/src/framework/mpas_halo_types.inc
@@ -31,6 +31,7 @@
         integer, dimension(:,:,:), CONTIGUOUS pointer :: recvListDst => null()  ! (maxNRecvList,nHalos,nRecvEndpts)
         integer, dimension(:), CONTIGUOUS pointer :: unpackOffsets => null()    ! (nRecvEndpts)
 
+	real (kind=RKIND), dimension(:), pointer :: r1arr => null()      ! Pointer to field array, only used internally
         real (kind=RKIND), dimension(:,:), pointer :: r2arr => null()    ! Pointer to field array, only used internally
         real (kind=RKIND), dimension(:,:,:), pointer :: r3arr => null()  ! Pointer to field array, only used internally
     end type mpas_halo_field


### PR DESCRIPTION
This is a new scale-aware approach for GF convection with subsidence spreading. When run the model, a new parameter of config_gf_sub3d in the namelist.atmosphere is used to determine how to select the scale-aware approach, By default, config_gf_sub3d=0 is the traditional approach. When config_gf_sub3d=1, the subsidence of tendencies are spreading to the 1st layer neighboring grids. When config_gf_sub3d=2, the subsidence of tendencies are spreading to the 1st and 2nd layers of neighboring grids. 

This PR has been tested on Jet with Intel compiler. 

<details>
  <summary>
    test case results
  </summary>

```
  1 
  2    test_hash_to_compare = 7d715f24d
  3       gsl_hash_baseline = d469f0ed6
  4      ncar_hash_baseline = 41e9a3fb8
  5          test_directory = /mnt/lfs5/BMC/gsd-fv3-dev/Haiqin.Li/mpas-gsl/mpas_testcase/run_case/
  6  gsl_baseline_directory = /lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/
  7 ncar_baseline_directory = /lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/
  8            compile_flag = -intdebug
  9          test_repo_name = gsl
 10 
 11 ######################################################################
 12 # compare to previous GSL CONUS mesoscale_reference baselines A1GSL
 13 ######################################################################
 14 
 15   === history.2023-03-10_15.00.00.nc comparison
 16 Files "/mnt/lfs5/BMC/gsd-fv3-dev/Haiqin.Li/mpas-gsl/mpas_testcase/run_case/gsl-7d715f24d-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wr    fruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-d469f0ed6-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.
 17 
 18   === history.2023-03-10_15.12.00.nc comparison
 19 Files "/mnt/lfs5/BMC/gsd-fv3-dev/Haiqin.Li/mpas-gsl/mpas_testcase/run_case/gsl-7d715f24d-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/BMC/wr    fruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-d469f0ed6-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.
 20 
 21   === history.2023-03-10_16.00.00.nc comparison
 22 Variable               Group  Count          Sum      AbsSum          Min         Max       Range         Mean      StdDev
 23 qv                     /      48945   0.00386438    0.042342 -0.000976536 0.000811956  0.00178849  7.89535e-08 1.09757e-05
 24 qc                     /        913   1.4785e-05   0.0112392 -0.000551464 0.000406107 0.000957571  1.61939e-08 5.07602e-05
 25 qr                     /       1610  0.000173852  0.00217856 -5.57418e-05  9.1645e-05 0.000147387  1.07983e-07 5.52115e-06
 26 qi                     /       7476 -0.000421567  0.00311177 -2.86886e-05 6.60597e-05 9.47483e-05 -5.63893e-08 1.81713e-06
 27 qs                     /       5190  -0.00238576  0.00361717 -3.22015e-05 2.51369e-05 5.73385e-05 -4.59685e-07 1.93879e-06
 28 qg                     /       4418 -0.000133407 0.000286291 -1.80972e-05 1.10782e-05 2.91754e-05 -3.01963e-08 5.98473e-07
 29 u                      /     167129      2.22503     623.733     -2.33459     2.25468     4.58927  1.33132e-05   0.0308596
 30 w                      /      67550     -1.81588     5.37249   -0.0128017  0.00460545   0.0174071  -2.6882e-05 0.000299131
 31 pressure               /      49698      993.691     20235.5     -378.484      239.43     617.914    0.0199946     4.76404
 32 surface_pressure       /        901      107.781     1027.31     -81.8594     164.242     246.102     0.119624     6.72459
 33 rho                    /      50532    -0.055917    0.846859   -0.0117505  0.00822115   0.0199716 -1.10657e-06 0.000148867
 34 theta                  /      46732      13.9189     223.058     -1.84998     2.83725     4.68723  0.000297844   0.0330637
 35 relhum                 /      52306     -76.8757     1298.81     -15.2756     24.9763     40.2518  -0.00146973    0.268999
 36 divergence             /      60421  4.42321e-08  0.00277419 -1.21357e-05 1.13601e-05 2.34958e-05  7.32065e-13  2.6052e-07
 37 vorticity              /     112242  3.36782e-07  0.00901244 -4.12307e-05 2.98395e-05 7.10702e-05   3.0005e-12 6.95306e-07
 38 ke                     /      60216     -72.0012     2613.71     -15.3132      16.944     32.2573  -0.00119572    0.284406
 39 uReconstructZonal      /      60008      2.88423     200.103     -1.73497     1.80258     3.53754  4.80641e-05   0.0266162
 40 uReconstructMeridional /      60308     -2.09461     182.232     -1.33836      1.3606     2.69895 -3.47318e-05   0.0237866
 41 ertel_pv               /      61140      7.60535     108.588      -1.2611     2.71302     3.97412  0.000124392   0.0188268
 42 u_pv                   /       1089     -0.18305     1.07033   -0.0248756   0.0680943   0.0929699  -0.00016809  0.00331279
 43 v_pv                   /       1112    0.0364013    0.746046   -0.0135841   0.0547066   0.0682907   3.2735e-05  0.00204446
 44 theta_pv               /        977     -0.31427     1.05902   -0.0600891   0.0516357    0.111725 -0.000321668  0.00330951
 45 vort_pv                /       1112 -2.86239e-07  5.6836e-06 -2.53407e-07 6.35628e-07 8.89035e-07 -2.57409e-10 2.68736e-08
 46 depv_dt_lw             /      60337 -0.000114271    0.020238 -0.000127245 0.000132524 0.000259769 -1.89388e-09  1.8569e-06
 47 depv_dt_sw             /      60449   0.00303819   0.0216939 -6.12423e-05  6.5947e-05 0.000127189  5.02603e-08 1.43224e-06
 48 depv_dt_bl             /      60251   0.00745676   0.0555019 -0.000821849  0.00486501  0.00568686  1.23762e-07 2.39694e-05
 49 depv_dt_cu             /      20122   0.00225074   0.0711472  -0.00197791  0.00173782  0.00371573  1.11855e-07 4.34771e-05
 50 depv_dt_mix            /      65022 -2.12558e-05  0.00126057 -1.94189e-05 1.00653e-05 2.94843e-05 -3.26902e-10 1.84186e-07
 51 dtheta_dt_mp           /      14413   -0.0118428   0.0655192  -0.00156784 0.000847965  0.00241581 -8.21676e-07 3.44313e-05
 52 depv_dt_mp             /      34572  -0.00124609   0.0448874   -0.0010877 0.000677555  0.00176525 -3.60434e-08 1.57995e-05
 53 depv_dt_diab           /      64970    0.0113641    0.113928  -0.00149939  0.00480546  0.00630485  1.74912e-07  2.8374e-05
 54 depv_dt_fric           /      66399  -0.00163309   0.0362658 -0.000701358 0.000358966  0.00106032 -2.45951e-08 6.24467e-06
 55 depv_dt_diab_pv        /       1175  0.000115324 0.000189304 -8.84473e-06 7.23693e-05  8.1214e-05  9.81485e-08 2.15973e-06
 56 depv_dt_fric_pv        /       1212 -1.93594e-05 5.39188e-05 -2.19117e-05 5.54403e-06 2.74557e-05 -1.59731e-08 7.24469e-07
 57 rainnc                 /        663   -0.0154195    0.220709  -0.00999486   0.0197239   0.0297187 -2.32571e-05  0.00142975
 58 precipw                /        926     0.566892     1.64322   -0.0553503   0.0373859   0.0927362  0.000612195  0.00512782
 59 cuprec                 /         91  4.89159e-05 0.000145134 -1.05696e-05 5.32626e-05 6.38322e-05  5.37537e-07 6.08585e-06
 60 rainc                  /         98    0.0145268    0.145041    -0.013737   0.0228976   0.0366346  0.000148233  0.00395249
 61 kpbl                   /         51            5          77           -4          10          14    0.0980392     2.20232
 62 hpbl                   /        944      682.034     6543.19     -234.366     1110.55     1344.92     0.722493     46.4151
 63 hfx                    /       1015      168.962      4736.8      -59.936     79.8549     139.791     0.166465     12.7098
 64 qfx                    /       1003  -1.5216e-05 0.000734104 -1.53165e-05 1.59315e-05  3.1248e-05 -1.51705e-08 2.13005e-06
 65 cd                     /        956  0.000871542   0.0865168  -0.00205779  0.00326906  0.00532685  9.11654e-07 0.000292707
 66 cda                    /        963  -0.00021217    0.079111  -0.00171188  0.00264494  0.00435682 -2.20321e-07 0.000251002
 67 ck                     /        977  -0.00129054   0.0229201 -0.000356044 0.000572963 0.000929006 -1.32092e-06 6.20747e-05
 68 cka                    /        985  -0.00165321   0.0242567 -0.000330771 0.000535918 0.000866689 -1.67838e-06 6.33135e-05
 69 lh                     /       1001     -60.1372     1884.88     -38.3066     39.8447     78.1512   -0.0600771      5.3837
 70 u10                    /       1054      1.63824     8.27247    -0.205225    0.392202    0.597427   0.00155431   0.0239913
 71 v10                    /       1058     0.900571     7.83083    -0.184163    0.284031    0.468194  0.000851202   0.0219846
 72 q2                     /        928  0.000220005  0.00387214  -5.9586e-05 0.000118938 0.000178524  2.37075e-07  1.1473e-05
 73 t2m                    /        826     -1.70181     25.1016    -0.276093    0.371857    0.647949  -0.00206031   0.0661023
 74 th2m                   /        820     -1.89386     25.7549    -0.276093    0.378662    0.654755  -0.00230959   0.0677455
 75 gsw                    /        656     -6627.89     16185.3     -158.473     148.589     307.062     -10.1035     40.0296
 76 glw                    /        646      2527.04     2799.52     -5.56015     28.5363     34.0964      3.91182     6.18278
 77 acsnow                 /        219   -0.0291812   0.0411574   -0.0154515  0.00123506   0.0166866 -0.000133248  0.00137745
 78 skintemp               /        652     -1.85742     190.963     -2.42166     3.53732     5.95898  -0.00284881    0.597329
 79 snow                   /        313      1.73677     2.53218   -0.0400391    0.131815    0.171854   0.00554877   0.0205215
 80 snowh                  /        312    0.0159452   0.0208751 -0.000455976  0.00212276  0.00257874  5.11063e-05 0.000233864
 81 sh2o                   /       1146   -0.0162074   0.0253993  -0.00111066 0.000553042   0.0016637 -1.41426e-05 8.51747e-05
 82 smois                  /       1080  -0.00838593   0.0162073 -0.000910491 0.000193775  0.00110427 -7.76475e-06 6.42282e-05
 83 tslb                   /        623     0.515259     11.6254    -0.191895    0.234253    0.426147  0.000827061   0.0427283
 84 
 85 ######################################################################
 86 # compare to previous GSL CONUS hrrrv5 GFS baselines C5GSL
 87 ######################################################################
 88 
 89   === history.2023-03-10_15.00.00.nc comparison
 90 Files "/mnt/lfs5/BMC/gsd-fv3-dev/Haiqin.Li/mpas-gsl/mpas_testcase/run_case/gsl-7d715f24d-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Ba    rlage/mpas/baselines_mpas/run_case/gsl-d469f0ed6-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.
 91 
 92   === history.2023-03-10_15.12.00.nc comparison
 93 Files "/mnt/lfs5/BMC/gsd-fv3-dev/Haiqin.Li/mpas-gsl/mpas_testcase/run_case/gsl-7d715f24d-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Ba    rlage/mpas/baselines_mpas/run_case/gsl-d469f0ed6-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.
 94 
 95   === history.2023-03-10_16.00.00.nc comparison
 96 Variable Group Count         Sum     AbsSum          Min         Max       Range         Mean      StdDev
 97 q2       /         3 -4.3474e-05 0.00011096 -5.65659e-05 3.37432e-05 9.03091e-05 -1.44913e-05 4.54686e-05
 98 t2m      /         3     4.86951    4.86951      0.51535      3.2197     2.70435      1.62317     1.41686
 99 th2m     /         3     4.87262    4.87262     0.516479     3.22147     2.70499      1.62421     1.41738
100 
101 ######################################################################
102 # compare to previous GSL CONUS hrrrv5 RAP winter baselines C7GSL
103 ######################################################################
104 
105   === history.2024-02-02_18.00.00.nc comparison
106 Files "/mnt/lfs5/BMC/gsd-fv3-dev/Haiqin.Li/mpas-gsl/mpas_testcase/run_case/gsl-7d715f24d-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Ba    rlage/mpas/baselines_mpas/run_case/gsl-d469f0ed6-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.00.00.nc" are identical.
107 
108   === history.2024-02-02_18.12.00.nc comparison
109 Files "/mnt/lfs5/BMC/gsd-fv3-dev/Haiqin.Li/mpas-gsl/mpas_testcase/run_case/gsl-7d715f24d-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Ba    rlage/mpas/baselines_mpas/run_case/gsl-d469f0ed6-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.12.00.nc" are identical.
110 
111   === history.2024-02-02_19.00.00.nc comparison
112 Variable Group Count          Sum      AbsSum          Min          Max       Range         Mean      StdDev
113 q2       /         2 -6.15788e-05 6.15788e-05 -4.00036e-05 -2.15753e-05 1.84283e-05 -3.07894e-05 1.30308e-05
114 t2m      /         2     -7.87473     7.87473     -7.27899    -0.595734     6.68326     -3.93736     4.72578
115 th2m     /         2     -7.88025     7.88025     -7.28363    -0.596619     6.68701     -3.94012     4.72843
116 
117 ######################################################################
118 # compare to previous GSL CONUS hrrrv5 RAP winter baselines C8GSL
119 ######################################################################
120 
121   === history.2024-08-15_18.00.00.nc comparison
122 Files "/mnt/lfs5/BMC/gsd-fv3-dev/Haiqin.Li/mpas-gsl/mpas_testcase/run_case/gsl-7d715f24d-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Ba    rlage/mpas/baselines_mpas/run_case/gsl-d469f0ed6-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.00.00.nc" are identical.
123 
124   === history.2024-08-15_18.12.00.nc comparison
125 Files "/mnt/lfs5/BMC/gsd-fv3-dev/Haiqin.Li/mpas-gsl/mpas_testcase/run_case/gsl-7d715f24d-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Ba    rlage/mpas/baselines_mpas/run_case/gsl-d469f0ed6-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.12.00.nc" are identical.
126 
127   === history.2024-08-15_19.00.00.nc comparison
128 Files "/mnt/lfs5/BMC/gsd-fv3-dev/Haiqin.Li/mpas-gsl/mpas_testcase/run_case/gsl-7d715f24d-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_19.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Ba    rlage/mpas/baselines_mpas/run_case/gsl-d469f0ed6-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_19.00.00.nc" are identical.
129 
```
</details>