### PR TITLE
Update to MYNN-EDMF to add re-indexed arrays and temperature tendency change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MPAS-v8.2.2-2.8
+MPAS-v8.2.2-2.9
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for
 developing atmosphere, ocean, and other earth-system simulation components for

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.2.2-2.8">
+<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.2.2-2.9">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1137,6 +1137,8 @@
                         <var name="maxmf"/>
                         <var name="maxwidth"/>
                         <var name="ztop_plume"/>
+			<var name="excess_h"/>
+			<var name="excess_q"/>
                         <var name="hpbl"/>
                         <var name="cldfrac_cu"/>
                         <var name="refl10cm_cu"/>
@@ -3040,6 +3042,14 @@
 
                 <var name="ztop_plume" type="real" dimensions="nCells Time" units="m"
                      description="Height of highest penetrating plume"
+                     packages="bl_mynnedmf_in"/>
+
+		<var name="excess_h" type="real" dimensions="nCells Time" units="K"
+                     description="Maximum excess heat added to plumes"
+                     packages="bl_mynnedmf_in"/>
+
+		<var name="excess_q" type="real" dimensions="nCells Time" units="kg kg^{-1}"
+                     description="Maximum excess moisture added to plumes"
                      packages="bl_mynnedmf_in"/>
 
 		<!-- MYJ PBL SCHEME: -->

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
@@ -1460,7 +1460,7 @@
                   rthraten   = rthraten_p   , pblh       = hpbl_p      , kpbl        = kpbl_p           , &
                   cldfra_bl  = cldfrabl_p   , qc_bl      = qcbl_p      , qi_bl       = qibl_p           , &
                   maxwidth   = maxwidthbl_p , maxmf      = maxmfbl_p   , ztop_plume  = zbl_plume_p      , &
-                  excess_h   = excessh_p    , excess_q   = excessq_h   ,                                  &
+                  excess_h   = excessh_p    , excess_q   = excessq_p   ,                                  &
                   qke        = qke_p        , qke_adv    = qkeadv_p    ,                                  &
                   tsq        = tsq_p        , qsq        = qsq_p       , cov         = cov_p            , &
                   el_pbl     = elpbl_p      , rublten    = rublten_p   , rvblten     = rvblten_p        , &

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
@@ -196,7 +196,9 @@
        if(.not.allocated(maxwidthbl_p)  ) allocate(maxwidthbl_p(ims:ime,jms:jme)        )
        if(.not.allocated(maxmfbl_p)     ) allocate(maxmfbl_p(ims:ime,jms:jme)           )
        if(.not.allocated(zbl_plume_p)   ) allocate(zbl_plume_p(ims:ime,jms:jme)         )
-
+       if(.not.allocated(excessh_p)     ) allocate(excessh_p(ims:ime,jms:jme)           )
+       if(.not.allocated(excessq_p)     ) allocate(excessq_p(ims:ime,jms:jme)           ) 
+       
        if(.not.allocated(cov_p)         ) allocate(cov_p(ims:ime,kms:kme,jms:jme)       )
        if(.not.allocated(qke_p)         ) allocate(qke_p(ims:ime,kms:kme,jms:jme)       )
        if(.not.allocated(qsq_p)         ) allocate(qsq_p(ims:ime,kms:kme,jms:jme)       )
@@ -371,7 +373,9 @@
        if(allocated(maxwidthbl_p)  ) deallocate(maxwidthbl_p  )
        if(allocated(maxmfbl_p)     ) deallocate(maxmfbl_p     )
        if(allocated(zbl_plume_p)   ) deallocate(zbl_plume_p   )
-
+       if(allocated(excessh_p)     ) deallocate(excessh_p     )                                                                                                         
+       if(allocated(excessq_p)     ) deallocate(excessq_p     )
+       
        if(allocated(cov_p)       ) deallocate(cov_p       )
        if(allocated(qke_p)       ) deallocate(qke_p       )
        if(allocated(qsq_p)       ) deallocate(qsq_p       )
@@ -723,6 +727,8 @@
           maxwidthbl_p(i,j) = 0._RKIND
           maxmfbl_p(i,j)    = 0._RKIND
           zbl_plume_p(i,j)  = 0._RKIND
+          excessh_p(i,j)    = 0._RKIND
+          excessq_p(i,j)    = 0._RKIND
        enddo
        enddo
 
@@ -826,7 +832,7 @@
  real(kind=RKIND),dimension(:),pointer  :: delta,wstar
       
 !local pointers for MYNN scheme:
- real(kind=RKIND),dimension(:),pointer  :: maxmf,maxwidth,ztop_plume
+ real(kind=RKIND),dimension(:),pointer  :: maxmf,maxwidth,ztop_plume,excess_h,excess_q
  real(kind=RKIND),dimension(:,:),pointer:: cov,qke,qsq,tsq,sh3d,sm3d,tke_pbl,qke_adv,el_pbl,dqke,qbuoy, &
                                            qdiss,qshear,qwt
  real(kind=RKIND),dimension(:,:),pointer:: cldfrac_bl,qc_bl,qi_bl
@@ -992,6 +998,8 @@
        call mpas_pool_get_array(diag_physics,'maxmf'     ,maxmf     )
        call mpas_pool_get_array(diag_physics,'maxwidth'  ,maxwidth  )
        call mpas_pool_get_array(diag_physics,'ztop_plume',ztop_plume)
+       call mpas_pool_get_array(diag_physics,'excess_h'  ,excess_h  )
+       call mpas_pool_get_array(diag_physics,'excess_q'  ,excess_q  )
        call mpas_pool_get_array(diag_physics,'el_pbl'    ,el_pbl    )
        call mpas_pool_get_array(diag_physics,'cov'       ,cov       )
        call mpas_pool_get_array(diag_physics,'qke'       ,qke       )
@@ -1026,6 +1034,8 @@
           maxmf(i)      = maxmfbl_p(i,j)
           maxwidth(i)   = maxwidthbl_p(i,j)
           ztop_plume(i) = zbl_plume_p(i,j)
+          excess_h(i)   = excessh_p(i,j)
+          excess_q(i)   = excessq_p(i,j)
        enddo
        enddo
 
@@ -1449,8 +1459,9 @@
                   nc         = nc_p         , nifa       = nifa_p      , nwfa        = nwfa_p           , &
                   rthraten   = rthraten_p   , pblh       = hpbl_p      , kpbl        = kpbl_p           , &
                   cldfra_bl  = cldfrabl_p   , qc_bl      = qcbl_p      , qi_bl       = qibl_p           , &
-                  maxwidth   = maxwidthbl_p , maxmf      = maxmfbl_p   ,                                  &
-                  ztop_plume = zbl_plume_p  , dqke       = dqke_p      , qke_adv     = qkeadv_p         , &
+                  maxwidth   = maxwidthbl_p , maxmf      = maxmfbl_p   , ztop_plume  = zbl_plume_p      , &
+                  excess_h   = excessh_p    , excess_q   = excessq_h   ,                                  &
+                  qke        = qke_p        , qke_adv    = qkeadv_p    ,                                  &
                   tsq        = tsq_p        , qsq        = qsq_p       , cov         = cov_p            , &
                   el_pbl     = elpbl_p      , rublten    = rublten_p   , rvblten     = rvblten_p        , &
                   rthblten   = rthblten_p   , rqvblten   = rqvblten_p  , rqcblten    = rqcblten_p       , &
@@ -1460,7 +1471,7 @@
                   edmf_thl   = edmfthl_p    , edmf_ent   = edmfent_p   , edmf_qc     = edmfqc_p         , &
                   sub_thl    = subthl_p     , sub_sqv    = subqv_p     , det_thl     = detthl_p         , &
                   det_sqv    = detqv_p      , exch_h     = kzh_p       , exch_m      = kzm_p            , &
