### PR TITLE
Add ML component to TEMPO for number concentration prediction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MPAS-v8.2.2-2.12
+MPAS-v8.2.2-3.0
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for
 developing atmosphere, ocean, and other earth-system simulation components for

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.2.2-2.12">
+<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.2.2-3.0">
 
 
 <!-- **************************************************************************************** -->

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -2459,6 +2459,21 @@
                      description="Logical flag to turn on/off prognostic graupel number concentration and rime density"
                      possible_values=".true. or .false."/>
 
+		<nml_option name="config_tempo_ml_nc_pbl" type="logical" default_value="false" in_defaults="false"
+		     units="-"
+                     description="Logical flag to turn on/off ML prediction of boundary layer cloud number concentrations"
+                     possible_values=".true. or .false."/>
+
+		<nml_option name="config_tempo_ml_nc" type="logical" default_value="false" in_defaults="false"
+		     units="-"
+                     description="Logical flag to turn on/off ML prediction of microphysics cloud number concentrations"
+                     possible_values=".true. or .false."/>
+
+		<nml_option name="config_tempo_ml_nr" type="logical" default_value="false" in_defaults="false"
+		     units="-"
+                     description="Logical flag to turn on/off ML prediction of microphysics rain number concentrations"
+                     possible_values=".true. or .false."/>
+
                 <nml_option name="config_nssl_moments" type="character" default_value="nssl2m" in_defaults="false"
                      units="-"
                      description="Whether to activate the 3moment version of NSSL"

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -376,6 +376,7 @@ module atm_core
 !     use mpas_atmphys_aquaplanet
       use mpas_atmphys_control
       use mpas_atmphys_init
+      use mpas_atmphys_init_tempo
       use mpas_atmphys_manager
 #endif
 
@@ -565,6 +566,7 @@ module atm_core
          !initialization of all physics:
          call physics_init(dminfo, stream_manager, clock, block % configs, mesh, diag, tend, state, 1,       &
                            diag_physics, diag_physics_noahmp, ngw_input, atm_input, sfc_input, output_noahmp)
+         call tempo_ml_init(block % configs)
       endif
 #endif
    

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
@@ -628,6 +628,7 @@
                         has_reqc  = has_reqc    , has_reqi   = has_reqi     , has_reqs   = has_reqs     , &
                         !! ntc       = ntc_p       , muc        = muc_p                                    , &
                         refl_10cm  = refl10cm_p , frainnc    = frainnc_p                                , &
+                        qcbl      = qcbl_p      , cldfrac    = cldfrac_p                                , &
                         ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde           , &
                         ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme           , &
                         its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte             &
@@ -649,7 +650,7 @@
                         has_reqc  = has_reqc    , has_reqi   = has_reqi     , has_reqs   = has_reqs     , &
                         !! ntc       = ntc_p       , muc        = muc_p                                    , &
                         refl_10cm  = refl10cm_p , frainnc    = frainnc_p                                , &
-                        qcbl      = qcbl_p      , cldfrac    = cldfrac_p                                , &
+                        !! qcbl      = qcbl_p      , cldfrac    = cldfrac_p                                , &
                         ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde           , &
                         ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme           , &
                         its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte             &

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
@@ -674,6 +674,7 @@
                      has_reqc  = has_reqc    , has_reqi   = has_reqi     , has_reqs   = has_reqs     , &
                      !! ntc       = ntc_p       , muc        = muc_p                                    , &
                      refl_10cm  = refl10cm_p , frainnc    = frainnc_p                                , &
+                     qcbl      = qcbl_p      , cldfrac    = cldfrac_p                                , &
                      ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde           , &
                      ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme           , &
                      its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte             &

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
@@ -110,13 +110,14 @@
  character(len=StrKIND),pointer:: microp_scheme
  character(len=StrKIND),pointer:: nssl_moments
  logical,pointer:: config_tempo_hailaware, config_tempo_aerosolaware
