### PR TITLE
Add maximum hail size diagnostics for TEMPO

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MPAS-v8.2.2-3.0
+MPAS-v8.2.2-3.1
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for
 developing atmosphere, ocean, and other earth-system simulation components for

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -661,6 +661,9 @@
 			<var name="tyear_mean"/>
 			<var name="tyear_accum"/>
 			<var name="refl10cm"/>
+			<var name="max_hail_diameter_sfc"/>
+			<var name="max_hail_diameter_sfc_acc"/>
+			<var name="max_hail_diameter_column"/>
 			<var name="refl10cm_max"/>
 			<var name="i_rainnc"/>
 			<var name="rainncv"/>
@@ -1122,6 +1125,9 @@
 			<var name="rainnc"/>
 			<var name="vcpool"/>
 			<var name="refl10cm"/>
+			<var name="max_hail_diameter_sfc"/>
+			<var name="max_hail_diameter_sfc_acc"/>
+			<var name="max_hail_diameter_column"/>
 			<var name="refl10cm_max"/>
 			<var name="refl10cm_1km"/>
 			<var name="refl10cm_1km_max"/>
@@ -2712,6 +2718,18 @@
 		<var name="refl10cm" type="real" dimensions="nVertLevels nCells Time" units="dBZ"
                      description="10 cm radar reflectivity"
                      packages="mp_thompson_in;mp_wsm6_in;mp_nssl2m_in;mp_tempo_in"/>
+
+		<var name="max_hail_diameter_sfc" type="real" dimensions="nCells Time" units="mm"
+                     description="Maximum hail diameter at the surface"
+                     packages="mp_tempo_in"/>
+
+		<var name="max_hail_diameter_column" type="real" dimensions="nCells Time" units="mm"
+                     description="Maximum hail diameter in the vertical column"
+                     packages="mp_tempo_in"/>
+
+		<var name="max_hail_diameter_sfc_acc" type="real" dimensions="nCells Time" units="mm"
+                     description="Maximum hail diameter at the surface accumulated over diagnostic output"
+                     packages="mp_tempo_in"/>
 
                 <var name="refl10cm_max" type="real" dimensions="nCells Time" units="dBZ"
                      description="10 cm maximum radar reflectivity"

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.2.2-3.0">
+<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.2.2-3.1">
 
 
 <!-- **************************************************************************************** -->

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -953,12 +953,16 @@ module atm_core
    
       type (mpas_pool_type), pointer :: diag_physics
    
-      real (kind=RKIND), dimension(:), pointer :: refl10cm_1km_max
+      real (kind=RKIND), dimension(:), pointer :: refl10cm_1km_max, max_hail_diameter_sfc_acc
 
 #ifdef DO_PHYSICS
       call mpas_pool_get_array(diag_physics, 'refl10cm_1km_max', refl10cm_1km_max)
+      call mpas_pool_get_array(diag_physics, 'max_hail_diameter_sfc_acc', max_hail_diameter_sfc_acc)
       if(associated(refl10cm_1km_max)) then
          refl10cm_1km_max(:) = 0.
+      endif
+      if(associated(max_hail_diameter_sfc_acc)) then
+         max_hail_diameter_sfc_acc(:) = 0.
       endif
 #endif
    

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
@@ -196,6 +196,8 @@
           if(.not.allocated(refl10cm_p)  ) allocate(refl10cm_p(ims:ime,kms:kme,jms:jme) )
           if(.not.allocated(refl10cm_1km_p)  ) allocate(refl10cm_1km_p(ims:ime,jms:jme) )
           if(.not.allocated(frainnc_p) ) allocate(frainnc_p(ims:ime,jms:jme) )
+          if(.not.allocated(max_hail_diameter_sfc_p) ) allocate(max_hail_diameter_sfc_p(ims:ime,jms:jme) )
+          if(.not.allocated(max_hail_diameter_column_p) ) allocate(max_hail_diameter_column_p(ims:ime,jms:jme) )
 
           ! Allocate TEMPO options based on config flags insead of adding more nested select cases
           ! These flags are associated with appropriate packages in mpas_atmphys_packages.F
@@ -347,6 +349,8 @@
           if(allocated(refl10cm_p)  ) deallocate(refl10cm_p  )
           if(allocated(refl10cm_1km_p)) deallocate(refl10cm_1km_p)
           if(allocated(frainnc_p) ) deallocate(frainnc_p)
+          if(allocated(max_hail_diameter_sfc_p) ) deallocate(max_hail_diameter_sfc_p)
+          if(allocated(max_hail_diameter_column_p) ) deallocate(max_hail_diameter_column_p)
 
           if (config_tempo_hailaware) then
              if(allocated(ng_p) ) deallocate(ng_p )