-                  qke        = qke_p        , qwt        = qwt_p       , qshear      = qshear_p         , &
+                  dqke       = dqke_p       , qwt        = qwt_p       , qshear      = qshear_p         , &
                   qbuoy      = qbuoy_p      , qdiss      = qdiss_p     , sh3d        = sh3d_p           , &
                   sm3d       = sm3d_p       , spp_pbl    = spp_pbl     , pattern_spp = pattern_spp_pbl  , &
                   do_restart         = config_do_restart   ,                                              &

--- a/src/core_atmosphere/physics/mpas_atmphys_vars.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_vars.F
@@ -440,8 +440,10 @@
  real(kind=RKIND),dimension(:,:),allocatable:: &
     maxwidthbl_p,     &!max plume width                                                                        [m]
     maxmfbl_p,        &!maximum mass flux for PBL shallow convection.
-    zbl_plume_p        !height of highest penetrating plume                                                    [m]
-
+    zbl_plume_p,      &!height of highest penetrating plume                                                    [m]
+    excessh_p,        &!maximum heat excess applied to plumes                                                  [K]
+    excessq_p          !maximum moisture excess applied to plumes                                          [kg/kg]
+      
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     dqke_p,           &!
     qbuoy_p,          &!

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.2.2-2.8">
+<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.2.2-2.9">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->


### PR DESCRIPTION
The majority of the changes in this PR are to re-index some arrays in the mass-flux component. Variables at the interface are indexed from kts to kte+1 where kts is the surface. Variables at the mass layers are kts to kte. Before this PR, some of these arrays were used inconsistently. The inconsistencies were known, so it did cause a problem, but it always bothered me. After the cleanup, the results are practically identical, as expected. It can not be bit-for-bit identical due to some vertical interpolations.

There is one additional change to the temperature tendency calculation, which should have a small impact, but it may impact upper-level RH enough to deserve system testing in advance of HWT. MPAS-Dev2 testing shows very small impacts overall from this modification.

A second part of this PR includes a TKE-dependent lateral entrainment for the mass-flux scheme. This seemingly has a small impact over land, but significantly improves the mass-flux activity over water. Changes to CONUS stats are expected to be very minor.