-
+ logical,pointer:: config_tempo_ml_nc_pbl
 !-----------------------------------------------------------------------------------------------------------------
 
  call mpas_pool_get_config(configs,'config_microp_scheme',microp_scheme)
  call mpas_pool_get_config(configs,'config_nssl_moments',nssl_moments)
  call mpas_pool_get_config(configs,'config_tempo_hailaware',config_tempo_hailaware)
  call mpas_pool_get_config(configs,'config_tempo_aerosolaware',config_tempo_aerosolaware)
+ call mpas_pool_get_config(configs,'config_tempo_ml_nc_pbl',config_tempo_ml_nc_pbl)
 
 !sounding variables:
  if(.not.allocated(rho_p) ) allocate(rho_p(ims:ime,kms:kme,jms:jme) )
@@ -204,6 +205,11 @@
              if(.not.allocated(volg_p)) allocate(volg_p(ims:ime,kms:kme,jms:jme))
           endif
 
+          if (config_tempo_ml_nc_pbl) then
+             if(.not.allocated(cldfrac_p) ) allocate(cldfrac_p(ims:ime,kms:kme,jms:jme))
+             if(.not.allocated(qcbl_p) ) allocate(qcbl_p(ims:ime,kms:kme,jms:jme))
+          endif
+
           if (config_tempo_aerosolaware) then
              if(.not.allocated(nifa2d_p)) allocate(nifa2d_p(ims:ime,jms:jme))
              if(.not.allocated(nwfa2d_p)) allocate(nwfa2d_p(ims:ime,jms:jme))
@@ -261,6 +267,7 @@
  character(len=StrKIND),pointer:: microp_scheme
  character(len=StrKIND),pointer:: nssl_moments
  logical,pointer:: config_tempo_hailaware, config_tempo_aerosolaware
+ logical,pointer:: config_tempo_ml_nc_pbl
 
 !-----------------------------------------------------------------------------------------------------------------
 
@@ -268,6 +275,7 @@
  call mpas_pool_get_config(configs,'config_nssl_moments',nssl_moments)
  call mpas_pool_get_config(configs,'config_tempo_hailaware',config_tempo_hailaware)
  call mpas_pool_get_config(configs,'config_tempo_aerosolaware',config_tempo_aerosolaware)
+ call mpas_pool_get_config(configs,'config_tempo_ml_nc_pbl',config_tempo_ml_nc_pbl)
 
 !sounding variables:
  if(allocated(rho_p) ) deallocate(rho_p )
@@ -351,6 +359,11 @@
           if (config_tempo_hailaware) then
              if(allocated(ng_p) ) deallocate(ng_p )
              if(allocated(volg_p) ) deallocate(volg_p )
+          endif
+
+          if (config_tempo_ml_nc_pbl) then
+             if(allocated(cldfrac_p) ) deallocate(cldfrac_p)
+             if(allocated(qcbl_p) ) deallocate(qcbl_p)
           endif
 
           if (config_tempo_aerosolaware) then
@@ -636,6 +649,7 @@
                         has_reqc  = has_reqc    , has_reqi   = has_reqi     , has_reqs   = has_reqs     , &
                         !! ntc       = ntc_p       , muc        = muc_p                                    , &
                         refl_10cm  = refl10cm_p , frainnc    = frainnc_p                                , &
+                        qcbl      = qcbl_p      , cldfrac    = cldfrac_p                                , &
                         ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde           , &
                         ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme           , &
                         its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte             &

--- a/src/core_atmosphere/physics/mpas_atmphys_init_tempo.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_init_tempo.F
@@ -73,13 +73,13 @@ type(mpas_pool_type),intent(in):: configs
  tempo_ml_data(1)%transform_mean = nc_ml_trans_mean
  tempo_ml_data(1)%transform_var = nc_ml_trans_var
 
