### PR TITLE
v8.2.2-2.4 Updating MYNN-EDMF with new options/defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MPAS-v8.2.2-2.3
+MPAS-v8.2.2-2.4
 ====
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -2612,7 +2612,7 @@
                      description="=1:activate mixing of aerosols in the MYNN PBL scheme (=0 otherwise)"
                      possible_values="0,1"/>
 
-		<nml_option name="config_mynn_mixnumcon" type="integer" default_value="0" in_defaults="false"
+		<nml_option name="config_mynn_mixnumcon" type="integer" default_value="1" in_defaults="false"
                      units="-"
                      description="=1:activate mixing of number concentrations in the MYNN PBL scheme (=0 otherwise)"
                      possible_values="0,1"/>

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -2602,11 +2602,21 @@
                      description="=0:suppress the allocation of variables needed in the EDMF option of the MYNN PBL scheme"
                      possible_values="0,1:updrafts,2:downdrafts"/>
 
-                <nml_option name="config_mynn_mixscalars" type="integer" default_value="1" in_defaults="false"
+                <nml_option name="config_mynn_mixscalars" type="integer" default_value="0" in_defaults="false"
                      units="-"
                      description="=1:activate mixing of scalars in the MYNN PBL scheme (=0 otherwise)"
                      possible_values="0,1"/>
 
+		<nml_option name="config_mynn_mixaerosols" type="integer" default_value="1" in_defaults="false"
+                     units="-"
+                     description="=1:activate mixing of aerosols in the MYNN PBL scheme (=0 otherwise)"
+                     possible_values="0,1"/>
+
+		<nml_option name="config_mynn_mixnumcon" type="integer" default_value="0" in_defaults="false"
+                     units="-"
+                     description="=1:activate mixing of number concentrations in the MYNN PBL scheme (=0 otherwise)"
+                     possible_values="0,1"/>
+		
                 <nml_option name="config_mynn_mixclouds" type="integer" default_value="1" in_defaults="false"
                      units="-"
                      description="1:activate mixing of cloud condensates in the MYNN PBL scheme"

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.2.2-2.3">
+<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.2.2-2.4">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
@@ -1200,6 +1200,8 @@
                    bl_mynn_edmf_tke,    &
                    bl_mynn_edmf_output, &
                    bl_mynn_mixscalars,  &
+                   bl_mynn_mixaerosols, &
+                   bl_mynn_mixnumcon,   &
                    bl_mynn_cloudmix,    &
                    bl_mynn_mixqt,       &
                    bl_mynn_tkebudget,   &
@@ -1390,6 +1392,8 @@
        call mpas_pool_get_config(configs,'config_mynn_edmf_output',bl_mynn_edmf_output)
        call mpas_pool_get_config(configs,'config_mynn_closure'    ,bl_mynn_closure    )
        call mpas_pool_get_config(configs,'config_mynn_mixscalars' ,bl_mynn_mixscalars )
+       call mpas_pool_get_config(configs,'config_mynn_mixaerosols',bl_mynn_mixaerosols)
+       call mpas_pool_get_config(configs,'config_mynn_mixnumcon'  ,bl_mynn_mixnumcon  )
        call mpas_pool_get_config(configs,'config_mynn_mixclouds'  ,bl_mynn_cloudmix   )
        call mpas_pool_get_config(configs,'config_mynn_mixqt'      ,bl_mynn_mixqt      )
        call mpas_pool_get_config(configs,'config_mynn_tkeadvect'  ,bl_mynn_tkeadvect  )
@@ -1477,6 +1481,8 @@
                   bl_mynn_edmf_tke   = bl_mynn_edmf_tke    ,                                              &
                   bl_mynn_output     = bl_mynn_edmf_output ,                                              &
                   bl_mynn_mixscalars = bl_mynn_mixscalars  ,                                              &
+                  bl_mynn_mixaerosols= bl_mynn_mixaerosols ,                                              &
+                  bl_mynn_mixnumcon  = bl_mynn_mixnumcon   ,                                              &
                   bl_mynn_cloudmix   = bl_mynn_cloudmix    ,                                              &
                   bl_mynn_mixqt      = bl_mynn_mixqt       ,                                              &
                   ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,                 &

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.2.2-2.3">
+<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.2.2-2.4">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->


### PR DESCRIPTION
4 updates to the MYNN-EDMF repository, tested in WRF & MPAS, are now committed to MPAS. The following summarizes these changes:

1. In an effort to improve LLJs, 10-m winds and increase the wind shear at low-levels to better match WFIP3 data, a new option was added to use an alternate form of the pblh for stable conditions. The version used is now selectable with an internal parameter "stable_method": option 0: TKE-based version (original), option 1: ustar*700 (now default). This improves overestimation of the stable boundary layer and makes the diagnostic slightly more independent from the rest of the scheme, so I may not have to retune it after adjusting the TKE in stable conditions. It's also much simpler, no loops required. Other tweaks to the diffusivity in stable conditions also accompany this modification. Will impact solution.

2. An option to control the mixing of a subset of scalars within the larger set of "scalars" has been asked for. Two additional mixing options are added: bl_mynn_mixaerosols (default=1, on), bl_mynn_mixnumcon (default=0, off), to allow for this additional control. Also, any new species that are to be mixed can now be added to a generic "scalar" array and controlled by the old option bl_mynn_mixscalars (default=0, off). Any new scalars added will be mixed both locally and nonlocally. Will impact solution, but only slightly.

3. Adding explicit solver option (bl_mynn_edmf=2). The default is to run with the original (implicit) method. The new option (bl_mynn_edmf=2) uses an explicit solver for the mass flux component with and addition option "upwind" (internal parameter for now), which is set to 1.0 for upwind differencing or 0.5 for centered differencing. Note that for the original implicit method (bl_mynn_edmf=1) uses a centered differencing. This option was developed by Kay Suselj (NASA/JPL) and is considered still under development although initial tests look reasonable. By default, this will not impact the solution unless bl_mynn_edmf is set to 2 (not default).

4. Moved the parameters that regulate the bounds for the ice & water friendly aerosols (QNWFA & QNIFA) to the dycore-dependent common file. This is because a better solution has already been found for MPAS, but not yet implemented for WRF, so WRF needs these rather draconian limits at this time. No impact for MPAS, due to Anders' previous modification. Positive impact for WRF.

5. More precision-related cleaning was added to this PR (i.e., 1.0 changed to "one", 0.5 changed to "half", etc...). No impact.

All testing thus far has been on single cases in both WRF & MPAS, using both debug and regular compilations.

Information on running mandatory regression tests on Jet can be found [here](https://github.com/barlage/mpas_testcase) and the results pasted below.

<details>
  <summary>
    regression test case results
  </summary>
  
```
PASTE compare_run_testcases AND/OR compare_create_testcases TEXT HERE
```
</details>