@@ -660,6 +664,8 @@
                      has_reqc  = has_reqc    , has_reqi   = has_reqi     , has_reqs   = has_reqs     , &
                      !! ntc       = ntc_p       , muc        = muc_p                                    , &
                      refl_10cm  = refl10cm_p , frainnc    = frainnc_p                                , &
+                     max_hail_diameter_sfc = max_hail_diameter_sfc_p                                 , &
+                     max_hail_diameter_column = max_hail_diameter_column_p                           , &
                      ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde           , &
                      ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme           , &
                      its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte             &
@@ -835,7 +841,12 @@
        call mpas_log_write('            since WSM6 or Thompson microphysics scheme was not selected')
     end if
  endif
- 
+
+ if(trim(microp_scheme) == "mp_tempo") then
+    call mpas_log_write('Computing accumulated max hail diameter at the surface')
+    call compute_accumulated_max_hail(diag_physics,its,ite)
+ endif
+
 !... copy updated precipitation from the wrf-physics grid back to the geodesic-dynamics grid:
  call precip_to_MPAS(configs,diag_physics,its,ite)
 
@@ -1365,6 +1376,36 @@ subroutine compute_hourly_max_radar_reflectivity(configs,diag_physics,its,ite)
  end select microp_select
 
  end subroutine compute_hourly_max_radar_reflectivity
+
+!=================================================================================================================
+ subroutine compute_accumulated_max_hail(diag_physics,its,ite)
+!=================================================================================================================
+
+!input arguments:
+ integer,intent(in):: its,ite
+
+!inout arguments:
+ type(mpas_pool_type),intent(inout):: diag_physics
+
+!local pointers:
+ real(kind=RKIND),dimension(:),pointer:: max_hail_diameter_sfc, max_hail_diameter_sfc_acc
+
+!local variables and arrays:
+ integer:: i,j
+
+!-----------------------------------------------------------------------------------------------------------------
+
+ call mpas_pool_get_array(diag_physics,'max_hail_diameter_sfc',max_hail_diameter_sfc)
+ call mpas_pool_get_array(diag_physics,'max_hail_diameter_sfc_acc',max_hail_diameter_sfc_acc)
+
+ do j = jts,jte ! Assuming here that jts == jte (2D arrays)
+    do i = its,ite
+       max_hail_diameter_sfc_acc(i) = max(max_hail_diameter_sfc_acc(i), max_hail_diameter_sfc_p(i,j))
+    enddo
+ enddo
+
+end subroutine compute_accumulated_max_hail
+
 !=================================================================================================================
  subroutine compute_relhum(diag,its,ite)
 !=================================================================================================================

--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -676,6 +676,7 @@
  real(kind=RKIND),dimension(:,:),pointer  :: ni,nr,nc,ns,ng,nh,nccn,nwfa,nifa
  real(kind=RKIND),dimension(:,:),pointer  :: volg,volh,zrw,zgw,zhw
  real(kind=RKIND),dimension(:,:),pointer  :: rainprod,evapprod,refl10cm
+ real(kind=RKIND),dimension(:),pointer  :: max_hail_diameter_sfc, max_hail_diameter_column
  real(kind=RKIND),dimension(:,:),pointer  :: re_cloud,re_ice,re_snow
  real(kind=RKIND),dimension(:,:),pointer  :: rthmpten,rqvmpten,rqcmpten,rqrmpten,rqimpten,rqsmpten,rqgmpten
  real(kind=RKIND),dimension(:,:),pointer  :: rncmpten,rnimpten,rnrmpten,rnifampten,rnwfampten
@@ -821,8 +822,16 @@
           case("mp_tempo")
              call mpas_pool_get_dimension(state,'index_ni',index_ni)
              call mpas_pool_get_dimension(state,'index_nr',index_nr)
+             call mpas_pool_get_array(diag_physics,'max_hail_diameter_sfc' ,max_hail_diameter_sfc)
+             call mpas_pool_get_array(diag_physics,'max_hail_diameter_column' ,max_hail_diameter_column)
              ni   => scalars(index_ni,:,:)
              nr   => scalars(index_nr,:,:)
+             do j = jts,jte
+             do i = its,ite
+                max_hail_diameter_sfc_p(i,j) = max_hail_diameter_sfc(i)
+                max_hail_diameter_column_p(i,j) = max_hail_diameter_column(i)
+             enddo
+             enddo
 
 !             call mpas_pool_get_array(diag_physics,'nt_c',nt_c)
 !             call mpas_pool_get_array(diag_physics,'mu_c',mu_c)
@@ -1134,6 +1143,7 @@
  real(kind=RKIND),dimension(:,:),pointer  :: ni,nr,nc,ns,ng,nh,nccn,nwfa,nifa
  real(kind=RKIND),dimension(:,:),pointer  :: volg,volh,zrw,zgw,zhw
  real(kind=RKIND),dimension(:,:),pointer  :: rainprod,evapprod,refl10cm
