### PR TITLE
8.2.2-2.11 Correct initialization of snow on sea ice.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MPAS-v8.2.2-2.8
+MPAS-v8.2.2-2.11
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for
 developing atmosphere, ocean, and other earth-system simulation components for

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.2.2-2.8">
+<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.2.2-2.11">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->

--- a/src/core_atmosphere/physics/mpas_atmphys_initialize_real.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_initialize_real.F
@@ -943,6 +943,7 @@ end subroutine init_soil_layers_properties
  real(kind=RKIND),dimension(:),pointer  :: vegfra
  real(kind=RKIND),dimension(:),pointer  :: seaice,snoalb,xice
  real(kind=RKIND),dimension(:),pointer  :: skintemp,tmn,xland
+ real(kind=RKIND),dimension(:),pointer  :: snow, snowh
  real(kind=RKIND),dimension(:,:),pointer:: tslb,smois,sh2o,smcrel
 
  logical, pointer :: config_frac_seaice
@@ -978,6 +979,9 @@ end subroutine init_soil_layers_properties
  call mpas_pool_get_array(input, 'skintemp', skintemp)
  call mpas_pool_get_array(input, 'tmn', tmn)
  call mpas_pool_get_array(input, 'xland', xland)
+
+ call mpas_pool_get_array(input, 'snow', snow)
+ call mpas_pool_get_array(input, 'snowh', snowh)
 
  call mpas_pool_get_array(input, 'tslb', tslb)
  call mpas_pool_get_array(input, 'smois', smois)
@@ -1020,6 +1024,9 @@ end subroutine init_soil_layers_properties
        vegfra(iCell) = 0._RKIND
        xland(iCell)  = 1._RKIND
        seaice(iCell) = 1._RKIND
+       !top limit on snow depth on sea ice: 40 cm or 120 mm swe
+       snowh(iCell) = min(snowh(iCell),0.4_RKIND)
+       snow(iCell)  = min(snow(iCell),120._RKIND)
 
        !... recalculate the soil temperature and soil moisture:
        do iSoil = 1, nSoilLevels

--- a/src/core_atmosphere/physics/mpas_atmphys_initialize_real.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_initialize_real.F
@@ -1024,9 +1024,9 @@ end subroutine init_soil_layers_properties
        vegfra(iCell) = 0._RKIND
        xland(iCell)  = 1._RKIND
        seaice(iCell) = 1._RKIND
-       !top limit on snow depth on sea ice: 40 cm or 120 mm swe
-       snowh(iCell) = min(snowh(iCell),0.4_RKIND)
-       snow(iCell)  = min(snow(iCell),120._RKIND)
+       !top limit on snow depth on sea ice: 1.2 m or 360 mm swe
+       snowh(iCell) = min(snowh(iCell),1.2_RKIND)
+       snow(iCell)  = min(snow(iCell),360._RKIND)
 
        !... recalculate the soil temperature and soil moisture:
        do iSoil = 1, nSoilLevels

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.2.2-2.8">
+<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.2.2-2.11">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -6131,8 +6131,8 @@ module init_atm_cases
                interp_list(2) = W_AVERAGE4
                interp_list(3) = 0
 
-               masked = 0
-               fillval = 0.0
+               !masked = 0
+               !fillval = 0.0
 
                nInterpPoints = nCells
                latPoints => latCell
@@ -6146,8 +6146,8 @@ module init_atm_cases
                interp_list(2) = W_AVERAGE4
                interp_list(3) = 0
 
-               masked = 0
-               fillval = 0.0
+               !masked = 0
+               !fillval = 0.0
 
                nInterpPoints = nCells
                latPoints => latCell


### PR DESCRIPTION
The title above should be a 1 line short summary of the pull request (i.e. what the project the PR represents is intended to do).

Enter a description of this PR. This should include why this PR was created, and what it does.
    1. Removed land/water masking in snow interpolation. This fix is needed to
       keep GFS snow on sea ice. If some water points will get non-zero snow after horizontal interpolation, it 
       will be anyway cleaned out later in the model.
   2. Limit initial snow ice to 1.2 m.

Testing and relations to other Pull Requests should be added as subsequent comments.

See the below examples for more information.
https://github.com/MPAS-Dev/MPAS/pull/930
https://github.com/MPAS-Dev/MPAS/pull/931

Information on running mandatory regression tests on Jet can be found [here](https://github.com/barlage/mpas_testcase) and the results pasted below.

This PR is tested against version 8.2.2-2.8, and all suites have identical results because the situation with snow on sea ice was not presented in our test cases.
The comparison results are in /mnt/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/utils/compare_run_testcases_v8.2.2-2.11-intdebug

<details>
  <summary>
    regression test case results
  </summary>
  
```
PASTE compare_run_testcases AND/OR compare_create_testcases TEXT HERE

     version_to_compare = v8.2.2-2.11
   gsl_version_baseline = v8.2.2-2.8
  ncar_version_baseline = v8.2.2
         test_directory = /lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/
 gsl_baseline_directory = /lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/
ncar_baseline_directory = /lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/
           compile_flag = -intdebug
         test_repo_name = gsl

######################################################################
# compare to previous GSL CONUS mesoscale_reference baselines A1GSL
######################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.11-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.8-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.11-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.8-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.11-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.8-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

#############################################################################
# compare to previous GSL CONUS mesoscale_reference_noahmp baselines E1GSL
#############################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.11-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.8-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.11-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.8-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.11-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.8-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

######################################################################
# compare to previous GSL CONUS hrrrv5 GFS baselines C5GSL
######################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.11-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.8-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.11-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.8-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.11-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.8-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

######################################################################
# compare to previous GSL CONUS hrrrv5 RAP winter baselines C7GSL
######################################################################

  === history.2024-02-02_18.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.11-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.8-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.00.00.nc" are identical.

  === history.2024-02-02_18.12.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.11-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.8-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.12.00.nc" are identical.

  === history.2024-02-02_19.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.11-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_19.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.8-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_19.00.00.nc" are identical.

######################################################################
# compare to previous GSL CONUS hrrrv5 RAP summer baselines C8GSL
######################################################################

  === history.2024-08-15_18.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.11-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.8-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.00.00.nc" are identical.

  === history.2024-08-15_18.12.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.11-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.8-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.12.00.nc" are identical.

  === history.2024-08-15_19.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.11-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_19.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.8-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_19.00.00.nc" are identical.

########################################################################
# compare to previous NCAR CONUS mesoscale_reference baselines A1NCAR
########################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.11-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.2.2-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.11-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.2.2-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/smirnova/MPAS_regression_tests/mpas_testcase/run_case/gsl-v8.2.2-2.11-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.2.2-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

```
</details>
