### PR TITLE
Fixed bug in package definitions for UGWP in mpas_atm_core_interface.F and updated UGWP submodule

### DIFF
--- a/src/core_atmosphere/mpas_atm_core_interface.F
+++ b/src/core_atmosphere/mpas_atm_core_interface.F
@@ -202,6 +202,17 @@ module atm_core_interface
                              messageType=MPAS_LOG_ERR)
       end if
 
+#ifdef DO_PHYSICS
+      !check that all the physics options are correctly defined and that at
+      !least one physics parameterization is called (using the logical moist_physics):
+      call physics_namelist_check(configs)
+
+      local_ierr = atmphys_setup_packages(configs, streamInfo, packages, iocontext)
+      if (local_ierr /= 0) then
+         ierr = ierr + 1
+         call mpas_log_write('Package setup failed for atmphys in core_atmosphere', messageType=MPAS_LOG_ERR)
+      end if
+
       !
       ! Optional gravity wave drag parameterization streams
       !
@@ -242,16 +253,6 @@ module atm_core_interface
                              messageType=MPAS_LOG_ERR)
       end if
 
-#ifdef DO_PHYSICS
-      !check that all the physics options are correctly defined and that at
-      !least one physics parameterization is called (using the logical moist_physics):
-      call physics_namelist_check(configs)
-
-      local_ierr = atmphys_setup_packages(configs, streamInfo, packages, iocontext)
-      if (local_ierr /= 0) then
-         ierr = ierr + 1
-         call mpas_log_write('Package setup failed for atmphys in core_atmosphere', messageType=MPAS_LOG_ERR)
-      end if
 #endif
 
    end function atm_setup_packages


### PR DESCRIPTION
This PR fixes a bug in the specification of packages for the UGWP physics parameterization in mpas_atm_core_interface.F.  The calls to the definition of these packages was made before the call to define the physics suites.  This caused the packages to not be defined if the default physics suite was chosen, i.e., if the ugwp_gwdo scheme was not explicitly listed in the namelist.  The modified code was tested and now functions as expected.  Results are identical to previous successful test runs.  Thanks to @barlage for finding the fix.

The UGWP submodule points to an updated commit, which was to add a log write for the variable 'knob_ugwp_tauamp' on initialization.  This modification does not change the solution.