- if (.not.allocated(tempo_ml_data(1)%weights00)) allocate(tempo_ml_data(1)%weights00(nc_ml_input,nc_ml_nodes))
- if (.not.allocated(tempo_ml_data(1)%weights01)) allocate(tempo_ml_data(1)%weights01(nc_ml_nodes,nc_ml_output))
+ if (.not.allocated(tempo_ml_data(1)%weights00)) allocate(tempo_ml_data(1)%weights00(nc_ml_nodes,nc_ml_input))
+ if (.not.allocated(tempo_ml_data(1)%weights01)) allocate(tempo_ml_data(1)%weights01(nc_ml_output,nc_ml_nodes))
  if (.not.allocated(tempo_ml_data(1)%bias00)) allocate(tempo_ml_data(1)%bias00(nc_ml_nodes))
  if (.not.allocated(tempo_ml_data(1)%bias01)) allocate(tempo_ml_data(1)%bias01(nc_ml_output))
 
- tempo_ml_data(1)%weights00 = reshape(nc_ml_w00, (/nc_ml_input, nc_ml_nodes/), order=(/2,1/))
- tempo_ml_data(1)%weights01 = reshape(nc_ml_w01, (/nc_ml_nodes, nc_ml_output/))
+ tempo_ml_data(1)%weights00 = reshape(nc_ml_w00, (/nc_ml_nodes, nc_ml_input/))
+ tempo_ml_data(1)%weights01 = reshape(nc_ml_w01, (/nc_ml_output, nc_ml_nodes/))
  tempo_ml_data(1)%bias00 = nc_ml_b00
  tempo_ml_data(1)%bias01 = nc_ml_b01
 
@@ -94,13 +94,13 @@ type(mpas_pool_type),intent(in):: configs
  tempo_ml_data(2)%transform_mean = nc_ml_trans_mean
  tempo_ml_data(2)%transform_var = nc_ml_trans_var
 
- if (.not.allocated(tempo_ml_data(2)%weights00)) allocate(tempo_ml_data(2)%weights00(nc_ml_input,nc_ml_nodes))
- if (.not.allocated(tempo_ml_data(2)%weights01)) allocate(tempo_ml_data(2)%weights01(nc_ml_nodes,nc_ml_output))
+ if (.not.allocated(tempo_ml_data(2)%weights00)) allocate(tempo_ml_data(2)%weights00(nc_ml_nodes,nc_ml_input))
+ if (.not.allocated(tempo_ml_data(2)%weights01)) allocate(tempo_ml_data(2)%weights01(nc_ml_output,nc_ml_nodes))
  if (.not.allocated(tempo_ml_data(2)%bias00)) allocate(tempo_ml_data(2)%bias00(nc_ml_nodes))
  if (.not.allocated(tempo_ml_data(2)%bias01)) allocate(tempo_ml_data(2)%bias01(nc_ml_output))
 
- tempo_ml_data(2)%weights00 = reshape(nc_ml_w00, (/nc_ml_input, nc_ml_nodes/), order=(/2,1/))
- tempo_ml_data(2)%weights01 = reshape(nc_ml_w01, (/nc_ml_nodes, nc_ml_output/))
+ tempo_ml_data(2)%weights00 = reshape(nc_ml_w00, (/nc_ml_nodes, nc_ml_input/))
+ tempo_ml_data(2)%weights01 = reshape(nc_ml_w01, (/nc_ml_output, nc_ml_nodes/))
  tempo_ml_data(2)%bias00 = nc_ml_b00
  tempo_ml_data(2)%bias01 = nc_ml_b01
 

--- a/src/core_atmosphere/physics/mpas_atmphys_init_tempo.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_init_tempo.F
@@ -71,7 +71,7 @@ type(mpas_pool_type),intent(in):: configs
  if (.not.allocated(tempo_ml_data(1)%transform_var)) allocate(tempo_ml_data(1)%transform_var(nc_ml_input))
 
  tempo_ml_data(1)%transform_mean = nc_ml_trans_mean
