### PR TITLE
Revert "V8.2.2-2.5 - MPAS 2-m diagnostics uses flux method."

### DIFF
--- a/src/core_atmosphere/physics/physics_wrf/module_sf_sfcdiags_ruclsm.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_sfcdiags_ruclsm.F
@@ -51,8 +51,8 @@ contains
 
       logical :: flux
 
-      flux = .true. ! used in RAP and HRRR
-      !flux = .false. ! used in UFS (RRFS)
+      !flux = .true. ! used in RAP and HRRR
+      flux = .false. ! used in UFS (RRFS)
 
       do j=jts,jte
         do i=its,ite


### PR DESCRIPTION
Reverts NOAA-GSL/MPAS-Model#92