### PR TITLE
V8.2.2-2.5 - MPAS 2-m diagnostics uses flux method.

### DIFF
--- a/src/core_atmosphere/physics/physics_wrf/module_sf_sfcdiags_ruclsm.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_sfcdiags_ruclsm.F
@@ -51,8 +51,8 @@ contains
 
       logical :: flux
 
-      !flux = .true. ! used in RAP and HRRR
-      flux = .false. ! used in UFS (RRFS)
+      flux = .true. ! used in RAP and HRRR
+      !flux = .false. ! used in UFS (RRFS)
 
       do j=jts,jte
         do i=its,ite


### PR DESCRIPTION
The title above should be a 1 line short summary of the pull request (i.e. what the project the PR represents is intended to do).

Enter a description of this PR. This should include why this PR was created, and what it does.
V8.2.2-2.5. Switch to using flux method in MPAS 2-m diagnostics for HRRRv5 suite.
Testing and relations to other Pull Requests should be added as subsequent comments.

See the below examples for more information.
https://github.com/MPAS-Dev/MPAS/pull/930
https://github.com/MPAS-Dev/MPAS/pull/931

Information on running mandatory regression tests on Jet can be found [here](https://github.com/barlage/mpas_testcase) and the results pasted below.

<details>
  <summary>
    regression test case results
  </summary>
  
```
PASTE compare_run_testcases AND/OR compare_create_testcases TEXT HERE

     version_to_compare = v8.2.2-2.5
   gsl_version_baseline = v8.2.2-2.4
  ncar_version_baseline = v8.2.2
         test_directory = /lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/
 gsl_baseline_directory = /lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/
ncar_baseline_directory = /lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/
           compile_flag = -intdebug
         test_repo_name = gsl

######################################################################
# compare to previous GSL CONUS mesoscale_reference baselines A1GSL
######################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.5-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.4-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.5-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.4-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.5-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.4-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.
#############################################################################
# compare to previous GSL CONUS mesoscale_reference_noahmp baselines E1GSL
#############################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.5-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.4-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.5-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.4-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.5-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.4-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

######################################################################
# compare to previous GSL CONUS hrrrv5 GFS baselines C5GSL
######################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.5-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.4-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Variable Group Count       Sum   AbsSum          Min         Max      Range         Mean      StdDev
q2       /      1150 -0.160763 0.191095  -0.00148708 0.000197447 0.00168453 -0.000139794 0.000246454
t2m      /       847   55.3707   55.425 -0.000183105     1.67166    1.67184    0.0653727   0.0991583
th2m     /       847   55.1793  55.2345 -0.000183105     1.67252     1.6727    0.0651468   0.0989982

  === history.2023-03-10_16.00.00.nc comparison
Variable Group Count       Sum   AbsSum          Min         Max      Range         Mean      StdDev
q2       /      1172 -0.129982 0.159965  -0.00122815 0.000193205 0.00142136 -0.000110906 0.000195305
t2m      /      1010    55.173  55.2972 -0.000335693     1.30753    1.30786    0.0546267   0.0870249
th2m     /      1010   54.9792  55.1053 -0.000335693     1.30823    1.30856    0.0544349   0.0868319

######################################################################
# compare to previous GSL CONUS hrrrv5 RAP winter baselines C7GSL
######################################################################

  === history.2024-02-02_18.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.5-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.4-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.00.00.nc" are identical.

  === history.2024-02-02_18.12.00.nc comparison
Variable Group Count       Sum   AbsSum          Min         Max      Range         Mean      StdDev
q2       /      1223 -0.213206 0.242098  -0.00150812 0.000320744 0.00182887 -0.000174331 0.000252358
t2m      /       972   65.7606  65.8144 -0.000213623     1.31042    1.31064    0.0676549   0.0873865
th2m     /       972   65.5265  65.5819 -0.000213623     1.31195    1.31216    0.0674141   0.0871804

  === history.2024-02-02_19.00.00.nc comparison
Variable Group Count       Sum   AbsSum         Min         Max      Range         Mean      StdDev
q2       /      1216 -0.217462 0.244572 -0.00174394 8.63243e-05 0.00183026 -0.000178834 0.000269324
t2m      /      1013   62.4387  63.3583     -0.3078     0.16983   0.477631    0.0616374   0.0751583
th2m     /      1013   62.2094  63.1325   -0.308197    0.169037   0.477234    0.0614111   0.0748904

######################################################################
# compare to previous GSL CONUS hrrrv5 RAP winter baselines C8GSL
######################################################################

  === history.2024-08-15_18.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.5-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.4-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.00.00.nc" are identical.

  === history.2024-08-15_18.12.00.nc comparison
Variable Group Count      Sum   AbsSum         Min         Max      Range         Mean      StdDev
q2       /      1228 -0.56239 0.639158 -0.00305192 0.000762191 0.00381411 -0.000457972 0.000695473
t2m      /       987  57.6859  57.6933 -0.00012207    0.167572   0.167694    0.0584457   0.0701004
th2m     /       987   57.427  57.4347 -0.00012207    0.166473   0.166595    0.0581834   0.0697763

  === history.2024-08-15_19.00.00.nc comparison
Variable Group Count      Sum   AbsSum         Min         Max      Range         Mean      StdDev
q2       /      1229 -0.75122 0.820653 -0.00336403 0.000347447 0.00371148 -0.000611245 0.000806239
t2m      /      1039  56.6444    56.73 -0.00378418     0.18457   0.188354    0.0545182    0.069183
th2m     /      1039  56.3932  56.4813 -0.00393677    0.184296   0.188232    0.0542765   0.0688682

########################################################################
# compare to previous NCAR CONUS mesoscale_reference baselines A1NCAR
########################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.5-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.2.2-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.5-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.2.2-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.5-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.2.2-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

###############################################################################
# compare to previous NCAR CONUS mesoscale_reference_noahmp baselines E1NCAR
###############################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.5-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.2.2-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Variable Group Count     Sum  AbsSum        Min       Max     Range       Mean   StdDev
q2       /       781 1.08191 1.22294 -0.0108189 0.0104283 0.0212472 0.00138529 0.002047
t2m      /       781 578.985 1696.89   -6.63336   57.9242   64.5576   0.741339  4.24544
th2m     /       781 598.582 1733.05    -6.7655   58.1091   64.8746    0.76643   4.3173

  === history.2023-03-10_16.00.00.nc comparison
Variable Group Count        Sum  AbsSum        Min        Max     Range         Mean    StdDev
q2       /       781 -0.0800186  1.0817 -0.0140602 0.00843504 0.0224952 -0.000102457 0.0024593
t2m      /       781   -931.599 1409.99   -19.7743    8.99203   28.7663     -1.19283   2.26002
th2m     /       781   -952.914 1441.74   -20.8873    9.47638   30.3637     -1.22012    2.3268

```
</details>