- tempo_ml_data(1)%transform_var = nc_ml_trans_mean
+ tempo_ml_data(1)%transform_var = nc_ml_trans_var
 
  if (.not.allocated(tempo_ml_data(1)%weights00)) allocate(tempo_ml_data(1)%weights00(nc_ml_input,nc_ml_nodes))
  if (.not.allocated(tempo_ml_data(1)%weights01)) allocate(tempo_ml_data(1)%weights01(nc_ml_nodes,nc_ml_output))
@@ -84,9 +84,25 @@ type(mpas_pool_type),intent(in):: configs
  tempo_ml_data(1)%bias01 = nc_ml_b01
 
  ! Rain water
- tempo_ml_data(2)%input_size = nr_ml_input
- tempo_ml_data(2)%node_size = nr_ml_nodes
- tempo_ml_data(2)%output_size = nr_ml_output
+ tempo_ml_data(2)%input_size = nc_ml_input
+ tempo_ml_data(2)%node_size = nc_ml_nodes
+ tempo_ml_data(2)%output_size = nc_ml_output
+
+ if (.not.allocated(tempo_ml_data(2)%transform_mean)) allocate(tempo_ml_data(2)%transform_mean(nc_ml_input))
+ if (.not.allocated(tempo_ml_data(2)%transform_var)) allocate(tempo_ml_data(2)%transform_var(nc_ml_input))
+
+ tempo_ml_data(2)%transform_mean = nc_ml_trans_mean
+ tempo_ml_data(2)%transform_var = nc_ml_trans_var
+
+ if (.not.allocated(tempo_ml_data(2)%weights00)) allocate(tempo_ml_data(2)%weights00(nc_ml_input,nc_ml_nodes))
+ if (.not.allocated(tempo_ml_data(2)%weights01)) allocate(tempo_ml_data(2)%weights01(nc_ml_nodes,nc_ml_output))
+ if (.not.allocated(tempo_ml_data(2)%bias00)) allocate(tempo_ml_data(2)%bias00(nc_ml_nodes))
+ if (.not.allocated(tempo_ml_data(2)%bias01)) allocate(tempo_ml_data(2)%bias01(nc_ml_output))
+
+ tempo_ml_data(2)%weights00 = reshape(nc_ml_w00, (/nc_ml_input, nc_ml_nodes/), order=(/2,1/))
+ tempo_ml_data(2)%weights01 = reshape(nc_ml_w01, (/nc_ml_nodes, nc_ml_output/))
+ tempo_ml_data(2)%bias00 = nc_ml_b00
+ tempo_ml_data(2)%bias01 = nc_ml_b01
 
  ! Save neural network
  call tempo_save_or_read_ml_data(ml_data_in=tempo_ml_data)

--- a/src/core_atmosphere/physics/mpas_atmphys_init_tempo.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_init_tempo.F
@@ -16,11 +16,16 @@
 
  use mpas_atmphys_utilities
  use module_mp_tempo_params, only: ntb_arc,ntb_arw,ntb_art,ntb_arr,ntb_ark,tnccn_act, &
-      naCCN1,naCCN0,naIN0,naIN1,nwfa_default,aero_max
-                              
+      naCCN1,naCCN0,naIN0,naIN1,nwfa_default,aero_max, &
+      nc_ml_input, nc_ml_nodes, nc_ml_output, &
+      nr_ml_input, nr_ml_nodes, nr_ml_output, &
+      nc_ml_trans_mean, nc_ml_trans_var, &
+      nc_ml_w00, nc_ml_w01, nc_ml_b00, nc_ml_b01
+ use module_mp_tempo_ml, only: MLdata, tempo_save_or_read_ml_data
+
  implicit none
  private
