### PR TITLE
add needed land variables to the da_state stream

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1308,8 +1308,6 @@
                         <var name="ivgtyp"/>
                         <var name="landusef"/>
                         <var name="mminlu"/>
-                        <var name="isice_lu"/>
-                        <var name="iswater_lu"/>
                         <var name="landmask"/>
                         <var name="shdmin"/>
                         <var name="shdmax"/>

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1303,6 +1303,20 @@
 			<var name="uReconstructMeridional"/>
 			<var name="surface_pressure"/>
 #ifdef DO_PHYSICS
+                        <var name="isltyp"/>
+                        <var name="soilf"/>
+                        <var name="ivgtyp"/>
+                        <var name="landusef"/>
+                        <var name="mminlu"/>
+                        <var name="isice_lu"/>
+                        <var name="iswater_lu"/>
+                        <var name="landmask"/>
+                        <var name="shdmin"/>
+                        <var name="shdmax"/>
+                        <var name="snoalb"/>
+                        <var name="albedo12m"/>
+                        <var name="greenfrac"/>
+                        <var name="lai12m"/>
 			<var name="cldfrac"/>
 			<var name="re_cloud" packages="mp_thompson_in;mp_wsm6_in;mp_tempo_in"/>
 			<var name="re_ice" packages="mp_thompson_in;mp_wsm6_in;mp_tempo_in"/>


### PR DESCRIPTION
The cycling DA uses the `mpasout` file to warm start new forecasts. It uses the `da_state` stream, which misses the following variables:
```
<var name="isltyp"/>                                                                                                                                                   
<var name="soilf"/>
<var name="ivgtyp"/>
<var name="landusef"/>
<var name="mminlu"/>
<var name="isice_lu"/>
<var name="iswater_lu"/>
<var name="landmask"/>
<var name="shdmin"/>
<var name="shdmax"/>
<var name="snoalb"/>
<var name="albedo12m"/>
<var name="greenfrac"/>
<var name="lai12m"/>
```

Address issue # 102