Information on running mandatory regression tests on Jet can be found [here](https://github.com/barlage/mpas_testcase) and the results pasted below.

<details>
  <summary>
    regression test case results
  </summary>
  
```
      version_to_compare = v8.2.2-2.9
   gsl_version_baseline = v8.2.2-2.8
  ncar_version_baseline = v8.2.2
         test_directory = /lfs5/BMC/rtwbl/olson/mpas_testcase/run_case/
 gsl_baseline_directory = /lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/
ncar_baseline_directory = /lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/
           compile_flag = -intdebug
         test_repo_name = gsl

######################################################################
# compare to previous GSL CONUS mesoscale_reference baselines A1GSL   
######################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/lfs5/BMC/rtwbl/olson/mpas_testcase/run_case/gsl-v8.2.2-2.9-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas
/baselines_mpas/run_case/gsl-v8.2.2-2.8-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/lfs5/BMC/rtwbl/olson/mpas_testcase/run_case/gsl-v8.2.2-2.9-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas
/baselines_mpas/run_case/gsl-v8.2.2-2.8-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/lfs5/BMC/rtwbl/olson/mpas_testcase/run_case/gsl-v8.2.2-2.9-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas
/baselines_mpas/run_case/gsl-v8.2.2-2.8-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

#############################################################################
# compare to previous GSL CONUS mesoscale_reference_noahmp baselines E1GSL   
#############################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/lfs5/BMC/rtwbl/olson/mpas_testcase/run_case/gsl-v8.2.2-2.9-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barla
ge/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.8-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/lfs5/BMC/rtwbl/olson/mpas_testcase/run_case/gsl-v8.2.2-2.9-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barla
ge/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.8-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/lfs5/BMC/rtwbl/olson/mpas_testcase/run_case/gsl-v8.2.2-2.9-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barla
ge/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.8-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

######################################################################
# compare to previous GSL CONUS hrrrv5 GFS baselines C5GSL            
######################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/lfs5/BMC/rtwbl/olson/mpas_testcase/run_case/gsl-v8.2.2-2.9-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas
/run_case/gsl-v8.2.2-2.8-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Variable               Group  Count          Sum      AbsSum          Min          Max       Range         Mean      StdDev
qv                     /      29329 -0.000963706  0.00386827 -6.68988e-05  5.38463e-05 0.000120745 -3.28585e-08 1.28486e-06
qc                     /        738  0.000157792  0.00019125  -2.8274e-06  3.46603e-05 3.74877e-05   2.1381e-07 2.13764e-06
qr                     /        295  8.52955e-06 8.91253e-06 -2.61682e-08  2.99448e-07 3.25616e-07  2.89137e-08 5.80929e-08
qi                     /         14 -1.71624e-12 1.71624e-12 -1.02318e-12 -4.94396e-17 1.02313e-12 -1.22589e-13 2.70671e-13
qs                     /          7 -8.78139e-15 8.78139e-15 -7.10543e-15 -2.10335e-17 7.08439e-15 -1.25448e-15 2.60128e-15
ni                     /         12 -0.000907202  0.00133445 -0.000976562  0.000183105  0.00115967 -7.56002e-05 0.000290225
nr                     /        295      4068.48     4346.37     -15.9674       87.563      103.53      13.7914     19.1445
nc                     /        825  3.53999e+08 1.83717e+09 -1.89248e+08   1.8835e+08 3.77598e+08       429090 1.54891e+07
nifa                   /      24094       614316 1.68003e+06     -18833.7      13262.4     32096.1      25.4966     540.225
nwfa                   /      27021 -5.57842e+08  4.7608e+09 -1.88348e+08  1.89247e+08 3.77595e+08     -20644.8 2.54016e+06
u                      /     149051     0.324482     67.9764    -0.222698     0.222679    0.445377  2.17699e-06  0.00431341
w                      /      72012   -0.0668015     0.18239 -0.000630673  0.000374712  0.00100539 -9.27644e-07 1.50917e-05
pressure               /      15488     -405.216     1028.17     -22.0078      31.7812     53.7891   -0.0261632    0.663287
surface_pressure       /        306     -11.0703     23.3359     -1.67969      1.02344     2.70312   -0.0361775    0.186897
rho                    /      18798   0.00440552   0.0611445  -0.00128984   0.00188661  0.00317645  2.34361e-07 3.37792e-05
theta                  /      15465     -1.47137      15.491     -0.43399     0.285767    0.719757 -9.51422e-05  0.00925948
relhum                 /      32063     -8.79992     216.423     -1.75513      2.97755     4.73268 -0.000274457   0.0704116
divergence             /      59156 -7.95894e-08 0.000269237 -1.28164e-06   1.3714e-06 2.65304e-06 -1.34542e-12 3.50966e-08
vorticity              /      97703  3.47533e-08 0.000970719  -5.3914e-06  4.33061e-06 9.72201e-06  3.55704e-13  9.0777e-08
ke                     /      51909      30.0908     295.196     -1.91187      2.59288     4.50475  0.000579684   0.0487275
uReconstructZonal      /      47902      -1.4629     22.7896    -0.191313     0.205933    0.397245 -3.05395e-05  0.00423881
uReconstructMeridional /      52834     -1.56964     19.9696    -0.139375     0.120735     0.26011 -2.97089e-05  0.00298512
ertel_pv               /      54443      5.61107     17.0322     -0.15438      1.07902      1.2334  0.000103063  0.00730457
u_pv                   /        881  0.000626475   0.0374109  -0.00137329   0.00146484  0.00283813  7.11095e-07 0.000120887
v_pv                   /       1021  0.000682779   0.0376499  -0.00116539   0.00126553  0.00243092  6.68735e-07 0.000113924
theta_pv               /        502   0.00143433   0.0244446 -0.000457764  0.000366211 0.000823975  2.85722e-06 6.52253e-05
vort_pv                /       1046 -4.68343e-09 1.16055e-07 -5.16593e-09  2.25918e-09 7.42511e-09 -4.47747e-12  3.2099e-10
depv_dt_lw             /      51223  1.70836e-06 3.48575e-05 -8.16217e-07  9.60223e-07 1.77644e-06  3.33515e-11 1.14882e-08
depv_dt_sw             /      51443 -7.24125e-08 2.53525e-06  -1.8956e-08  1.69596e-08 3.59155e-08 -1.40763e-12 4.42955e-10
depv_dt_bl             /      52636   0.00936138   0.0273076 -0.000278539   0.00150162  0.00178016  1.77851e-07 1.13058e-05
depv_dt_mix            /      63686  2.48871e-06 0.000249732 -8.42628e-06  3.12577e-06  1.1552e-05  3.90778e-11 6.39937e-08
dtheta_dt_mp           /       2208 -0.000663885  0.00243916 -7.89218e-05  0.000119019  0.00019794 -3.00672e-07 6.48162e-06
depv_dt_mp             /      18513  5.02967e-05   0.0020159 -9.73201e-05  0.000110212 0.000207533  2.71683e-09 1.65294e-06
depv_dt_diab           /      63542    0.0094158   0.0277395  -0.00027749   0.00149345  0.00177094  1.48182e-07 1.02468e-05
depv_dt_fric           /      67002  8.54332e-05   0.0194243 -0.000586423  0.000420636  0.00100706  1.27508e-09 6.61545e-06
depv_dt_diab_pv        /       1115 -1.76874e-08 7.91676e-07 -2.35364e-08  2.74467e-08  5.0983e-08 -1.58632e-11 2.52878e-09
depv_dt_fric_pv        /       1161 -2.66475e-08 2.60066e-07 -1.67638e-08  5.58794e-09 2.23517e-08 -2.29522e-11 7.04047e-10
rainnc                 /         33    0.0171299   0.0186692 -0.000361519   0.00237078   0.0027323  0.000519088 0.000657701
precipw                /        494     -0.04039   0.0477209  -0.00729084  0.000603676  0.00789452 -8.17612e-05 0.000561764
cldfrac_bl             /       7129      341.988     345.036    -0.273964     0.376947    0.650911    0.0479714   0.0412388

  === history.2023-03-10_16.00.00.nc comparison
Variable               Group  Count          Sum      AbsSum          Min         Max       Range         Mean      StdDev
qv                     /      55565   -0.0482994    0.142187 -0.000274384  0.00052892 0.000803304 -8.69241e-07 1.29385e-05
qc                     /       2252   0.00776228   0.0230338 -0.000263146  0.00033921 0.000602356  3.44684e-06    3.03e-05
qr                     /       3826  5.49083e-05  0.00183264 -0.000110909 0.000141201  0.00025211  1.43514e-08 5.51493e-06
qi                     /       3400  5.69666e-06 3.29464e-05 -8.03768e-07 2.52536e-06 3.32913e-06  1.67549e-09 8.01861e-08
qs                     /       4092  -0.00019587 0.000349227 -5.25938e-05 1.85291e-05 7.11228e-05 -4.78666e-08 1.25968e-06
qg                     /        557 -0.000201253  0.00206083 -0.000196965 7.39369e-05 0.000270902 -3.61316e-07 1.74069e-05
ni                     /       3399      38443.1      170215     -17459.8     44411.6     61871.5      11.3101     895.858
nr                     /       3826      20770.5      226707     -14007.4     27903.3     41910.6      5.42878     759.921
ng                     /        556     -9322.57     28065.9     -2841.79     1254.62      4096.4     -16.7672     249.642
nc                     /       2252  1.78668e+09 9.42281e+09 -1.30437e+08 1.18123e+08  2.4856e+08       793376 1.47249e+07
nifa                   /      47483  3.20823e+06 2.12221e+07      -118568     58869.1      177437      67.5659     2224.23
nwfa                   /      53934  -1.9814e+10  6.2743e+11 -1.12295e+09 1.28977e+09 2.41272e+09      -367374 5.14311e+07
volg                   /        557 -1.26226e-06 3.12942e-06 -3.31277e-07 8.64228e-08   4.177e-07 -2.26618e-09 2.91451e-08
u                      /     179779     -1.41145     1433.64     -1.94437     1.99282     3.93719 -7.85102e-06   0.0366848
w                      /      72481    -0.695251      6.3444   -0.0123932  0.00418179    0.016575 -9.59218e-06   0.0002858
pressure               /      56059     -8185.64     22554.6     -63.9062     127.758     191.664    -0.146018     1.74442
surface_pressure       /        947     -42.1016     899.883     -33.1328     24.3203     57.4531   -0.0444578     2.98993
rho                    /      56383      0.27131     1.50525  -0.00232482  0.00484645  0.00717127  4.81191e-06 0.000119471
theta                  /      53727     -55.9638     404.453     -1.52612    0.687958     2.21408  -0.00104163   0.0327233
relhum                 /      56678     -78.8063     3713.55      -10.058     17.9492     28.0072  -0.00139042    0.341941
divergence             /      64973  1.27215e-06  0.00518692 -1.07097e-05 1.06297e-05 2.13394e-05  1.95796e-11 3.27492e-07
vorticity              /     121839 -2.29797e-07    0.016644 -3.78285e-05 4.38271e-05 8.16557e-05 -1.88607e-12 7.33705e-07
ke                     /      64904     -450.833     5069.94     -20.9672     20.2714     41.2386  -0.00694616    0.367557
uReconstructZonal      /      64762      24.2341     470.831     -1.85923     1.52362     3.38285  0.000374202   0.0333957
uReconstructMeridional /      64948      7.83287     398.577     -1.85981    0.934487      2.7943  0.000120602   0.0264726
ertel_pv               /      67138      13.5646     197.116    -0.428844    0.402618    0.831462  0.000202041   0.0139513
u_pv                   /       1103    0.0577728     1.27264   -0.0158043   0.0251122   0.0409164  5.23779e-05  0.00208528
v_pv                   /       1116     0.177389     1.14888   -0.0106089   0.0518227   0.0624316  0.000158951  0.00226609
theta_pv               /       1041    0.0233459    0.826447   -0.0271301   0.0357361   0.0628662  2.24265e-05   0.0020321
vort_pv                /       1122 -8.64351e-08 4.20239e-06 -1.04905e-07 1.91594e-07 2.96499e-07 -7.70367e-11 1.02159e-08
depv_dt_lw             /      70260   0.00268851   0.0568603 -0.000395105 0.000315331 0.000710436  3.82652e-08 6.11048e-06
depv_dt_sw             /      70118   0.00133646   0.0140685 -7.23478e-05 8.93334e-05 0.000161681  1.90601e-08 1.41079e-06
depv_dt_bl             /      57941  -0.00242852    0.147493 -0.000416177  0.00343031  0.00384648 -4.19137e-08 2.40515e-05
depv_dt_mix            /      70659  2.07739e-06  0.00208176 -4.76317e-06 5.45559e-06 1.02188e-05  2.94002e-11   1.434e-07
dtheta_dt_mp           /      11414  -0.00352813   0.0472828 -0.000268004 0.000359175 0.000627179 -3.09105e-07 1.68968e-05
depv_dt_mp             /      31256   0.00317696   0.0326959 -0.000247964 0.000389267 0.000637231  1.01643e-07 7.83056e-06
depv_dt_diab           /      71700    0.0047755     0.16703 -0.000413776  0.00343367  0.00384745  6.66039e-08 2.15644e-05
depv_dt_fric           /      72212   0.00181164   0.0681861  -0.00115743 0.000964195  0.00212163  2.50878e-08 1.17558e-05
depv_dt_diab_pv        /       1195  1.36459e-05 5.60207e-05 -2.16395e-06 3.06171e-06 5.22567e-06  1.14191e-08 1.67374e-07
depv_dt_fric_pv        /       1230  3.48267e-06 2.29331e-05 -3.80592e-06 1.39999e-06 5.20591e-06  2.83144e-09 1.39323e-07
rainnc                 /        296     0.510314    0.569565  -0.00520003    0.157127    0.162328   0.00172403  0.00992154
precipw                /        958     -1.96538     2.89881    -0.165211   0.0211754    0.186386  -0.00205155   0.0106817
kpbl                   /         78           18          78           -1           1           2     0.230769    0.979306
hpbl                   /       1128      1337.75     7539.41     -102.612     135.117     237.729      1.18595     16.2898
hfx                    /       1138     -1613.91      2539.7     -49.4638     34.8039     84.2677      -1.4182     6.11107
qfx                    /       1113 -9.14389e-05 0.000325256 -8.51155e-06 4.27066e-06 1.27822e-05 -8.21554e-08 8.41086e-07
cd                     /       1118    -0.023389   0.0745963   -0.0024122  0.00762851   0.0100407 -2.09204e-05 0.000298174
cda                    /       1120   -0.0246115   0.0647975  -0.00204022  0.00414309  0.00618331 -2.19746e-05 0.000207525
ck                     /       1125   -0.0100013   0.0339964 -0.000631985  0.00332482   0.0039568 -8.89006e-06 0.000128927
cka                    /       1128   -0.0120695   0.0332246 -0.000627223  0.00206493  0.00269215    -1.07e-05  0.00010409
lh                     /       1113     -227.426     820.896     -21.2789     10.6767     31.9555    -0.204336     2.10635
u10                    /       1139      2.05562      19.588    -0.197454      0.1895    0.386954   0.00180476   0.0310623
v10                    /       1135      3.47635     20.2974    -0.221885     1.32404     1.54593   0.00306287   0.0527523
q2                     /       1109   -0.0109762   0.0129423  -0.00020901 7.27978e-05 0.000281808 -9.89741e-06  2.4751e-05
t2m                    /       1052     -14.8171     27.8372    -0.400909    0.218048    0.618958   -0.0140847   0.0567629
th2m                   /       1049     -14.9143      28.463    -0.410492    0.216858     0.62735   -0.0142177   0.0576697
gsw                    /       1087     -7183.11     11515.6     -172.261     141.031     313.292      -6.6082     23.5448
glw                    /       1082      2109.71     3533.68     -30.9813     46.0264     77.0077      1.94982     6.26522
skintemp               /        760     -54.9117     82.4397     -1.33673    0.837799     2.17453   -0.0722522    0.216843
snow                   /        331      3.18073     4.94964    -0.109459    0.456633    0.566092   0.00960946   0.0492454
snowh                  /        339    0.0192924    0.042351 -0.000712901  0.00261325  0.00332616  5.69097e-05 0.000285631
canwat                 /         79 -0.000129144  0.00185569  -0.00071327 0.000265013 0.000978283 -1.63474e-06 9.12877e-05
sh2o                   /       3165   -0.0408115     0.26661   -0.0173424   0.0383723   0.0557147 -1.28946e-05 0.000872582
smois                  /       3330  -0.00755105    0.102613  -0.00432888  0.00203362   0.0063625 -2.26758e-06 0.000151923
tslb                   /       3156     -117.968     163.325     -1.33673    0.837799     2.17453   -0.0373789    0.140326
soilt1                 /        241    -0.897552     1.78391    -0.134521   0.0436096    0.178131  -0.00372428   0.0179041
rhosnf                 /         40      3247.64      7572.4     -1073.42     1092.99     2166.41       81.191     449.301
snowfallac             /         40  0.000281107 0.000328982 -2.38479e-05 4.43487e-05 6.81966e-05  7.02767e-06 1.21895e-05
acrunoff               /        267   -0.0676345   0.0852409   -0.0273936    0.002801   0.0301946 -0.000253313  0.00202674
grdflx                 /        763      1029.92     2666.77     -65.0192     57.2406      122.26      1.34982       8.197
sfc_albedo             /        338     0.055475    0.151412   -0.0145937   0.0423608   0.0569546  0.000164127  0.00283598
cldfrac_bl             /       6842      268.229     322.912    -0.471804    0.985458     1.45726    0.0392032   0.0727271
snowc                  /        327     0.260848    0.765918   -0.0725368    0.226027    0.298564  0.000797701   0.0151833
graupelnc              /          9    0.0102874   0.0102885  -5.1773e-07   0.0102829   0.0102834   0.00114305  0.00342745

######################################################################
# compare to previous GSL CONUS hrrrv5 RAP winter baselines C7GSL     
######################################################################

  === history.2024-02-02_18.00.00.nc comparison
Files "/lfs5/BMC/rtwbl/olson/mpas_testcase/run_case/gsl-v8.2.2-2.9-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas
/run_case/gsl-v8.2.2-2.8-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.00.00.nc" are identical.

  === history.2024-02-02_18.12.00.nc comparison
Variable               Group  Count          Sum      AbsSum          Min         Max       Range         Mean      StdDev
qv                     /      47621  -0.00327506   0.0466327 -0.000188671 0.000362848 0.000551519 -6.87734e-08 5.75755e-06
qc                     /       1406  -0.00121232  0.00554176 -0.000134367 0.000201615 0.000335982 -8.62245e-07 1.20194e-05
qr                     /       4572  6.16031e-05 0.000815641 -7.41698e-06  1.1129e-05 1.85459e-05   1.3474e-08  7.8555e-07
qi                     /       4402   6.4732e-06 7.54328e-06 -8.26356e-08 7.97563e-07 8.80198e-07  1.47051e-09 2.28196e-08
qs                     /       8517  0.000512361  0.00113983 -1.16936e-05 0.000181315 0.000193009  6.01575e-08 2.13662e-06
qg                     /       1922  0.000131451 0.000291826  -1.0175e-05 1.38963e-05 2.40713e-05   6.8393e-08 8.24259e-07
ni                     /       4356      3242.04     10213.2     -784.969      3052.2     3837.17     0.744271     51.1942
nr                     /       4569      15548.8      140862     -1439.28     1524.72        2964       3.4031     123.288
ng                     /       1913      14430.7     20461.5     -317.077     761.792     1078.87      7.54348      56.085
nc                     /       1407 -3.41231e+08 2.12184e+09  -1.6249e+08 7.41654e+07 2.36656e+08      -242523  7.6814e+06
nifa                   /      34942      -746596 1.42388e+07      -167565      212630      380195     -21.3667      2929.4
nwfa                   /      42429    2.805e+08 2.66813e+10 -8.86276e+07 8.35905e+07 1.72218e+08      6611.05 3.29943e+06
volg                   /       1923  2.16846e-07 4.26235e-07  -1.2298e-08 2.75864e-08 3.98844e-08  1.12765e-10 1.34919e-09
u                      /     176389      2.73267     340.746    -0.284543    0.346447     0.63099  1.54923e-05  0.00829889
w                      /      72386    -0.225705     1.61785  -0.00269305  0.00130067  0.00399373 -3.11807e-06 9.07959e-05
pressure               /      40373      -2712.6     9938.25     -84.5312     48.7031     133.234   -0.0671884     1.59557
surface_pressure       /        790      37.1953     388.258     -23.5391     22.6797     46.2188    0.0470827     1.98847
rho                    /      43226     0.020084     0.38447  -0.00130069  0.00195777  0.00325847  4.64628e-07 5.01038e-05
theta                  /      34728     -10.4435     96.4841    -0.708313    0.240234    0.948547 -0.000300722   0.0157152
relhum                 /      51646      61.2491     1088.42      -3.0334     9.19164      12.225   0.00118594    0.148983
divergence             /      64304 -5.03893e-07  0.00135652 -2.08052e-06 1.63277e-06 3.71329e-06 -7.83611e-12  7.4888e-08
vorticity              /     116194  2.23665e-06  0.00458088  -5.3358e-06 6.25654e-06 1.15923e-05  1.92493e-11  1.7605e-07
ke                     /      63429     0.990932     1405.06     -5.16867       3.959     9.12767  1.56227e-05   0.0961532
uReconstructZonal      /      62983     -2.75764     112.521    -0.313451    0.234961    0.548411 -4.37839e-05  0.00723397
uReconstructMeridional /      63083      -4.2591     100.159    -0.160363    0.211403    0.371766 -6.75158e-05  0.00634658
ertel_pv               /      63739      11.5548     57.8658    -0.202725    0.999012     1.20174  0.000181283  0.00807759
u_pv                   /       1086    0.0541792    0.300517  -0.00473404   0.0640221   0.0687561  4.98888e-05  0.00201937
v_pv                   /       1071   -0.0135161    0.272727   -0.0279932  0.00490761   0.0329008   -1.262e-05  0.00107897
theta_pv               /        711   -0.0336914    0.144409   -0.0491638  0.00598145   0.0551453 -4.73859e-05  0.00188418
vort_pv                /       1090  4.15177e-07 8.74259e-07 -1.47016e-08 2.03276e-07 2.17977e-07  3.80896e-10 6.69367e-09
depv_dt_lw             /      61414 -7.63614e-06 0.000176617 -4.75883e-06 1.56445e-06 6.32327e-06 -1.24339e-10 3.54509e-08
depv_dt_sw             /      60957 -1.09401e-07 1.55259e-05 -5.76477e-08 4.83979e-08 1.06046e-07 -1.79473e-12 1.40406e-09
depv_dt_bl             /      62452    0.0201549    0.108419 -0.000281795  0.00172903  0.00201083  3.22726e-07 1.37185e-05
depv_dt_mix            /      68804 -5.52007e-06 0.000615927 -1.05856e-05 3.20995e-06 1.37955e-05  -8.0229e-11  6.9798e-08
dtheta_dt_mp           /      10062  -0.00712225   0.0309767 -0.000370407 0.000235028 0.000605435 -7.07837e-07 1.32867e-05
depv_dt_mp             /      34818  -0.00114544   0.0208664 -0.000283847  0.00024012 0.000523967  -3.2898e-08 4.59937e-06
depv_dt_diab           /      68907    0.0189962    0.102452 -0.000301138  0.00170835  0.00200948  2.75678e-07 1.26275e-05
depv_dt_fric           /      70672   0.00479098    0.119092  -0.00257147  0.00172277  0.00429423  6.77918e-08  2.7031e-05
depv_dt_diab_pv        /       1137 -6.90353e-08 1.81073e-06 -7.14033e-08 4.65546e-08 1.17958e-07 -6.07171e-11 5.54552e-09
depv_dt_fric_pv        /       1207  8.16601e-09 2.73517e-06 -1.30385e-07 1.24797e-07 2.55182e-07  6.76554e-12 1.08303e-08
rainnc                 /        502   -0.0109949    0.186799   -0.0193349   0.0172758   0.0366107 -2.19022e-05  0.00164367
precipw                /        916   -0.0848017    0.556211   -0.0279369   0.0252604   0.0531974 -9.25782e-05  0.00236569
cldfrac_bl             /       7302      197.642     209.053    -0.308552    0.421751    0.730303    0.0270668   0.0393588
snownc                 /        138    -0.004682   0.0177267  -0.00662349  0.00247665  0.00910014 -3.39275e-05 0.000648247
graupelnc              /        234  -0.00117224  0.00824717   -0.0016433  0.00335935  0.00500266 -5.00957e-06 0.000269783

  === history.2024-02-02_19.00.00.nc comparison
Variable               Group  Count          Sum      AbsSum          Min         Max       Range         Mean      StdDev
qv                     /      56984   -0.0661521    0.359728 -0.000526027  0.00129246  0.00181849 -1.16089e-06 2.81393e-05
qc                     /       1308   -0.0107915    0.048716 -0.000401017  0.00055442 0.000955438 -8.25037e-06 6.73692e-05
qr                     /       5582  0.000913453  0.00507744 -4.34874e-05 2.74168e-05 7.09042e-05  1.63643e-07 2.99968e-06
qi                     /       5136  2.38763e-05 6.70003e-05 -8.98311e-07 2.86216e-06 3.76047e-06  4.64881e-09 7.63177e-08
qs                     /       9276   0.00607566  0.00871778 -5.08262e-05 7.40235e-05  0.00012485  6.54987e-07  3.9457e-06
qg                     /       2778  0.000377074  0.00074889 -6.36047e-06 2.68627e-05 3.32232e-05  1.35736e-07 1.17458e-06
ni                     /       5136      44515.4      155574     -12908.5      8627.8     21536.3      8.66733     299.905
nr                     /       5582       138214      649035     -3753.57     3750.08     7503.64      24.7607     358.704
ng                     /       2778      21873.6     32329.8     -229.776     876.644     1106.42      7.87388     51.3482
nc                     /       1308 -4.99173e+09 1.68385e+10 -2.26887e+08 2.29251e+08 4.56138e+08 -3.81631e+06 2.70835e+07
nifa                   /      46478 -1.71107e+07  1.0593e+08      -465636      427896      893532     -368.146     12915.8
nwfa                   /      55597 -9.15892e+10 1.15762e+12 -1.71645e+09 2.25011e+09 3.96656e+09 -1.64738e+06 7.35051e+07
volg                   /       2778  6.62718e-07  1.1814e-06 -9.53057e-09 5.09019e-08 6.04324e-08  2.38559e-10 2.17505e-09
u                      /     179866      11.2454     3521.83     -6.70682     5.61624     12.3231  6.25208e-05   0.0849035
w                      /      72423     -3.20984     24.3899   -0.0236446   0.0132497   0.0368943 -4.43207e-05 0.000958726
pressure               /      57272     -17673.2     68843.8      -261.82      125.59      387.41    -0.308583     4.30383
surface_pressure       /        974      642.633     2505.65     -92.5703     81.3594      173.93     0.659787     6.63963
rho                    /      57334     0.292098     3.20704  -0.00345647  0.00803244   0.0114889  5.09467e-06 0.000226766
theta                  /      56058     -103.349     960.856     -2.81009    0.904724     3.71481  -0.00184361   0.0721638
relhum                 /      57444      425.056       10599     -15.7472     38.5359     54.2831   0.00739949    0.964723
divergence             /      65006  2.54704e-07   0.0146287 -4.32411e-05 3.48158e-05 7.80569e-05  3.91816e-12 8.35485e-07
vorticity              /     122272  1.78795e-05   0.0412112 -0.000124717 0.000124273 0.000248989  1.46227e-10 1.85826e-06
ke                     /      65009      -307.81     15490.1     -58.4129     46.1432     104.556  -0.00473488    0.986012
uReconstructZonal      /      64972      -5.4723     1122.69     -4.02265     6.64919     10.6718 -8.42256e-05   0.0758119
uReconstructMeridional /      65012     -7.21136     932.184     -5.74657     4.58565     10.3322 -0.000110924    0.058037
ertel_pv               /      69052      24.9836     447.036     -1.24154     1.13701     2.37854  0.000361809   0.0292388
u_pv                   /       1135     -11.2476     20.3235      -10.643    0.773708     11.4167  -0.00990974    0.318021
v_pv                   /       1134      5.60853     12.5456    -0.122813     4.55823     4.68104    0.0049458    0.138863
theta_pv               /       1078     -43.9391     50.9048     -44.1999    0.341003     44.5409   -0.0407598     1.34664
vort_pv                /       1134 -1.94466e-05 4.84045e-05 -1.60442e-05 1.36609e-06 1.74103e-05 -1.71487e-08  4.9106e-07
iLev_DT                /          1           -7           7           -7          -7           0           -7           0
depv_dt_lw             /      72212   0.00444621   0.0807528 -0.000232846 0.000250578 0.000483424  6.15717e-08 6.78193e-06
depv_dt_sw             /      72060  0.000700451   0.0225399 -8.04558e-05 7.86669e-05 0.000159123  9.72039e-09 1.77381e-06
depv_dt_bl             /      60959   0.00309888    0.276096   -0.0016893  0.00374411  0.00543341  5.08354e-08 2.60266e-05
depv_dt_mix            /      71579 -1.17676e-06  0.00385911 -2.07981e-05 2.52286e-05 4.60267e-05 -1.64401e-11 2.88531e-07
dtheta_dt_mp           /      15733   -0.0151427    0.174803  -0.00114326 0.000564194  0.00170746  -9.6248e-07 3.75013e-05
depv_dt_mp             /      37268  -0.00535466   0.0960401  -0.00184855  0.00155763  0.00340618  -1.4368e-07 1.89626e-05
depv_dt_diab           /      72512    0.0028897    0.308397  -0.00188508  0.00368123  0.00556631  3.98513e-08 2.60895e-05
depv_dt_fric           /      72700  -0.00199538    0.255968  -0.00227888  0.00153028  0.00380917 -2.74468e-08  3.2619e-05
depv_dt_diab_pv        /       1225  9.55905e-06 7.58361e-05 -1.96112e-06 5.51666e-06 7.47778e-06  7.80331e-09 2.36977e-07
depv_dt_fric_pv        /       1231   6.6671e-05  0.00101113 -0.000149434 0.000121218 0.000270651    5.416e-08 7.83461e-06
rainnc                 /        603      2.36087     3.04377   -0.0444582    0.138687    0.183145   0.00391521   0.0127923
precipw                /        975     -2.88224     7.57697    -0.238985      0.1057    0.344685  -0.00295614   0.0194467
kpbl                   /        132          -25         133           -1           2           3    -0.189394    0.997191
hpbl                   /       1098     -4918.53     17527.9     -230.596     213.901     444.497     -4.47953     33.3007
hfx                    /       1136     -1169.95     3462.83      -65.852     37.1348     102.987     -1.02989     7.02476
qfx                    /       1136 -9.88043e-06 0.000602991 -9.07617e-06 1.65654e-05 2.56415e-05 -8.69756e-09 1.31607e-06
cd                     /       1120   -0.0346594   0.0655051  -0.00456774   0.0023156  0.00688334 -3.09459e-05 0.000230433
cda                    /       1120   -0.0302783   0.0588721  -0.00346711  0.00220883  0.00567594 -2.70342e-05 0.000194945
ck                     /       1129   -0.0168127   0.0306752  -0.00124225  0.00063718  0.00187943 -1.48917e-05 8.21495e-05
cka                    /       1129   -0.0166059   0.0309958   -0.0011082 0.000690823  0.00179903 -1.47085e-05 8.04991e-05
lh                     /       1136     -25.5283     1510.65     -22.6904     41.4134     64.1038   -0.0224721     3.29125
u10                    /       1136      10.8831      28.031    -0.555218     1.17407     1.72929   0.00958018   0.0639893
v10                    /       1135      -4.2084     25.5634    -0.634355    0.552028     1.18638  -0.00370784   0.0478888
q2                     /       1130    -0.010956   0.0167155 -0.000184111 0.000105697 0.000289808 -9.69556e-06 2.47772e-05
t2m                    /       1084     -9.88229     39.5487    -0.464752    0.443848      0.9086  -0.00911651   0.0700245
th2m                   /       1091     -10.7171      40.245    -0.486023     0.47171    0.957733  -0.00982316   0.0719192
gsw                    /       1151     -6177.84     18591.6     -191.386     183.944      375.33     -5.36737     29.3556
glw                    /       1142      1605.18     4628.76     -45.2773     53.4667      98.744      1.40558     7.44403
skintemp               /        763     -36.5677     106.339     -1.47787     1.08701     2.56488   -0.0479263    0.242834
snow                   /        168       3.7961     6.22501    -0.190812     0.42917    0.619982    0.0225958   0.0705039
snowh                  /        169    0.0259031   0.0432008  -0.00100994  0.00276384  0.00377378  0.000153273 0.000444873
canwat                 /        311    0.0227173   0.0395253  -0.00193733  0.00287684  0.00481417  7.30459e-05 0.000370921
sh2o                   /       3920    0.0222809    0.313739   -0.0253919  0.00916708    0.034559   5.6839e-06 0.000636487
smois                  /       4040    0.0836823    0.207587  -0.00190932  0.00911452   0.0110238  2.07134e-05 0.000243367
tslb                   /       3476     -84.3091     216.739     -1.46088     1.08701     2.54788   -0.0242546    0.147134
soilt1                 /         80    -0.635986     1.11804     -0.15097    0.041687    0.192657  -0.00794983   0.0308597
rhosnf                 /         61      1074.38     1108.48     -2.57794     1063.55     1066.13      17.6127     136.159
snowfallac             /         61   0.00126987  0.00134656 -2.00824e-05 0.000315045 0.000335127  2.08175e-05 4.91741e-05
acrunoff               /        418    -0.136162    0.201406   -0.0396537  0.00782576   0.0474794 -0.000325746  0.00286473
grdflx                 /        763      270.932      4438.6     -64.4889     56.6025     121.091     0.355087     10.5107
sfc_albedo             /        162     0.028104   0.0387397 -0.000629321  0.00748934  0.00811866  0.000173481 0.000879631
cldfrac_bl             /       9114      268.704     496.057      -0.8745           1      1.8745    0.0294826   0.0983821
snowc                  /        180    0.0240721    0.135987   -0.0180637  0.00598452   0.0240482  0.000133734  0.00195238
snownc                 /        167   -0.0237075    0.211544   -0.0169302   0.0202458    0.037176 -0.000141961  0.00342048
graupelnc              /        260     0.214888    0.258334  -0.00832958     0.03896   0.0472896  0.000826491  0.00410958

######################################################################
# compare to previous GSL CONUS hrrrv5 RAP winter baselines C8GSL     
######################################################################

  === history.2024-08-15_18.00.00.nc comparison
Files "/lfs5/BMC/rtwbl/olson/mpas_testcase/run_case/gsl-v8.2.2-2.9-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas
/run_case/gsl-v8.2.2-2.8-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.00.00.nc" are identical.

  === history.2024-08-15_18.12.00.nc comparison
Variable               Group  Count          Sum      AbsSum          Min         Max       Range         Mean      StdDev
qv                     /      51364    0.0097219    0.152272  -0.00032032 0.000483182 0.000803502  1.89275e-07 1.42806e-05
qc                     /        985  0.000729967  0.00484735 -0.000123979 0.000850962 0.000974941  7.41083e-07 3.30277e-05
qr                     /       3405  0.000888813  0.00139044 -6.73003e-06 4.02483e-05 4.69783e-05  2.61032e-07  2.2781e-06
qi                     /       1494  2.24483e-07 4.75656e-07 -9.45838e-08  2.7432e-07 3.68904e-07  1.50256e-10  7.5325e-09
qs                     /       3393  2.67199e-06 3.80523e-05 -7.89094e-06 6.04234e-06 1.39333e-05  7.87501e-10 2.00935e-07
qg                     /        823  4.03826e-07 4.93302e-07 -1.90594e-08 1.08251e-07  1.2731e-07  4.90675e-10 6.17114e-09
ni                     /       1493     -1837.52      1961.1     -1588.55     5.27051     1593.82     -1.23076     41.7277
nr                     /       3407      88849.5      129890     -1536.88     4577.64     6114.51      26.0785     214.781
ng                     /        817      5.33039     29.5309     -5.40076     5.04597     10.4467   0.00652435     0.32969
nc                     /        985  5.82567e+08 3.22743e+09 -9.13507e+07 2.25587e+08 3.16937e+08       591439 1.46161e+07
nifa                   /      45006       655484 1.23371e+07      -134650      145144      279794      14.5644     2477.59
nwfa                   /      48277  1.62738e+10 9.91488e+10 -4.66091e+08  2.2065e+08  6.8674e+08       337093 9.29112e+06
volg                   /        824  5.90219e-10 7.54951e-10 -2.27519e-11 1.42886e-10 1.65638e-10  7.16286e-13 8.34372e-12
u                      /     178650     -2.13523      480.72    -0.305747     0.34243    0.648177  -1.1952e-05  0.00996443
w                      /      72411    -0.886378     3.69829   -0.0046656  0.00168468  0.00635028 -1.22409e-05 0.000221913
pressure               /      45453      -1900.2     13293.1     -130.859     305.961      436.82   -0.0418059     2.84336
surface_pressure       /        838      57.2578     335.914     -7.19531     31.8438     39.0391    0.0683267     1.57915
rho                    /      48168   -0.0267489    0.593586  -0.00541377  0.00600773   0.0114215 -5.55326e-07 9.56793e-05
theta                  /      40724     -3.47293     183.356     -1.79391     1.60199      3.3959 -8.52797e-05   0.0336935
relhum                 /      54085      8.09041     1556.55     -4.21514     11.6673     15.8824  0.000149587    0.183159
divergence             /      64804 -4.89989e-07  0.00209095  -1.7364e-06  2.4323e-06  4.1687e-06  -7.5611e-12 9.77276e-08
vorticity              /     118522 -2.24325e-07  0.00613529 -6.17028e-06 5.22913e-06 1.13994e-05 -1.89269e-12 2.13454e-07
ke                     /      64465     -4.13632      1184.6     -2.74666     4.71852     7.46518 -6.41638e-05   0.0831176
uReconstructZonal      /      64096     -8.34792     144.743    -0.250184    0.211393    0.461577 -0.000130241  0.00794066
uReconstructMeridional /      64520     -6.66613     148.995     -0.26303    0.304712    0.567742 -0.000103319  0.00804062
ertel_pv               /      65864       49.551     163.563      -4.9841     6.57851     11.5626  0.000752322   0.0618752
u_pv                   /       1101    0.0169288    0.603761   -0.0121689   0.0107894   0.0229583  1.53759e-05  0.00144945
v_pv                   /       1121     0.036242    0.547074   -0.0106602   0.0116843   0.0223445  3.23301e-05  0.00124978
theta_pv               /        806    0.0109558    0.163544  -0.00549316  0.00888062   0.0143738  1.35928e-05 0.000626259
vort_pv                /       1105 -1.18437e-07 1.01304e-06 -3.50337e-08 2.41489e-08 5.91826e-08 -1.07183e-10 2.82748e-09
depv_dt_lw             /      63924 -5.66022e-05 0.000789586 -1.21551e-05 9.18109e-06 2.13362e-05 -8.85462e-10 1.68178e-07
depv_dt_sw             /      63987 -1.91319e-07 2.36222e-05 -1.18116e-07 7.12358e-08 1.89352e-07 -2.98997e-12 1.93958e-09
depv_dt_bl             /      64666    0.0735722    0.254776  -0.00665098  0.00880577   0.0154568  1.13773e-06 9.06777e-05
depv_dt_mix            /      69387 -1.59247e-06  0.00199076 -5.09191e-05 3.18576e-05 8.27767e-05 -2.29505e-11 4.78975e-07
dtheta_dt_mp           /       9727  0.000250244   0.0368934 -0.000708093  0.00156004  0.00226813  2.57268e-08 3.05503e-05
depv_dt_mp             /      37035 -0.000999534   0.0177174 -0.000278526 0.000269252 0.000547778 -2.69889e-08 5.49531e-06
depv_dt_diab           /      69539    0.0725143    0.252788  -0.00662559  0.00876898   0.0153946  1.04279e-06 8.71171e-05
depv_dt_fric           /      71086   -0.0115513    0.111394  -0.00358655 0.000875605  0.00446216 -1.62498e-07  2.2688e-05
depv_dt_diab_pv        /       1144 -8.87439e-08 1.63575e-06 -5.61549e-08 5.45601e-08 1.10715e-07 -7.75733e-11 5.64872e-09
depv_dt_fric_pv        /       1208  4.16506e-09 2.01267e-06 -6.70552e-08  4.1211e-08 1.08266e-07   3.4479e-12 5.07302e-09
rainnc                 /        237     0.059364    0.098861  -0.00616965   0.0139496   0.0201193  0.000250481  0.00166604
precipw                /        941    -0.596606     1.04902    -0.240417   0.0452347    0.285652 -0.000634013   0.0100072
cldfrac_bl             /       4616      153.402     195.753    -0.298455    0.480319    0.778774    0.0332327   0.0570699
graupelnc              /         21  2.45521e-09 7.67844e-09  -1.9063e-09 2.16824e-09 4.07454e-09  1.16915e-10 7.27658e-10

  === history.2024-08-15_19.00.00.nc comparison
Variable               Group  Count          Sum      AbsSum          Min         Max       Range         Mean      StdDev
qv                     /      57289   -0.0690941    0.764846  -0.00147445  0.00187385   0.0033483 -1.20606e-06 5.18163e-05
qc                     /        971   0.00131446   0.0302647  -0.00042271 0.000752439  0.00117515  1.35372e-06 7.55345e-05
qr                     /       4671   0.00210111  0.00364346 -2.45294e-05   5.213e-05 7.66594e-05  4.49819e-07 3.39794e-06
qi                     /       1629 -5.08096e-07 5.69739e-06 -2.84685e-07 1.42782e-07 4.27467e-07 -3.11907e-10 1.37002e-08
qs                     /       3616  8.76024e-06  0.00019372 -8.16909e-06 5.94478e-06 1.41139e-05  2.42263e-09 2.88601e-07
qg                     /        554  -5.0455e-06 7.55151e-06 -5.89898e-07 3.63041e-07 9.52939e-07  -9.1074e-09 7.16721e-08
ni                     /       1629       1074.1     12123.7     -595.126     3289.79     3884.91     0.659362     87.3171
nr                     /       4671      89714.5      342963     -3825.62     4151.55     7977.17      19.2067      314.28
ng                     /        554      276.367     761.838      -75.291     310.948     386.239     0.498857     14.0353
nc                     /        971 -1.73888e+09 9.65428e+09 -1.52588e+08 2.29937e+08 3.82525e+08 -1.79081e+06 2.59438e+07
nifa                   /      51316      -280954 4.05671e+07      -102130      135964      238094     -5.47498     3539.74
nwfa                   /      56223  3.70404e+10 1.11732e+12 -1.01252e+09 1.05336e+09 2.06588e+09       658813  5.5989e+07
volg                   /        554 -7.93553e-09  1.5849e-08 -9.84527e-10  1.4678e-09 2.45233e-09 -1.43241e-11 1.41487e-10
u                      /     179881     -7.63709     3209.74     -1.63483     1.48223     3.11706 -4.24563e-05   0.0445899
w                      /      72424     -4.82011     34.9555   -0.0448026     0.01711   0.0619125  -6.6554e-05  0.00132789
pressure               /      57347     -13657.2     73171.4     -158.297     250.445     408.742    -0.238149     4.07714
surface_pressure       /        973      627.188     2371.72     -75.3359     37.0156     112.352     0.644591     5.00858
rho                    /      57405     0.353194     2.91495  -0.00230467  0.00701147  0.00931615  6.15266e-06 0.000186266
theta                  /      56673     -117.481      1058.9     -3.42026     1.09042     4.51068  -0.00207296    0.075745
relhum                 /      57241      439.166     9252.66     -13.5805     40.2862     53.8667   0.00767223    0.725026
divergence             /      65017 -5.66376e-07   0.0152686 -1.02262e-05 1.90771e-05 2.93033e-05 -8.71121e-12 6.09163e-07
vorticity              /     122342  1.44384e-06   0.0281646 -2.96028e-05 2.77735e-05 5.73763e-05  1.18017e-11 7.49972e-07
ke                     /      65017      95.9421     7255.78     -12.6033     18.5887     31.1919   0.00147565    0.333536
uReconstructZonal      /      64988     -15.8245     899.933     -1.40585    0.957363     2.36322 -0.000243499   0.0348058
uReconstructMeridional /      65015     -8.89168     880.418    -0.998408     1.19295     2.19136 -0.000136764   0.0325208
ertel_pv               /      70480      37.2769     369.801     -1.15979     7.33903     8.49882    0.0005289   0.0394216
u_pv                   /       1126      1.71624     8.94687    -0.147704      1.1932     1.34091    0.0015242   0.0392484
v_pv                   /       1148      0.54697     7.30459   -0.0807829    0.107589    0.188372  0.000476455   0.0108069
theta_pv               /       1098     -1.71381     7.27521     -2.25314    0.240814     2.49396  -0.00156084   0.0698177
vort_pv                /       1149  3.35182e-06 2.90304e-05 -7.45418e-07 5.58637e-06 6.33179e-06  2.91717e-09 1.71946e-07
iLev_DT                /          1            1           1            1           1           0            1           0
depv_dt_lw             /      72595    0.0058046   0.0704632 -0.000891602  0.00045599  0.00134759  7.99587e-08 7.77117e-06
depv_dt_sw             /      72516  0.000626985   0.0268317 -0.000184188 0.000121956 0.000306144  8.64616e-09 2.24207e-06
depv_dt_bl             /      61292    0.0306553    0.326293  -0.00217253    0.013884   0.0160566  5.00152e-07 7.64813e-05
depv_dt_mix            /      71868 -1.63629e-05   0.0032595 -5.08006e-05 1.30304e-05  6.3831e-05  -2.2768e-10 3.00966e-07
dtheta_dt_mp           /      14318   0.00136672    0.128056 -0.000785319  0.00112796  0.00191328  9.54548e-08 3.85196e-05
depv_dt_mp             /      40271  -0.00279028   0.0617066 -0.000570061 0.000663056  0.00123312 -6.92876e-08 1.17449e-05
depv_dt_diab           /      72695    0.0342802    0.348503  -0.00217254   0.0139519   0.0161244  4.71563e-07 7.06919e-05
depv_dt_fric           /      72728   0.00168932     0.14198 -0.000779919  0.00078705  0.00156697  2.32279e-08 1.65505e-05
depv_dt_diab_pv        /       1227  1.69847e-05 7.95539e-05 -1.66548e-06 6.01634e-06 7.68182e-06  1.38425e-08 2.99265e-07
depv_dt_fric_pv        /       1230  4.26583e-05 0.000544755 -6.75548e-05 0.000139305 0.000206859  3.46815e-08 5.07892e-06
rainnc                 /        447     0.767545      1.1356    -0.100768   0.0606446    0.161413    0.0017171    0.008231
precipw                /        976     -3.60684     12.9586    -0.327118     0.12738    0.454498  -0.00369553   0.0358193
kpbl                   /        114          -31         115           -2           1           3     -0.27193    0.980203
hpbl                   /       1087     -3513.05       19396     -259.707     279.689     539.397     -3.23188     37.6732
hfx                    /       1137     -862.735     4729.47     -60.0156     107.026     167.042    -0.758782     10.1813
qfx                    /       1136 -0.000559684  0.00118538 -3.92362e-05 1.89387e-05 5.81749e-05 -4.92679e-07 2.97001e-06
cd                     /       1133   -0.0245166    0.047865  -0.00149309 0.000576654  0.00206974 -2.16387e-05 0.000109254
cda                    /       1135   -0.0219389   0.0427973  -0.00121173 0.000486502  0.00169823 -1.93294e-05 9.47982e-05
ck                     /       1135  -0.00731285   0.0221526 -0.000691523 0.000281162 0.000972684 -6.44304e-06 4.70631e-05
cka                    /       1135  -0.00814028   0.0222158 -0.000625682 0.000244915 0.000870596 -7.17206e-06 4.63366e-05
lh                     /       1136     -1399.21     2963.45     -98.0906     47.3467     145.437      -1.2317     7.42502
u10                    /       1136    -0.588504     16.8198    -0.392836    0.129193    0.522029 -0.000518049   0.0261614
v10                    /       1137      -0.1529     17.2701    -0.589324    0.200018    0.789341 -0.000134477   0.0307741
q2                     /       1128   -0.0119787   0.0265538 -0.000307582  0.00010987 0.000417452 -1.06194e-05 3.94684e-05
t2m                    /       1085     -10.5574     44.0398    -0.378754    0.585175    0.963928   -0.0097303    0.074956
th2m                   /       1095     -10.9008     44.7611    -0.389984    0.608398    0.998383  -0.00995506   0.0760942
gsw                    /       1149     -6979.19     27343.9     -389.451     262.286     651.737     -6.07414     49.3562
glw                    /       1152      672.561     3316.61     -27.7614     26.3254     54.0868     0.583821     5.43305
skintemp               /        765     -27.3945     131.685     -1.81097     2.85431     4.66528   -0.0358098    0.346481
canwat                 /         26  -0.00592279   0.0460125   -0.0126893  0.00379488   0.0164842   -0.0002278  0.00309255
sh2o                   /       4045    0.0330953   0.0652019  -0.00176249  0.00161394  0.00337644  8.18179e-06 7.39935e-05
smois                  /       4108    0.0351906   0.0697567  -0.00176249  0.00174829  0.00351079  8.56636e-06 7.50566e-05
tslb                   /       3380     -83.6067     275.219     -2.31027     2.85431     5.16458   -0.0247357    0.213636
acrunoff               /        192  0.000152146 0.000692097 -0.000151022   8.607e-05 0.000237092  7.92426e-07  1.5496e-05
grdflx                 /        766     -418.729     5459.52     -97.0783     118.321     215.399    -0.546644      15.594
cldfrac_bl             /       6215      206.289     355.917    -0.641478    0.875953     1.51743    0.0331921   0.0878432
graupelnc              /         21  2.81719e-09 8.04042e-09  -1.9063e-09 2.16824e-09 4.07454e-09  1.34152e-10 7.29155e-10

########################################################################
# compare to previous NCAR CONUS mesoscale_reference baselines A1NCAR   
########################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/lfs5/BMC/rtwbl/olson/mpas_testcase/run_case/gsl-v8.2.2-2.9-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas
/baselines_mpas/run_case/ncar-v8.2.2-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/lfs5/BMC/rtwbl/olson/mpas_testcase/run_case/gsl-v8.2.2-2.9-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas
/baselines_mpas/run_case/ncar-v8.2.2-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/lfs5/BMC/rtwbl/olson/mpas_testcase/run_case/gsl-v8.2.2-2.9-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas
/baselines_mpas/run_case/ncar-v8.2.2-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

```
</details>