- public:: init_tempo_aerosols_forMPAS
+ public:: init_tempo_aerosols_forMPAS, tempo_ml_init
 
 !MPAS main initialization of the TEMPO parameterization of cloud microphysics with nucleation of cloud
 !droplets based on distributions of CCNs and INs (aerosol-aware parameterization).
@@ -28,6 +33,44 @@
  
  contains
 
+!=================================================================================================================
+ subroutine tempo_ml_init()
+! Called once to initial data for tempo_ml
+!=================================================================================================================
+
+!local variables and pointers:
+ type(MLdata), dimension(2) :: tempo_ml_data
+
+ ! Cloud water
+ tempo_ml_data(1)%input_size = nc_ml_input
+ tempo_ml_data(1)%node_size = nc_ml_nodes
+ tempo_ml_data(1)%output_size = nc_ml_output
+
+ ! Rain water
+ tempo_ml_data(2)%input_size = nr_ml_input
+ tempo_ml_data(2)%node_size = nr_ml_nodes
+ tempo_ml_data(2)%output_size = nr_ml_output
+
+ if (.not.allocated(tempo_ml_data(1)%transform_mean)) allocate(tempo_ml_data(1)%transform_mean(nc_ml_input))
+ if (.not.allocated(tempo_ml_data(1)%transform_var)) allocate(tempo_ml_data(1)%transform_var(nc_ml_input))
+
+ tempo_ml_data(1)%transform_mean = nc_ml_trans_mean
+ tempo_ml_data(1)%transform_var = nc_ml_trans_mean
+
+ if (.not.allocated(tempo_ml_data(1)%weights00)) allocate(tempo_ml_data(1)%weights00(nc_ml_input,nc_ml_nodes))
+ if (.not.allocated(tempo_ml_data(1)%weights01)) allocate(tempo_ml_data(1)%weights01(nc_ml_nodes,nc_ml_output))
+ if (.not.allocated(tempo_ml_data(1)%bias00)) allocate(tempo_ml_data(1)%bias00(nc_ml_nodes))
+ if (.not.allocated(tempo_ml_data(1)%bias01)) allocate(tempo_ml_data(1)%bias01(nc_ml_output))
+
+ tempo_ml_data(1)%weights00 = reshape(nc_ml_w00, (/nc_ml_input, nc_ml_nodes/), order=(/2,1/))
+ tempo_ml_data(1)%weights01 = reshape(nc_ml_w01, (/nc_ml_nodes, nc_ml_output/))
+ tempo_ml_data(1)%bias00 = nc_ml_b00
+ tempo_ml_data(1)%bias01 = nc_ml_b01
+
+ ! Save neural network
+ call tempo_save_or_read_ml_data(ml_data_in=tempo_ml_data)
+
+ end subroutine tempo_ml_init
 
 !=================================================================================================================
  subroutine init_tempo_aerosols_forMPAS(do_restart,dminfo,mesh,state,time_lev,diag_physics)

--- a/src/core_atmosphere/physics/mpas_atmphys_init_tempo.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_init_tempo.F
@@ -34,22 +34,38 @@
  contains
 
 !=================================================================================================================
- subroutine tempo_ml_init()
+ subroutine tempo_ml_init(configs)
 ! Called once to initial data for tempo_ml
 !=================================================================================================================
 
+!input arguments:
+type(mpas_pool_type),intent(in):: configs
+
 !local variables and pointers:
  type(MLdata), dimension(2) :: tempo_ml_data
