### PR TITLE
Updating MYNN-EDMF submodule, including file name changes that conform to WRF standards

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -2462,7 +2462,7 @@
                 <nml_option name="config_physics_suite" type="character" default_value="mesoscale_reference" in_defaults="true"
                      units="-"
                      description="Choice of physics suite"
-                     possible_values="`mesoscale_reference',`convection_permitting',`none'"/>
+                     possible_values="`mesoscale_reference',`convection_permitting',`hrrrv5',`none'"/>
 
                 <nml_option name="config_microp_scheme" type="character" default_value="suite" in_defaults="false"
                      units="-"

--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -69,7 +69,7 @@ core_UGWP: core_physics_init
 	(cd UGWP; $(MAKE) all)
 
 core_mynnedmf: core_physics_init core_physics_mmm
-	(cd MYNN-EDMF; cp ./MPAS/Makefile .; cp ./MPAS/module_mynnedmf_driver.F90 .; cp ./MPAS/module_mynnedmf_common.F90 .; $(MAKE) all)
+	(cd MYNN-EDMF; cp ./MPAS/Makefile .; cp ./MPAS/module_bl_mynnedmf_driver.F90 .; cp ./MPAS/module_bl_mynnedmf_common.F90 .; $(MAKE) all)
 
 core_physics_wrf: core_physics_init core_physics_mmm core_UGWP
 	(cd physics_wrf; $(MAKE) all COREDEF="$(COREDEF)")

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
@@ -16,7 +16,7 @@
 
  use bl_mynn,only: bl_mynn_init
  use module_bl_mynn,only: mynn_bl_driver
- use module_mynnedmf_driver,only: mynnedmf_driver
+ use module_bl_mynnedmf_driver,only: mynnedmf_driver
  use module_bl_ysu
  use module_bl_myjpbl
 


### PR DESCRIPTION
This PR updates the MYNN-EDMF submodule. The main changes are:

1. Removal of the RH-based cloud fraction component in the stratus subgrid clouds
2. Implemented some tuning parameters to reduce subgrid clouds in the PBL, especially near the surface over water and ice.
3. Some misc mods include: (a) adding the less-restricted MF activation over water (from RRFSv1/CCPP), (b) a clean-up of the mixing length scale adaptivity, which only impacts near LES scales, (c) adding the "hrrrv5" option to the suite flag description in the Registry (no impact, just documentation).

Some results of this testing can be found in the attached pdf.
[Updates to MYNN-EDMF submodule (09 Dec 2024).pdf](https://github.com/user-attachments/files/18067043/Updates.to.MYNN-EDMF.submodule.09.Dec.2024.pdf)


This code is already running in the realtime WRF-WFIP3 and MPAS-dev2 on jet and has been testing in a MPAS case study. The regression tests (attached) show expected changes to the hrrrv5 suite and do not change the mesoscale_reference suite.
[compare_run_testcases_6b9226531-intdebug.txt](https://github.com/user-attachments/files/18188872/compare_run_testcases_6b9226531-intdebug.txt)