+ real(kind=RKIND),dimension(:),pointer  :: max_hail_diameter_sfc, max_hail_diameter_column
  real(kind=RKIND),dimension(:,:),pointer  :: re_cloud,re_ice,re_snow
  real(kind=RKIND),dimension(:,:),pointer  :: rthmpten,rqvmpten,rqcmpten,rqrmpten,rqimpten,rqsmpten,rqgmpten
  real(kind=RKIND),dimension(:,:),pointer  :: rncmpten,rnimpten,rnrmpten,rnifampten,rnwfampten
@@ -1323,6 +1333,15 @@
                 ni(k,i) = ni_p(i,k,j)
                 nr(k,i) = nr_p(i,k,j)
              enddo
+             enddo
+             enddo
+
+             call mpas_pool_get_array(diag_physics,'max_hail_diameter_sfc' ,max_hail_diameter_sfc)
+             call mpas_pool_get_array(diag_physics,'max_hail_diameter_column' ,max_hail_diameter_column)
+             do j = jts,jte
+             do i = its,ite
+                max_hail_diameter_sfc(i) = max_hail_diameter_sfc_p(i,j)
+                max_hail_diameter_column(i) = max_hail_diameter_column_p(i,j)
              enddo
              enddo
 

--- a/src/core_atmosphere/physics/mpas_atmphys_vars.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_vars.F
@@ -304,6 +304,8 @@
     refl10cm_cu_p      !
  real(kind=RKIND),dimension(:,:),allocatable:: &
     refl10cm_1km_p
+ real(kind=RKIND),dimension(:,:),allocatable:: &
+    max_hail_diameter_sfc_p, max_hail_diameter_column_p
 !=================================================================================================================
 !... variables and arrays related to parameterization of convection:
 !=================================================================================================================

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.2.2-3.0">
+<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.2.2-3.1">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->


### PR DESCRIPTION
Adds three 2D diagnostic fields:
max_hail_diameter_sfc: instantaneous maximum hail size at the surface
max_hail_diameter_sfc_acc: accumulated (over diagnostic output time) maximum hail size at the surface 
max_hail_diameter_sfc: instantaneous maximum hail size in the vertical column

Testing and relations to other Pull Requests should be added as subsequent comments.

See the below examples for more information.
https://github.com/MPAS-Dev/MPAS/pull/930
https://github.com/MPAS-Dev/MPAS/pull/931

Information on running mandatory regression tests on Jet can be found [here](https://github.com/barlage/mpas_testcase) and the results pasted below.

<details>
  <summary>
    regression test case results
  </summary>
  
```

     version_to_compare = v8.2.2-3.1
   gsl_version_baseline = v8.2.2-3.0
  ncar_version_baseline = v8.2.2
         test_directory = /scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/
 gsl_baseline_directory = /scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/
ncar_baseline_directory = /scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/
           compile_flag = -intdebug
         test_repo_name = gsl

######################################################################
# compare to previous GSL CONUS mesoscale_reference baselines A1GSL   
######################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.1-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.0-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.1-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.0-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.1-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.0-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

#############################################################################
# compare to previous GSL CONUS mesoscale_reference_noahmp baselines E1GSL   
#############################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.1-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.0-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.1-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.0-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.1-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.0-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

######################################################################
# compare to previous GSL CONUS hrrrv5 GFS baselines C5GSL            
######################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.1-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.0-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.1-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.0-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.1-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.0-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

######################################################################
# compare to previous GSL CONUS hrrrv5 RAP winter baselines C7GSL     
######################################################################

  === history.2024-02-02_18.00.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.1-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.00.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.0-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.00.00.nc" are identical.

  === history.2024-02-02_18.12.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.1-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.12.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.0-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.12.00.nc" are identical.

  === history.2024-02-02_19.00.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.1-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_19.00.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.0-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_19.00.00.nc" are identical.

######################################################################
# compare to previous GSL CONUS hrrrv5 RAP winter baselines C8GSL     
######################################################################

  === history.2024-08-15_18.00.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.1-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.00.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.0-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.00.00.nc" are identical.

  === history.2024-08-15_18.12.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.1-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.12.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.0-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.12.00.nc" are identical.

  === history.2024-08-15_19.00.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.1-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_19.00.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.0-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_19.00.00.nc" are identical.

########################################################################
# compare to previous NCAR CONUS mesoscale_reference baselines A1NCAR   
########################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.1-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.2.2-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.1-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.2.2-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/scratch2/BMC/wrfruc/jensen/git-local/use_for_tests/run_case/gsl-v8.2.2-3.1-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/scratch1/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.2.2-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

```
</details>