+ logical,pointer:: config_tempo_ml_nc_pbl,config_tempo_ml_nc,config_tempo_ml_nr
+
+ call mpas_pool_get_config(configs, 'config_tempo_ml_nc_pbl', config_tempo_ml_nc_pbl)
+ call mpas_pool_get_config(configs, 'config_tempo_ml_nc', config_tempo_ml_nc)
+ call mpas_pool_get_config(configs, 'config_tempo_ml_nr', config_tempo_ml_nr)
+
+ if(.not. (config_tempo_ml_nc_pbl .or. config_tempo_ml_nc .or. config_tempo_ml_nr)) then
+    call mpas_log_write('--- All configuration flags for TEMPO ML are false... TEMPO ML will not be used')
+    return
+ endif
+
+ if(config_tempo_ml_nc .or. config_tempo_ml_nr) then
+    call mpas_log_write('--- TEMPO ML for nc and nr prediction not yet working... These flags will be ignored')
+ endif
+
+ if(config_tempo_ml_nc_pbl) then
+    call mpas_log_write('--- Using TEMPO ML prediction to give life to the PBL clouds')
+ endif
 
  ! Cloud water
  tempo_ml_data(1)%input_size = nc_ml_input
  tempo_ml_data(1)%node_size = nc_ml_nodes
  tempo_ml_data(1)%output_size = nc_ml_output
-
- ! Rain water
- tempo_ml_data(2)%input_size = nr_ml_input
- tempo_ml_data(2)%node_size = nr_ml_nodes
- tempo_ml_data(2)%output_size = nr_ml_output
 
  if (.not.allocated(tempo_ml_data(1)%transform_mean)) allocate(tempo_ml_data(1)%transform_mean(nc_ml_input))
  if (.not.allocated(tempo_ml_data(1)%transform_var)) allocate(tempo_ml_data(1)%transform_var(nc_ml_input))
@@ -66,6 +82,11 @@
  tempo_ml_data(1)%weights01 = reshape(nc_ml_w01, (/nc_ml_nodes, nc_ml_output/))
  tempo_ml_data(1)%bias00 = nc_ml_b00
  tempo_ml_data(1)%bias01 = nc_ml_b01
+
+ ! Rain water
+ tempo_ml_data(2)%input_size = nr_ml_input
+ tempo_ml_data(2)%node_size = nr_ml_nodes
+ tempo_ml_data(2)%output_size = nr_ml_output
 
  ! Save neural network
  call tempo_save_or_read_ml_data(ml_data_in=tempo_ml_data)

--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -664,6 +664,7 @@
 !TEMPO/NSSL
  character(len=StrKIND),pointer:: nssl_moments
  logical,pointer:: config_tempo_hailaware, config_tempo_aerosolaware
+ logical,pointer:: config_tempo_ml_nc_pbl
  integer,pointer:: index_qh
  integer,pointer:: index_zrw,index_zgw,index_zhw
  integer,pointer:: index_ns,index_ng,index_nh,index_nccn
@@ -677,6 +678,7 @@
  real(kind=RKIND),dimension(:,:),pointer  :: volg,volh,zrw,zgw,zhw
  real(kind=RKIND),dimension(:,:),pointer  :: rainprod,evapprod,refl10cm
  real(kind=RKIND),dimension(:,:),pointer  :: re_cloud,re_ice,re_snow
+ real(kind=RKIND),dimension(:,:),pointer  :: qc_bl, cldfrac_bl
  real(kind=RKIND),dimension(:,:),pointer  :: rthmpten,rqvmpten,rqcmpten,rqrmpten,rqimpten,rqsmpten,rqgmpten
  real(kind=RKIND),dimension(:,:),pointer  :: rncmpten,rnimpten,rnrmpten,rnifampten,rnwfampten
  real(kind=RKIND),dimension(:,:,:),pointer:: scalars
@@ -690,6 +692,7 @@
  call mpas_pool_get_config(configs,'config_nssl_moments',nssl_moments)
  call mpas_pool_get_config(configs,'config_tempo_hailaware',config_tempo_hailaware)
  call mpas_pool_get_config(configs,'config_tempo_aerosolaware',config_tempo_aerosolaware)
+ call mpas_pool_get_config(configs,'config_tempo_ml_nc_pbl',config_tempo_ml_nc_pbl)
 
  call mpas_pool_get_array(mesh,'zgrid',zgrid)
  call mpas_pool_get_array(mesh,'zz'   ,zz   )
@@ -839,6 +842,19 @@
              enddo
              enddo
              enddo
+
+             if(config_tempo_ml_nc_pbl) then
+                call mpas_pool_get_array(diag_physics,'qc_bl',qc_bl)
+                call mpas_pool_get_array(diag_physics,'cldfrac_bl',cldfrac_bl)
+                do j = jts, jte
+                do k = kts, kte
+                do i = its, ite
+                   qcbl_p(i,k,j) = qc_bl(k,i)
+                   cldfrac_p(i,k,j) = cldfrac_bl(k,i)
+                enddo
+                enddo
+                enddo
+             endif
 
              if(config_tempo_aerosolaware) then
                 call mpas_pool_get_dimension(state,'index_nc'  ,index_nc  )

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.2.2-2.12">
+<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.2.2-3.0">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->


### PR DESCRIPTION
Add ML component to TEMPO for number concentration prediction.

This PR adds a neural network module to TEMPO that predicts cloud droplet number concentrations from hydrometer and environmental features. Prediction of cloud droplet number concentrations is used to give PBL clouds effective radius values. Infrastructure to allow for replacement of nc in the microphysics and nr prediction for convective reflectivity was also added here.
Current effective radius values from boundary layer clouds use 10.5 microns over water and 7.5 microns over land:
![rre_cloud_ctrl_wiw_21](https://github.com/user-attachments/assets/b4ae27bd-b911-449a-8140-8e3ee85c8e49)

Using ML to diagnose nc from boundary layer clouds and giving them physically consistent effective radius values:
![rre_cloud_exp_wiw_21](https://github.com/user-attachments/assets/5f36a04b-07f6-4d5b-aa7c-839614681c04)

Testing


Information on running mandatory regression tests on Jet can be found [here](https://github.com/barlage/mpas_testcase) and the results pasted below.

<details>
  <summary>
    regression test case results
  </summary>
  
```

     version_to_compare = v8.2.2-3.0
   gsl_version_baseline = v8.2.2-2.12
  ncar_version_baseline = v8.2.2
         test_directory = /scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/
 gsl_baseline_directory = /scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/
ncar_baseline_directory = /scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/
           compile_flag = -intdebug
         test_repo_name = gsl

######################################################################
# compare to previous GSL CONUS mesoscale_reference baselines A1GSL   
######################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.0-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.12-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.0-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.12-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.0-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.12-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

#############################################################################
# compare to previous GSL CONUS mesoscale_reference_noahmp baselines E1GSL   
#############################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.0-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.12-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.0-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.12-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.0-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.12-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

######################################################################
# compare to previous GSL CONUS hrrrv5 GFS baselines C5GSL            
######################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.0-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.12-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.0-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.12-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.0-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.12-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

######################################################################
# compare to previous GSL CONUS hrrrv5 RAP winter baselines C7GSL     
######################################################################

  === history.2024-02-02_18.00.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.0-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.00.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.12-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.00.00.nc" are identical.

  === history.2024-02-02_18.12.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.0-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.12.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.12-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.12.00.nc" are identical.

  === history.2024-02-02_19.00.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.0-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_19.00.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.12-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_19.00.00.nc" are identical.

######################################################################
# compare to previous GSL CONUS hrrrv5 RAP winter baselines C8GSL     
######################################################################

  === history.2024-08-15_18.00.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.0-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.00.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.12-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.00.00.nc" are identical.

  === history.2024-08-15_18.12.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.0-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.12.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.12-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.12.00.nc" are identical.

  === history.2024-08-15_19.00.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.0-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_19.00.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-2.12-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_19.00.00.nc" are identical.

########################################################################
# compare to previous NCAR CONUS mesoscale_reference baselines A1NCAR   
########################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.0-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.2.2-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.0-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.2.2-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.0-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.2.2-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

```
</details>
