### PR TITLE
changes to fix the convection permitting suite

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1754,7 +1754,7 @@
 
                         <var name="nr" array_group="number" units="nb kg^{-1}"
                              description="Rain number concentration"
-                             packages="mp_thompson_in;mp_nssl2m_in;mp_tempo_in"/>
+                             packages="mp_thompson_in;mp_thompson_aers_in;mp_nssl2m_in;mp_tempo_in"/>
                         
                         <var name="ns" array_group="number" units="nb kg^{-1}"
                              description="Snow number concentration"
@@ -2145,7 +2145,7 @@
 
                         <var name="tend_nr" name_in_code="nr" array_group="number" units="nb m^{-3} s^{-1}" 
                              description="Tendency of rain number concentration multiplied by dry air density divided by d(zeta)/dz"
-                             packages="mp_thompson_in;mp_nssl2m_in;mp_tempo_in"/>
+                             packages="mp_thompson_in;mp_thompson_aers_in;mp_nssl2m_in;mp_tempo_in"/>
 
                         <var name="tend_ns" name_in_code="ns" array_group="number" units="nb m^{-3} s^{-1}"
                              description="Tendency of snow number concentration multiplied by dry air density divided by d(zeta)/dz"

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -1,3 +1,4 @@
+
 ! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
 ! and the University Corporation for Atmospheric Research (UCAR).
 !
@@ -16,7 +17,6 @@
 
 module atm_time_integration
 
-   use mpas_derived_types
    use mpas_pool_routines
    use mpas_kind_types
    use mpas_constants
@@ -34,8 +34,8 @@ module atm_time_integration
 #endif
 
    use mpas_atm_boundaries, only : nSpecZone, nRelaxZone, nBdyZone, mpas_atm_get_bdy_state, mpas_atm_get_bdy_tend  ! regional_MPAS addition
-   
-   use mpas_atm_iau  
+
+   use mpas_atm_iau
 
    !
    ! Abstract interface for routine used to communicate halos of fields
@@ -59,10 +59,10 @@ module atm_time_integration
    real (kind=RKIND), dimension(:,:), pointer :: tend_ru_physics, tend_rtheta_physics, tend_rho_physics
    
    ! Used in compute_dyn_tend
-   real (kind=RKIND), allocatable, dimension(:,:) :: qtot 
+   real (kind=RKIND), allocatable, dimension(:,:) :: qtot
    real (kind=RKIND), allocatable, dimension(:,:) :: delsq_theta, delsq_w, delsq_divergence
    real (kind=RKIND), allocatable, dimension(:,:) :: delsq_u
-!   real (kind=RKIND), allocatable, dimension(:,:) :: delsq_circulation    ! no longer used -> removed 
+!   real (kind=RKIND), allocatable, dimension(:,:) :: delsq_circulation    ! no longer used -> removed
    real (kind=RKIND), allocatable, dimension(:,:) :: delsq_vorticity
    real (kind=RKIND), allocatable, dimension(:,:) :: dpdz
 
@@ -78,16 +78,16 @@ module atm_time_integration
    real (kind=RKIND), dimension(:,:), allocatable :: wdtn_arr
    real (kind=RKIND), dimension(:,:), allocatable :: rho_zz_int
 
-   real (kind=RKIND), dimension(:,:,:), allocatable :: scalars_driving ! regional_MPAS addition 
-   real (kind=RKIND), dimension(:,:), allocatable :: ru_driving_tend ! regional_MPAS addition 
-   real (kind=RKIND), dimension(:,:), allocatable :: rt_driving_tend ! regional_MPAS addition 
-   real (kind=RKIND), dimension(:,:), allocatable :: rho_driving_tend ! regional_MPAS addition 
-   real (kind=RKIND), dimension(:,:), allocatable :: ru_driving_values ! regional_MPAS addition 
-   real (kind=RKIND), dimension(:,:), allocatable :: rt_driving_values ! regional_MPAS addition 
-   real (kind=RKIND), dimension(:,:), allocatable :: rho_driving_values ! regional_MPAS addition 
+   real (kind=RKIND), dimension(:,:,:), allocatable :: scalars_driving ! regional_MPAS addition
+   real (kind=RKIND), dimension(:,:), allocatable :: ru_driving_tend ! regional_MPAS addition
+   real (kind=RKIND), dimension(:,:), allocatable :: rt_driving_tend ! regional_MPAS addition
+   real (kind=RKIND), dimension(:,:), allocatable :: rho_driving_tend ! regional_MPAS addition
+   real (kind=RKIND), dimension(:,:), allocatable :: ru_driving_values ! regional_MPAS addition
+   real (kind=RKIND), dimension(:,:), allocatable :: rt_driving_values ! regional_MPAS addition
+   real (kind=RKIND), dimension(:,:), allocatable :: rho_driving_values ! regional_MPAS addition
    integer, dimension(:), pointer :: bdyMaskEdge ! regional_MPAS addition
    logical, pointer :: config_apply_lbcs
-   
+
    ! Used in compute_solve_diagnostics
    real (kind=RKIND), allocatable, dimension(:,:) :: ke_vertex
    real (kind=RKIND), allocatable, dimension(:,:) :: ke_edge
@@ -104,7 +104,6 @@ module atm_time_integration
 
 
    contains
-
 
    !***********************************************************************
    !
@@ -387,11 +386,11 @@ module atm_time_integration
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
    ! Advance model state forward in time by the specified time step
    !
-   ! Input: domain - current model state in time level 1 (e.g., time_levs(1)state%h(:,:)) 
+   ! Input: domain - current model state in time level 1 (e.g., time_levs(1)state%h(:,:))
    !                 plus grid meta-data
-   ! Output: domain - upon exit, time level 2 (e.g., time_levs(2)%state%h(:,:)) contains 
+   ! Output: domain - upon exit, time level 2 (e.g., time_levs(2)%state%h(:,:)) contains
    !                  model state advanced forward in time by dt seconds
-   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
       implicit none
 
@@ -451,12 +450,12 @@ module atm_time_integration
    !
    ! Nonhydrostatic atmospheric solver
    !
-   ! Input: domain - current model state in time level 1 (e.g., time_levs(1)state%h(:,:)) 
+   ! Input: domain - current model state in time level 1 (e.g., time_levs(1)state%h(:,:))
    !                 plus grid meta-data and some diagnostics of state.
-   ! Output: domain - upon exit, time level 2 (e.g., time_levs(2)%state%h(:,:)) contains 
+   ! Output: domain - upon exit, time level 2 (e.g., time_levs(2)%state%h(:,:)) contains
    !                  model state advanced forward in time by dt seconds,
-   !                  and some diagnostics in diag 
-   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
+   !                  and some diagnostics in diag
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
       implicit none
 
@@ -499,8 +498,8 @@ module atm_time_integration
       character (len=StrKIND), pointer :: config_convection_scheme
 
       integer, pointer :: num_scalars, index_qv, nCells, nCellsSolve, nEdges, nEdgesSolve, nVertices, nVerticesSolve, nVertLevels
-      integer, pointer :: index_qc, index_qr, index_qi, index_qs, index_qg, index_nr, index_ni, index_nc, index_nifa, index_nwfa
-      integer, pointer :: index_qh, index_ns, index_ng, index_nh, index_nccn
+      integer, pointer :: index_qc, index_qr, index_qi, index_qs, index_qg, index_qh, index_nwfa, index_nifa
+      integer, pointer :: index_nc, index_nr, index_ni, index_ns, index_ng, index_nh, index_nccn
       integer, pointer :: index_volg, index_volh, index_zrw, index_zgw, index_zhw
 
       character(len=StrKIND), pointer :: config_IAU_option
@@ -602,13 +601,13 @@ module atm_time_integration
          call mpas_pool_get_dimension(state, 'index_qr', index_qr)
          call mpas_pool_get_dimension(state, 'index_qi', index_qi)
          call mpas_pool_get_dimension(state, 'index_qs', index_qs)
-         call mpas_pool_get_dimension(state, 'index_qg', index_qg)  
-         call mpas_pool_get_dimension(state, 'index_qh', index_qh)
+         call mpas_pool_get_dimension(state, 'index_qg', index_qg)
+         call mpas_pool_get_dimension(state, 'index_qh', index_qh) 
+         call mpas_pool_get_dimension(state, 'index_nc', index_nc)  
          call mpas_pool_get_dimension(state, 'index_nr', index_nr)
          call mpas_pool_get_dimension(state, 'index_ni', index_ni)
-         call mpas_pool_get_dimension(state, 'index_nc', index_nc)
-         call mpas_pool_get_dimension(state, 'index_nifa', index_nifa)
          call mpas_pool_get_dimension(state, 'index_nwfa', index_nwfa)
+         call mpas_pool_get_dimension(state, 'index_nifa', index_nifa)
          call mpas_pool_get_dimension(state, 'index_ns', index_ns)
          call mpas_pool_get_dimension(state, 'index_ng', index_ng)
          call mpas_pool_get_dimension(state, 'index_nh', index_nh)
@@ -778,9 +777,9 @@ module atm_time_integration
          call exchange_halo_group(domain, 'dynamics:exner')
 
 
-         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
-         ! BEGIN Runge-Kutta loop 
-         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
+         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+         ! BEGIN Runge-Kutta loop
+         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
          RK3_DYNAMICS : do rk_step = 1, 3  ! Runge-Kutta loop
 
@@ -863,7 +862,7 @@ module atm_time_integration
 !$OMP END PARALLEL DO
             call mpas_timer_stop('small_step_prep')
 
-          
+
 !------------------------------------------------------------------------------------------------------------------------
 
             if (config_apply_lbcs) then  ! adjust boundary tendencies for regional_MPAS dry dynamics in the specified zone
@@ -944,7 +943,7 @@ module atm_time_integration
 
                call mpas_timer_stop('atm_advance_acoustic_step')
 
-  
+
 ! rtheta_pp
 ! This is the only communications needed during the acoustic steps because we solve for u on all edges of owned cells
 
@@ -1026,7 +1025,7 @@ module atm_time_integration
             end if  ! regional_MPAS addition
 
 !-------------------------------------------------------------------
-            
+
             ! u
             if (config_apply_lbcs) then
                call exchange_halo_group(domain, 'dynamics:u_123')
@@ -1034,7 +1033,7 @@ module atm_time_integration
                call exchange_halo_group(domain, 'dynamics:u_3')
             end if
 
-            ! scalar advection: RK3 scheme of Skamarock and Gassmann (2011). 
+            ! scalar advection: RK3 scheme of Skamarock and Gassmann (2011).
             ! PD or monotonicity constraints applied only on the final Runge-Kutta substep.
 
             if (config_scalar_advection .and. (.not. config_split_dynamics_transport) ) then
@@ -1071,20 +1070,20 @@ module atm_time_integration
                   if (index_qh > 0) then
                      scalars_driving(index_qh,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qh', rk_timestep(rk_step) )
                   end if
+                  if (index_nc > 0) then
+                     scalars_driving(index_nc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nc', rk_timestep(rk_step) )
+                  end if
                   if (index_nr > 0) then
                      scalars_driving(index_nr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nr', rk_timestep(rk_step) )
                   end if
                   if (index_ni > 0) then
                      scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
                   end if
-                  if (index_nc > 0) then
-                     scalars_driving(index_nc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nc', rk_timestep(rk_step) )
+                  if (index_nwfa > 0) then
+                     scalars_driving(index_nwfa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nwfa', rk_timestep(rk_step) )
                   end if
                   if (index_nifa > 0) then
                      scalars_driving(index_nifa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nifa', rk_timestep(rk_step) )
-                  end if
-                  if (index_nwfa > 0) then
-                     scalars_driving(index_nwfa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nwfa', rk_timestep(rk_step) )
                   end if
                   if (index_ns > 0) then
                      scalars_driving(index_ns,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ns', rk_timestep(rk_step) )
@@ -1163,7 +1162,7 @@ module atm_time_integration
             end if
 
             ! set the zero-gradient condition on w for regional_MPAS
-            
+
             if ( config_apply_lbcs ) then  ! regional_MPAS addition
 
 !$OMP PARALLEL DO
@@ -1176,7 +1175,7 @@ module atm_time_integration
               ! w halo values needs resetting after regional boundary update
               call exchange_halo_group(domain, 'dynamics:w')
 
-            end if ! end of regional_MPAS addition 
+            end if ! end of regional_MPAS addition
 
          end do RK3_DYNAMICS
 
@@ -1277,20 +1276,20 @@ module atm_time_integration
                if (index_qh > 0) then
                   scalars_driving(index_qh,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qh', rk_timestep(rk_step) )
                end if
+               if (index_nc > 0) then
+                  scalars_driving(index_nc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nc', rk_timestep(rk_step) )
+               end if
                if (index_nr > 0) then
                   scalars_driving(index_nr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nr', rk_timestep(rk_step) )
                end if
                if (index_ni > 0) then
                   scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
                end if
-               if (index_nc > 0) then
-                  scalars_driving(index_nc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nc', rk_timestep(rk_step) )
+               if (index_nwfa > 0) then
+                  scalars_driving(index_nwfa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nwfa', rk_timestep(rk_step) )
                end if
                if (index_nifa > 0) then
                   scalars_driving(index_nifa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nifa', rk_timestep(rk_step) )
-               end if
-               if (index_nwfa > 0) then
-                  scalars_driving(index_nwfa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nwfa', rk_timestep(rk_step) )
                end if
                if (index_ns > 0) then
                   scalars_driving(index_ns,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ns', rk_timestep(rk_step) )
@@ -1476,20 +1475,20 @@ module atm_time_integration
          if (index_qh > 0) then
             scalars_driving(index_qh,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qh', dt)
          end if
+         if (index_nc > 0) then
+            scalars_driving(index_nc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nc', dt)
+         end if
          if (index_nr > 0) then
             scalars_driving(index_nr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nr', dt )
          end if
          if (index_ni > 0) then
             scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', dt )
          end if
-         if (index_nc > 0) then
-            scalars_driving(index_nc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nc', dt )
+         if (index_nwfa > 0) then
+            scalars_driving(index_nwfa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nwfa', dt )
          end if
          if (index_nifa > 0) then
             scalars_driving(index_nifa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nifa', dt )
-         end if
-         if (index_nwfa > 0) then
-            scalars_driving(index_nwfa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nwfa', dt )
          end if
          if (index_ns > 0) then
             scalars_driving(index_ns,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ns', dt)
@@ -1774,7 +1773,7 @@ module atm_time_integration
                                    cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
                                    cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd)
 
-      ! the moist coefficients cqu and cqw serve to transform the inverse dry density (1/rho_d) 
+      ! the moist coefficients cqu and cqw serve to transform the inverse dry density (1/rho_d)
       ! into the inverse full (moist) density (1/rho_m).
 
       implicit none
@@ -1815,7 +1814,7 @@ module atm_time_integration
                qtot(k,iCell) = qtot(k,iCell) + scalars(iq, k, iCell)
             end do
          end do
-      end do    
+      end do
 
 !      do iCell = cellSolveStart,cellSolveEnd
       do iCell = cellStart,cellEnd
@@ -1927,7 +1926,7 @@ module atm_time_integration
                                    cellSolveStart, cellSolveEnd, edgeSolveStart, edgeSolveEnd)
 
       use mpas_atm_dimensions
- 
+
       implicit none
 
 
@@ -2047,8 +2046,8 @@ module atm_time_integration
                                    cellSolveStart, cellSolveEnd, edgeSolveStart, edgeSolveEnd)
 
       ! following Klemp et al MWR 2007, we use preturbation variables
-      ! in the acoustic-step integration.  This routine computes those 
-      ! perturbation variables.  state variables are reconstituted after 
+      ! in the acoustic-step integration.  This routine computes those
+      ! perturbation variables.  state variables are reconstituted after
       ! the acousstic steps in subroutine atm_recover_large_step_variables
 
 
@@ -2225,7 +2224,7 @@ module atm_time_integration
                                    cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd)
 
       !  This subroutine performs the entire acoustic step update, following Klemp et al MWR 2007,
-      !  using forward-backward vertically implicit integration.  
+      !  using forward-backward vertically implicit integration.
       !  The gravity-waves are included in the acoustic-step integration.
       !  The input state variables that are updated are ru_p, rw_p (note that this is (rho*omega)_p here),
       !  rtheta_p, and rho_pp.  The time averaged mass flux is accumulated in ruAvg and wwAvg
@@ -2340,7 +2339,7 @@ module atm_time_integration
       call mpas_pool_get_array(diag, 'rw_save', rw_save)
 
       ! epssm is the offcentering coefficient for the vertically implicit integration.
-      call mpas_pool_get_config(configs, 'config_epssm', epssm) 
+      call mpas_pool_get_config(configs, 'config_epssm', epssm)
 
       call atm_advance_acoustic_step_work(nCells, nEdges, nCellsSolve, cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
                                    cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd, &
@@ -2428,13 +2427,13 @@ module atm_time_integration
 
       real (kind=RKIND), dimension(nCells+1) :: specZoneMaskCell
       real (kind=RKIND), dimension(nEdges+1) :: specZoneMaskEdge
-      
+
 
       integer, intent(in) :: small_step
       real (kind=RKIND), intent(in) :: dts, epssm,cf1, cf2, cf3
       real (kind=RKIND), dimension(nVertLevels) :: ts, rs
 
-  
+
       !
       ! Local variables
       !
@@ -2448,20 +2447,20 @@ module atm_time_integration
       resm = (1.0 - epssm) / (1.0 + epssm)
       rdts = 1./dts
 
-      if(small_step /= 1) then  !  not needed on first small step 
+      if(small_step /= 1) then  !  not needed on first small step
 
         ! forward-backward acoustic step integration.
-        ! begin by updating the horizontal velocity u, 
+        ! begin by updating the horizontal velocity u,
         ! and accumulating the contribution from the updated u to the other tendencies.
 
         ! we are looping over all edges, but only computing on edges of owned cells. This will include updates of
         ! all owned edges plus some edges that are owned by other blocks.  We perform these redundant computations
-        ! so that we do not have to communicate updates of u to update the cell variables (rho, w, and theta). 
+        ! so that we do not have to communicate updates of u to update the cell variables (rho, w, and theta).
 
         !MGD this loop will not be very load balanced with if-test below
 
         do iEdge=edgeStart,edgeEnd ! MGD do we really just need edges touching owned cells?
- 
+
            cell1 = cellsOnEdge(1,iEdge)
            cell2 = cellsOnEdge(2,iEdge)
 
@@ -2502,7 +2501,7 @@ module atm_time_integration
               end do
 !DIR$ IVDEP
               do k=1,nVertLevels
-                 ruAvg(k,iEdge) = ru_p(k,iEdge)                 
+                 ruAvg(k,iEdge) = ru_p(k,iEdge)
               end do
 
            end if ! end test for block-owned cells
@@ -2526,18 +2525,18 @@ module atm_time_integration
       do iCell=cellSolveStart,cellSolveEnd  ! loop over all owned cells to solve
 
          if(small_step == 1) then  ! initialize here on first small timestep.
-            wwAvg(1:nVertLevels+1,iCell) = 0.0            
-            rho_pp(1:nVertLevels,iCell) = 0.0            
-            rtheta_pp(1:nVertLevels,iCell) = 0.0            
+            wwAvg(1:nVertLevels+1,iCell) = 0.0
+            rho_pp(1:nVertLevels,iCell) = 0.0
+            rtheta_pp(1:nVertLevels,iCell) = 0.0
             rw_p(:,iCell) = 0.0
          end if
-            
+
          if(specZoneMaskCell(iCell) == 0.0) then  ! not specified zone, compute...
 
          ts(:) = 0.0
          rs(:) = 0.0
 
-         do i=1,nEdgesOnCell(iCell) 
+         do i=1,nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i,iCell)
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
@@ -2556,7 +2555,7 @@ module atm_time_integration
 !DIR$ IVDEP
          do k=1, nVertLevels
             rs(k) = rho_pp(k,iCell) + dts*tend_rho(k,iCell) + rs(k)                  &
-                            - cofrz(k)*resm*(rw_p(k+1,iCell)-rw_p(k,iCell)) 
+                            - cofrz(k)*resm*(rw_p(k+1,iCell)-rw_p(k,iCell))
             ts(k) = rtheta_pp(k,iCell) + dts*tend_rt(k,iCell) + ts(k)                &
                                - resm*rdzw(k)*( coftz(k+1,iCell)*rw_p(k+1,iCell)     &
                                                -coftz(k,iCell)*rw_p(k,iCell))
@@ -2589,10 +2588,10 @@ module atm_time_integration
 
 !MGD VECTOR DEPENDENCE
          do k=nVertLevels,1,-1
-            rw_p(k,iCell) = rw_p(k,iCell) - gamma_tri(k,iCell)*rw_p(k+1,iCell)     
+            rw_p(k,iCell) = rw_p(k,iCell) - gamma_tri(k,iCell)*rw_p(k+1,iCell)
          end do
 
-         ! the implicit Rayleigh damping on w (gravity-wave absorbing) 
+         ! the implicit Rayleigh damping on w (gravity-wave absorbing)
 
 !DIR$ IVDEP
          do k=2,nVertLevels
@@ -2670,7 +2669,7 @@ module atm_time_integration
       call mpas_pool_get_dimension(mesh, 'nCellsSolve', nCellsSolve)
       call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
 
-      call mpas_pool_get_config(configs, 'config_smdiv', smdiv) 
+      call mpas_pool_get_config(configs, 'config_smdiv', smdiv)
       call mpas_pool_get_config(configs, 'config_len_disp', config_len_disp)
 
       rdts = 1.0_RKIND / dts
@@ -2710,7 +2709,7 @@ module atm_time_integration
                                        cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
                                        cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd)
 
-      ! reconstitute state variables from acoustic-step perturbation variables 
+      ! reconstitute state variables from acoustic-step perturbation variables
       ! after the acoustic steps.  The perturbation variables were originally set in
       ! subroutine atm_set_smlstep_pert_variables prior to their acoustic-steps update.
       ! we are also computing a few other state-derived variables here.
@@ -2840,7 +2839,7 @@ module atm_time_integration
       real (kind=RKIND), intent(in) :: dt
 
       integer, dimension(nCells+1), intent(in) :: bdyMaskCell
-      
+
       real (kind=RKIND), dimension(nVertLevels+1,nCells+1) :: wwAvg
       real (kind=RKIND), dimension(nVertLevels+1,nCells+1) :: rw_save
       real (kind=RKIND), dimension(nVertLevels+1,nCells+1) :: w
@@ -2895,7 +2894,7 @@ module atm_time_integration
       rcv = rgas/(cp-rgas)
       p0 = 1.0e+05  ! this should come from somewhere else...
 
-      ! Avoid FP errors caused by a potential division by zero below by 
+      ! Avoid FP errors caused by a potential division by zero below by
       ! initializing the "garbage cell" of rho_zz to a non-zero value
       do k=1,nVertLevels
          rho_zz(k,nCells+1) = 1.0
@@ -2924,7 +2923,7 @@ module atm_time_integration
 
           ! pick up part of diagnosed w from omega - divide by density later
             w(k,iCell) = rw(k,iCell)/(fzm(k)*zz(k,iCell)+fzp(k)*zz(k-1,iCell))
-                                      
+
          end do
 
          w(nVertLevels+1,iCell) = 0.0
@@ -2950,8 +2949,8 @@ module atm_time_integration
 
       end do
 
-      ! recover time-averaged ruAvg on all edges of owned cells (for upcoming scalar transport).  
-      ! we solved for these in the acoustic-step loop.  
+      ! recover time-averaged ruAvg on all edges of owned cells (for upcoming scalar transport).
+      ! we solved for these in the acoustic-step loop.
       ! we will compute ru and u here also, given we are here, even though we only need them on nEdgesSolve
 
 !$OMP BARRIER
@@ -3010,7 +3009,6 @@ module atm_time_integration
    end subroutine atm_recover_large_step_variables_work
 
 
-   !-----------------------------------------------------------------------
    !  routine atm_advance_scalars
    !
    !> \brief Integrate scalar equations - explicit transport plus other tendencies
@@ -3682,7 +3680,7 @@ module atm_time_integration
       end if
 
       !  for positive-definite or monotonic option, we first update scalars using the tendency from sources other than
-      !  the resolved transport (these should constitute a positive definite update).  
+      !  the resolved transport (these should constitute a positive definite update).
       !  Note, however, that we enforce positive-definiteness in this update.
       !  The transport will maintain this positive definite solution and optionally, shape preservation (monotonicity).
 
@@ -3770,7 +3768,7 @@ module atm_time_integration
                   rho_zz_int(k,iCell) = rho_zz_int(k,iCell) - edgesOnCell_sign(i,iCell) &
                                                             * uhAvg(k,iEdge) * dvEdge(iEdge) * invAreaCell(iCell)
                end do
-               
+
             end do
          end do
 
@@ -3878,7 +3876,7 @@ module atm_time_integration
                s_max(k,iCell) = max(scalar_old(k-1,iCell),scalar_old(k,iCell),scalar_old(k+1,iCell))
                s_min(k,iCell) = min(scalar_old(k-1,iCell),scalar_old(k,iCell),scalar_old(k+1,iCell))
             end do
- 
+
             k = nVertLevels
             wdtn(k,iCell) = wwAvg(k,iCell)*(fnm(k)*scalar_new(k,iCell)+fnp(k)*scalar_new(k-1,iCell))
             s_max(k,iCell) = max(scalar_old(k,iCell),scalar_old(k-1,iCell))
@@ -3940,7 +3938,7 @@ module atm_time_integration
             cell2 = cellsOnEdge(2,iEdge)
 
             if (cell1 <= nCellsSolve .or. cell2 <= nCellsSolve) then  ! only for owned cells
-  
+
                ! special treatment of calculations involving edges between hexagonal cells
                ! original code retained in select "default" case
                ! be sure to see additional declarations near top of subroutine
@@ -4027,7 +4025,7 @@ module atm_time_integration
             end do
 
             !
-            ! scale_arr(SCALE_IN,:,:) and scale_arr(SCALE_OUT:,:) are used here to store the incoming and outgoing perturbation flux 
+            ! scale_arr(SCALE_IN,:,:) and scale_arr(SCALE_OUT:,:) are used here to store the incoming and outgoing perturbation flux
             ! contributions to the update:  first the vertical flux component, then the horizontal
             !
 
@@ -4083,7 +4081,7 @@ module atm_time_integration
                !$acc loop vector
                do k=1, nVertLevels
                   scalar_new(k,iCell) = scalar_new(k,iCell) - edgesOnCell_sign(i,iCell) * flux_upwind_tmp(k,iEdge) * invAreaCell(iCell)
- 
+
                   scale_arr(k,SCALE_OUT,iCell) = scale_arr(k,SCALE_OUT,iCell) &
                                                  - max(0.0_RKIND,edgesOnCell_sign(i,iCell)*flux_tmp(k,iEdge)) * invAreaCell(iCell)
                   scale_arr(k,SCALE_IN, iCell) = scale_arr(k,SCALE_IN, iCell) &
@@ -4319,7 +4317,7 @@ module atm_time_integration
    subroutine atm_compute_dyn_tend(tend, tend_physics, state, diag, mesh, configs, nVertLevels, rk_step, dt, &
                                    cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
                                    cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd)
-   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    ! Compute height and normal wind tendencies, as well as diagnostic variables
    !
    ! Input: state - current model state
@@ -4329,8 +4327,8 @@ module atm_time_integration
    ! Output: tend - tendencies: tend_u, tend_w, tend_theta and tend_rho
    !                these are all coupled-variable tendencies.
    !         various other quantities in diag: Smagorinsky eddy viscosity
-   !                
-   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
+   !
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
       implicit none
 
@@ -4359,7 +4357,7 @@ module atm_time_integration
                                                    meshScalingDel2, meshScalingDel4
       real (kind=RKIND), dimension(:,:), pointer :: weightsOnEdge, zgrid, rho_edge, rho_zz, ru, u, v, tend_u, &
                                                     divergence, vorticity, ke, pv_edge, theta_m, rw, tend_rho, &
-                                                    rt_diabatic_tend, tend_theta, tend_w, w, cqw, rb, rr, pp, pressure_b, zz, zxu, cqu, & 
+                                                    rt_diabatic_tend, tend_theta, tend_w, w, cqw, rb, rr, pp, pressure_b, zz, zxu, cqu, &
                                                     h_divergence, kdiff, edgesOnCell_sign, edgesOnVertex_sign, rw_save, ru_save
 
       real (kind=RKIND), dimension(:,:), pointer :: theta_m_save
@@ -4384,7 +4382,7 @@ module atm_time_integration
       real (kind=RKIND), dimension(:,:), pointer :: adv_coefs, adv_coefs_3rd
 
       real (kind=RKIND), dimension(:), pointer :: rdzu, rdzw, fzm, fzp, qv_init
-      real (kind=RKIND), dimension(:,:), pointer :: t_init 
+      real (kind=RKIND), dimension(:,:), pointer :: t_init
 
       real (kind=RKIND), pointer :: cf1, cf2, cf3
 
@@ -4542,7 +4540,7 @@ module atm_time_integration
          fEdge, dvEdge, dcEdge, invDcEdge, invDvEdge, invAreaCell, invAreaTriangle, meshScalingDel2, meshScalingDel4, &
          weightsOnEdge, zgrid, rho_edge, rho_zz, ru, u, v, tend_u, &
          divergence, vorticity, ke, pv_edge, theta_m, rw, tend_rho, &
-         rt_diabatic_tend, tend_theta, tend_w, w, cqw, rb, rr, pp, pressure_b, zz, zxu, cqu, & 
+         rt_diabatic_tend, tend_theta, tend_w, w, cqw, rb, rr, pp, pressure_b, zz, zxu, cqu, &
          h_divergence, kdiff, edgesOnCell_sign, edgesOnVertex_sign, rw_save, ru_save, &
          theta_m_save, exner, rr_save, scalars, tend_u_euler, tend_w_euler, tend_theta_euler, deriv_two, &
          cellsOnEdge, verticesOnEdge, edgesOnCell, edgesOnEdge, cellsOnCell, edgesOnVertex, nEdgesOnCell, nEdgesOnEdge, &
@@ -4566,7 +4564,7 @@ module atm_time_integration
       fEdge, dvEdge, dcEdge, invDcEdge, invDvEdge, invAreaCell, invAreaTriangle, meshScalingDel2, meshScalingDel4, &
       weightsOnEdge, zgrid, rho_edge, rho_zz, ru, u, v, tend_u, &
       divergence, vorticity, ke, pv_edge, theta_m, rw, tend_rho, &
-      rt_diabatic_tend, tend_theta, tend_w, w, cqw, rb, rr, pp, pressure_b, zz, zxu, cqu, & 
+      rt_diabatic_tend, tend_theta, tend_w, w, cqw, rb, rr, pp, pressure_b, zz, zxu, cqu, &
       h_divergence, kdiff, edgesOnCell_sign, edgesOnVertex_sign, rw_save, ru_save, &
       theta_m_save, exner, rr_save, scalars, tend_u_euler, tend_w_euler, tend_theta_euler, deriv_two, &
       cellsOnEdge, verticesOnEdge, edgesOnCell, edgesOnEdge, cellsOnCell, edgesOnVertex, nEdgesOnCell, nEdgesOnEdge, &
@@ -4669,7 +4667,7 @@ module atm_time_integration
       real (kind=RKIND), dimension(nVertLevels) :: fzm
       real (kind=RKIND), dimension(nVertLevels) :: fzp
       real (kind=RKIND), dimension(nVertLevels) :: qv_init
-      real (kind=RKIND), dimension(nVertLevels,nCells+1) :: t_init 
+      real (kind=RKIND), dimension(nVertLevels,nCells+1) :: t_init
 
       real (kind=RKIND) :: cf1, cf2, cf3
       real (kind=RKIND) :: prandtl_inv, r_areaCell, rgas_cprcv
@@ -4713,6 +4711,7 @@ module atm_time_integration
       ! Local variables
       !
       integer :: iEdge, iCell, iVertex, k, cell1, cell2, vertex1, vertex2, eoe, i, j, iq, iAdvCell
+      integer :: kk
 
       !real (kind=RKIND), parameter :: c_s = 0.125
       real (kind=RKIND), dimension( nVertLevels+1 ) :: d_diag, d_off_diag, flux_arr
@@ -4770,7 +4769,7 @@ module atm_time_integration
                end do
 !DIR$ IVDEP
                do k=1, nVertLevels
-                  ! here is the Smagorinsky formulation, 
+                  ! here is the Smagorinsky formulation,
                   ! followed by imposition of an upper bound on the eddy viscosity
                   kdiff(k,iCell) = min((c_s * config_len_disp)**2 * sqrt(d_diag(k)**2 + d_off_diag(k)**2),(0.01*config_len_disp**2) * invDt)
                end do
@@ -4802,7 +4801,7 @@ module atm_time_integration
             end do
 
          end if
-            
+
       end if
 
       ! tendency for density.
@@ -4829,7 +4828,7 @@ module atm_time_integration
          do k = 1,nVertLevels
             h_divergence(k,iCell) = h_divergence(k,iCell) * r
          end do
-      end do    
+      end do
 
       !
       ! dp / dz and tend_rho
@@ -4860,7 +4859,7 @@ module atm_time_integration
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
 
-         ! horizontal pressure gradient 
+         ! horizontal pressure gradient
 
          if(rk_step == 1) then
 !DIR$ IVDEP
@@ -4910,12 +4909,12 @@ module atm_time_integration
             ! of the horizontal momentum equation
             tend_u(k,iEdge) = tend_u(k,iEdge) + rho_edge(k,iEdge)* (q(k) - (ke(k,cell2) - ke(k,cell1))       &
                                                                  * invDcEdge(iEdge))                            &
-                                             - u(k,iEdge)*0.5*(h_divergence(k,cell1)+h_divergence(k,cell2)) 
+                                             - u(k,iEdge)*0.5*(h_divergence(k,cell1)+h_divergence(k,cell2))
 #ifdef CURVATURE
             ! curvature terms for the sphere
             tend_u(k,iEdge) = tend_u(k,iEdge) &
                              - 2.*omega*cos(angleEdge(iEdge))*cos(latEdge(iEdge))  &
-                               *rho_edge(k,iEdge)*.25*(w(k,cell1)+w(k+1,cell1)+w(k,cell2)+w(k+1,cell2))          & 
+                               *rho_edge(k,iEdge)*.25*(w(k,cell1)+w(k+1,cell1)+w(k,cell2)+w(k+1,cell2))          &
                              - u(k,iEdge)*.25*(w(k+1,cell1)+w(k,cell1)+w(k,cell2)+w(k+1,cell2))                  &
                                *rho_edge(k,iEdge) * inv_r_earth
 #endif
@@ -4959,7 +4958,7 @@ module atm_time_integration
 
                kdiffu = 0.5*(kdiff(k,cell1)+kdiff(k,cell2))
 
-               ! include 2nd-orer diffusion here 
+               ! include 2nd-orer diffusion here
                tend_u_euler(k,iEdge) = tend_u_euler(k,iEdge) &
                                        + rho_edge(k,iEdge)* kdiffu * u_diffusion * meshScalingDel2(iEdge)
 
@@ -4995,7 +4994,7 @@ module atm_time_integration
 
 
 
-         
+
 !$OMP BARRIER
 
             do iEdge=edgeSolveStart,edgeSolveEnd
@@ -5014,18 +5013,18 @@ module atm_time_integration
                   ! Compute diffusion, computed as \nabla divergence - k \times \nabla vorticity
                   !                    only valid for h_mom_eddy_visc4 == constant
                   !
-                  ! Here, we scale the diffusion on the divergence part a factor of config_del4u_div_factor 
+                  ! Here, we scale the diffusion on the divergence part a factor of config_del4u_div_factor
                   !    relative to the rotational part.  The stability constraint on the divergence component is much less
                   !    stringent than the rotational part, and this flexibility may be useful.
                   !
                   u_diffusion =  rho_edge(k,iEdge) *  ( ( delsq_divergence(k,cell2)  - delsq_divergence(k,cell1) ) * r_dc  &
                                                        -( delsq_vorticity(k,vertex2) - delsq_vorticity(k,vertex1) ) * r_dv )
                   tend_u_euler(k,iEdge) = tend_u_euler(k,iEdge) - u_diffusion
-                  
+
                end do
             end do
-         
-         end if ! 4th order mixing is active 
+
+         end if ! 4th order mixing is active
 
       !
       !  vertical mixing for u - 2nd order filter in physical (z) space
@@ -5229,19 +5228,19 @@ module atm_time_integration
                   do k=2,nVertLevels
                      tend_w_euler(k,iCell) = tend_w_euler(k,iCell) - edge_sign * (delsq_w(k,cell2) - delsq_w(k,cell1))
                   end do
-           
+
                end do
             end do
 
-         end if ! 4th order mixing is active 
+         end if ! 4th order mixing is active
 
       end if ! horizontal mixing for w computed in first rk_step
 
 ! Note for OpenMP parallelization: We could avoid allocating the delsq_w scratch
 !   array, and just use the delsq_theta array as was previously done; however,
 !   particularly when oversubscribing cores with threads, there is the risk that
-!   some threads may reach code further below that re-uses the delsq_theta array, 
-!   in which case we would need a barrier somewhere between here and that code 
+!   some threads may reach code further below that re-uses the delsq_theta array,
+!   in which case we would need a barrier somewhere between here and that code
 !   below to ensure correct behavior.
 
       !
@@ -5339,7 +5338,7 @@ module atm_time_integration
 
       if(rk_step > 1) then
         do iCell=cellSolveStart,cellSolveEnd
-          do i=1,nEdgesOnCell(iCell) 
+          do i=1,nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i,iCell)
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
@@ -5385,7 +5384,7 @@ module atm_time_integration
           end do
 
 !$OMP BARRIER
-            
+
          if (h_theta_eddy_visc4 > 0.0) then  ! 4th order mixing is active
 
             do iCell=cellSolveStart,cellSolveEnd    ! Technically updating fewer cells than before...
@@ -5404,7 +5403,7 @@ module atm_time_integration
                end do
             end do
 
-         end if ! 4th order mixing is active 
+         end if ! 4th order mixing is active
 
       end if ! theta mixing calculated first rk_step
 
@@ -5417,7 +5416,7 @@ module atm_time_integration
          wdtz(1) = 0.0
 
          k = 2
-         wdtz(k) =  rw(k,icell)*(fzm(k)*theta_m(k,iCell)+fzp(k)*theta_m(k-1,iCell))  
+         wdtz(k) =  rw(k,icell)*(fzm(k)*theta_m(k,iCell)+fzp(k)*theta_m(k-1,iCell))
          wdtz(k) =  wdtz(k)+(rw_save(k,icell)-rw(k,icell))*(fzm(k)*theta_m_save(k,iCell)+fzp(k)*theta_m_save(k-1,iCell))
          do k=3,nVertLevels-1
             wdtz(k) = flux3( theta_m(k-2,iCell),theta_m(k-1,iCell),theta_m(k,iCell),theta_m(k+1,iCell), rw(k,iCell), coef_3rd_order )
@@ -5437,7 +5436,7 @@ module atm_time_integration
       end do
 
       !
-      !  vertical mixing for theta - 2nd order 
+      !  vertical mixing for theta - 2nd order
       !
 
       if (rk_step == 1) then
@@ -5502,13 +5501,13 @@ module atm_time_integration
    subroutine atm_compute_solve_diagnostics(dt, state, time_lev, diag, mesh, configs, &
                                             cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
                                             rk_step )
-   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    ! Compute diagnostic fields used in the tendency computations
    !
    ! Input: state (s), grid - grid metadata
    !
    ! Output: diag - computed diagnostics
-   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
       implicit none
 
@@ -5755,7 +5754,7 @@ module atm_time_integration
          ! Replace 2.0 with 2 in exponentiation to avoid outside chance that
          ! compiler will actually allow "float raised to float" operation
          do iVertex=vertexStart,vertexEnd
-            r = 0.25 * invAreaTriangle(iVertex) 
+            r = 0.25 * invAreaTriangle(iVertex)
             do k=1,nVertLevels
 
 !               ke_vertex(k,iVertex) = (  dcEdge(EdgesOnVertex(1,iVertex))*dvEdge(EdgesOnVertex(1,iVertex))*u(k,EdgesOnVertex(1,iVertex))**2  &
@@ -5828,7 +5827,7 @@ module atm_time_integration
 !DIR$ IVDEP
          do k=1,nVertLevels
 !
-! the following commented code is for the PV conserving shallow water solver.  
+! the following commented code is for the PV conserving shallow water solver.
 !            h_vertex = 0.0
 !            do i=1,vertexDegree
 !               h_vertex = h_vertex + h(k,cellsOnVertex(i,iVertex)) * kiteAreasOnVertex(i,iVertex)
@@ -5875,7 +5874,7 @@ module atm_time_integration
 !$OMP BARRIER
 
          !
-         ! Modify PV edge with upstream bias. 
+         ! Modify PV edge with upstream bias.
          !
          ! Compute gradient of PV in the tangent direction
          !   ( this computes gradPVt at all edges bounding real cells )
@@ -5910,7 +5909,7 @@ module atm_time_integration
                                        cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd)
 
       implicit none
-   
+
       type (mpas_pool_type), intent(inout) :: state
       integer, intent(in) :: time_lev                    ! which time level to use from state
       type (mpas_pool_type), intent(inout) :: diag
@@ -6020,7 +6019,7 @@ module atm_time_integration
                           * (fzp(k) * zz(k-1,iCell) + fzm(k) * zz(k,iCell))
          end do
       end do
-  
+
       ! next, the piece that depends on ru
       do iCell=cellStart,cellEnd
          do i=1,nEdgesOnCell(iCell)
@@ -6092,7 +6091,7 @@ module atm_time_integration
       integer, intent(in) :: cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd
 
       real (kind=RKIND) :: inv_dynamics_split
-      
+
       real (kind=RKIND), dimension(:,:), pointer :: ru
       real (kind=RKIND), dimension(:,:), pointer :: ru_save
       real (kind=RKIND), dimension(:,:), pointer :: rw
@@ -6132,7 +6131,7 @@ module atm_time_integration
       call mpas_pool_get_array(state, 'rho_zz', rho_zz_2, 2)
 
       inv_dynamics_split = 1.0_RKIND / real(dynamics_split)
-      
+
       if (dynamics_substep < dynamics_split) then
 
          ru_save(:,edgeStart:edgeEnd) = ru(:,edgeStart:edgeEnd)
@@ -6167,10 +6166,10 @@ module atm_time_integration
 !-------------------------------------------------------------------------
 !
 ! these next 2 routines set an approximate zero gradient boundary condition for w for regional_MPAS
-!   
+!
    subroutine atm_zero_gradient_w_bdy( state, mesh, cellSolveStart, cellSolveEnd )
 
-      ! reconstitute state variables from acoustic-step perturbation variables 
+      ! reconstitute state variables from acoustic-step perturbation variables
       ! after the acoustic steps.  The perturbation variables were originally set in
       ! subroutine atm_set_smlstep_pert_variables prior to their acoustic-steps update.
       ! we are also computing a few other state-derived variables here.
@@ -6190,7 +6189,7 @@ module atm_time_integration
       call mpas_pool_get_array(mesh, 'bdyMaskCell', bdyMaskCell)
       call mpas_pool_get_array(mesh, 'nearestRelaxationCell', nearestRelaxationCell)
       call mpas_pool_get_dimension(mesh, 'nCells', nCells)
-      
+
       call atm_zero_gradient_w_bdy_work( w, bdyMaskCell, nearestRelaxationCell, nCells, cellSolveStart, cellSolveEnd )
 
    end subroutine atm_zero_gradient_w_bdy
@@ -6220,7 +6219,7 @@ module atm_time_integration
             do k = 2, nVertLevels
               w(k,iCell) = w(k,nearestRelaxationCell(iCell))
             end do
-         end if  
+         end if
       end do
 
    end subroutine atm_zero_gradient_w_bdy_work
@@ -6260,7 +6259,7 @@ module atm_time_integration
       call mpas_pool_get_array(mesh, 'bdyMaskCell', bdyMaskCell)
       call mpas_pool_get_array(mesh, 'bdyMaskEdge', bdyMaskEdge)
       call mpas_pool_get_array(tend, 'rt_diabatic_tend', rt_diabatic_tend)
-      
+
       do iCell = cellSolveStart, cellSolveEnd
          if(bdyMaskCell(iCell) > nRelaxZone) then
             do k=1, nVertLevels
@@ -6279,7 +6278,7 @@ module atm_time_integration
             end do
          end if
       end do
-      
+
     end subroutine atm_bdy_adjust_dynamics_speczone_tend
 
 !-------------------------------------------------------------------------
@@ -6316,7 +6315,7 @@ module atm_time_integration
       integer, dimension(:), pointer :: bdyMaskCell, bdyMaskEdge, nEdgesOnCell
       integer, dimension(:,:), pointer :: cellsOnEdge, verticesOnEdge, edgesOnCell, edgesOnVertex
       integer, pointer :: vertexDegree
-      
+
 
       real (kind=RKIND) :: edge_sign, laplacian_filter_coef, rayleigh_damping_coef, r_dc, r_dv, invArea
       real (kind=RKIND), pointer :: divdamp_coef
@@ -6377,7 +6376,7 @@ module atm_time_integration
             end do
          end if
       end do
-      
+
       !  Second, the horizontal filter for rtheta_m and rho_zz
 
       do iCell = cellSolveStart, cellSolveEnd ! threaded over cells
@@ -6443,7 +6442,7 @@ module atm_time_integration
                   divergence2(k) = divergence2(k) + edge_sign * (ru(k,iEdge_div) - ru_driving_values(k,iEdge_div))
                end do
             end do
-            
+
             iVertex = vertex1
             vorticity1(1:nVertLevels) = 0.
             do i=1,vertexDegree
@@ -6475,9 +6474,9 @@ module atm_time_integration
           end if  !  end test for relaxation-zone edge
 
        end do  !  end of loop over edges
-       
+
    end subroutine atm_bdy_adjust_dynamics_relaxzone_tend
-      
+
 
    subroutine atm_bdy_reset_speczone_values( state, diag, mesh, nVertLevels, &
                                              rt_driving_values, rho_driving_values, &
@@ -6501,14 +6500,14 @@ module atm_time_integration
 
       real (kind=RKIND), dimension(:,:), pointer :: theta_m, rtheta_p, rtheta_base
       integer, dimension(:), pointer :: bdyMaskCell
-      
+
       integer :: iCell, k
 
       call mpas_pool_get_array(mesh, 'bdyMaskCell', bdyMaskCell)
       call mpas_pool_get_array(state, 'theta_m', theta_m, 2)
       call mpas_pool_get_array(diag, 'rtheta_p', rtheta_p)
       call mpas_pool_get_array(diag, 'rtheta_base', rtheta_base)
-      
+
       do iCell = cellSolveStart, cellSolveEnd
          if( bdyMaskCell(iCell) > nRelaxZone) then
             do k=1, nVertLevels
@@ -6644,7 +6643,7 @@ module atm_time_integration
             end do
 
          else  if ( bdyMaskCell(iCell) > nRelaxZone) then ! specified zone
-            
+
             !  update the specified-zone values
             !
 !DIR$ IVDEP
@@ -6657,7 +6656,7 @@ module atm_time_integration
          end if
 
       end do  ! updates now in temp storage
-            
+
 !$OMP BARRIER
 
       do iCell = cellSolveStart, cellSolveEnd ! threaded over cells
@@ -6742,7 +6741,7 @@ module atm_time_integration
       do iCell = cellSolveStart, cellSolveEnd ! threaded over cells
 
          if ( bdyMaskCell(iCell) > nRelaxZone) then ! specified zone
-            
+
             !  update the specified-zone values
             !
 !DIR$ IVDEP
@@ -6755,7 +6754,7 @@ module atm_time_integration
          end if
 
       end do  ! updates now in temp storage
-            
+
    end subroutine atm_bdy_set_scalars_work
 
 !-------------------------------------------------------------------------
@@ -6784,10 +6783,12 @@ module atm_time_integration
        real (kind=RKIND) :: scalar_min, scalar_max
        real (kind=RKIND) :: global_scalar_min, global_scalar_max
 
+       real (kind=RKIND), pointer :: config_dt
        real (kind=RKIND), dimension(:), pointer :: latCell
        real (kind=RKIND), dimension(:), pointer :: lonCell
        real (kind=RKIND), dimension(:), pointer :: latEdge
        real (kind=RKIND), dimension(:), pointer :: lonEdge
+       real (kind=RKIND), dimension(:), pointer :: dcEdge
        integer, dimension(:), pointer :: indexToCellID
        integer :: indexMax, indexMax_global
        integer :: kMax, kMax_global
@@ -6795,10 +6796,14 @@ module atm_time_integration
        real (kind=RKIND) :: lonMax, lonMax_global
        real (kind=RKIND), dimension(5) :: localVals, globalVals
 
-       real (kind=RKIND) :: spd
-       real (kind=RKIND), dimension(:,:), pointer :: w
+       real (kind=RKIND) :: spd, courant, lipschitz, uEdge, rdz
+       real (kind=RKIND), dimension(:,:), pointer :: w, t, p
        real (kind=RKIND), dimension(:,:), pointer :: u, v, uReconstructZonal, uReconstructMeridional, uReconstructX, uReconstructY, uReconstructZ
        real (kind=RKIND), dimension(:,:,:), pointer :: scalars, scalars_1, scalars_2
+       real (kind=RKIND), dimension(:,:), pointer :: rho_zz, wwavg, uhAvg, zz
+       real (kind=RKIND), dimension(:), pointer :: rdzw, rdzu, fzm, fzp
+       integer, dimension(:,:), pointer :: cellsOnEdge
+       integer :: cell1, cell2
 
        call mpas_pool_get_config(block % configs, 'config_print_global_minmax_vel', config_print_global_minmax_vel)
        call mpas_pool_get_config(block % configs, 'config_print_detailed_minmax_vel', config_print_detailed_minmax_vel)

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -1,4 +1,3 @@
-
 ! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
 ! and the University Corporation for Atmospheric Research (UCAR).
 !
@@ -17,6 +16,7 @@
 
 module atm_time_integration
 
+   use mpas_derived_types
    use mpas_pool_routines
    use mpas_kind_types
    use mpas_constants
@@ -34,8 +34,8 @@ module atm_time_integration
 #endif
 
    use mpas_atm_boundaries, only : nSpecZone, nRelaxZone, nBdyZone, mpas_atm_get_bdy_state, mpas_atm_get_bdy_tend  ! regional_MPAS addition
-
-   use mpas_atm_iau
+   
+   use mpas_atm_iau  
 
    !
    ! Abstract interface for routine used to communicate halos of fields
@@ -59,10 +59,10 @@ module atm_time_integration
    real (kind=RKIND), dimension(:,:), pointer :: tend_ru_physics, tend_rtheta_physics, tend_rho_physics
    
    ! Used in compute_dyn_tend
-   real (kind=RKIND), allocatable, dimension(:,:) :: qtot
+   real (kind=RKIND), allocatable, dimension(:,:) :: qtot 
    real (kind=RKIND), allocatable, dimension(:,:) :: delsq_theta, delsq_w, delsq_divergence
    real (kind=RKIND), allocatable, dimension(:,:) :: delsq_u
-!   real (kind=RKIND), allocatable, dimension(:,:) :: delsq_circulation    ! no longer used -> removed
+!   real (kind=RKIND), allocatable, dimension(:,:) :: delsq_circulation    ! no longer used -> removed 
    real (kind=RKIND), allocatable, dimension(:,:) :: delsq_vorticity
    real (kind=RKIND), allocatable, dimension(:,:) :: dpdz
 
@@ -78,16 +78,16 @@ module atm_time_integration
    real (kind=RKIND), dimension(:,:), allocatable :: wdtn_arr
    real (kind=RKIND), dimension(:,:), allocatable :: rho_zz_int
 
-   real (kind=RKIND), dimension(:,:,:), allocatable :: scalars_driving ! regional_MPAS addition
-   real (kind=RKIND), dimension(:,:), allocatable :: ru_driving_tend ! regional_MPAS addition
-   real (kind=RKIND), dimension(:,:), allocatable :: rt_driving_tend ! regional_MPAS addition
-   real (kind=RKIND), dimension(:,:), allocatable :: rho_driving_tend ! regional_MPAS addition
-   real (kind=RKIND), dimension(:,:), allocatable :: ru_driving_values ! regional_MPAS addition
-   real (kind=RKIND), dimension(:,:), allocatable :: rt_driving_values ! regional_MPAS addition
-   real (kind=RKIND), dimension(:,:), allocatable :: rho_driving_values ! regional_MPAS addition
+   real (kind=RKIND), dimension(:,:,:), allocatable :: scalars_driving ! regional_MPAS addition 
+   real (kind=RKIND), dimension(:,:), allocatable :: ru_driving_tend ! regional_MPAS addition 
+   real (kind=RKIND), dimension(:,:), allocatable :: rt_driving_tend ! regional_MPAS addition 
+   real (kind=RKIND), dimension(:,:), allocatable :: rho_driving_tend ! regional_MPAS addition 
+   real (kind=RKIND), dimension(:,:), allocatable :: ru_driving_values ! regional_MPAS addition 
+   real (kind=RKIND), dimension(:,:), allocatable :: rt_driving_values ! regional_MPAS addition 
+   real (kind=RKIND), dimension(:,:), allocatable :: rho_driving_values ! regional_MPAS addition 
    integer, dimension(:), pointer :: bdyMaskEdge ! regional_MPAS addition
    logical, pointer :: config_apply_lbcs
-
+   
    ! Used in compute_solve_diagnostics
    real (kind=RKIND), allocatable, dimension(:,:) :: ke_vertex
    real (kind=RKIND), allocatable, dimension(:,:) :: ke_edge
@@ -104,6 +104,7 @@ module atm_time_integration
 
 
    contains
+
 
    !***********************************************************************
    !
@@ -386,11 +387,11 @@ module atm_time_integration
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
    ! Advance model state forward in time by the specified time step
    !
-   ! Input: domain - current model state in time level 1 (e.g., time_levs(1)state%h(:,:))
+   ! Input: domain - current model state in time level 1 (e.g., time_levs(1)state%h(:,:)) 
    !                 plus grid meta-data
-   ! Output: domain - upon exit, time level 2 (e.g., time_levs(2)%state%h(:,:)) contains
+   ! Output: domain - upon exit, time level 2 (e.g., time_levs(2)%state%h(:,:)) contains 
    !                  model state advanced forward in time by dt seconds
-   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
 
       implicit none
 
@@ -450,12 +451,12 @@ module atm_time_integration
    !
    ! Nonhydrostatic atmospheric solver
    !
-   ! Input: domain - current model state in time level 1 (e.g., time_levs(1)state%h(:,:))
+   ! Input: domain - current model state in time level 1 (e.g., time_levs(1)state%h(:,:)) 
    !                 plus grid meta-data and some diagnostics of state.
-   ! Output: domain - upon exit, time level 2 (e.g., time_levs(2)%state%h(:,:)) contains
+   ! Output: domain - upon exit, time level 2 (e.g., time_levs(2)%state%h(:,:)) contains 
    !                  model state advanced forward in time by dt seconds,
-   !                  and some diagnostics in diag
-   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   !                  and some diagnostics in diag 
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
 
       implicit none
 
@@ -498,8 +499,8 @@ module atm_time_integration
       character (len=StrKIND), pointer :: config_convection_scheme
 
       integer, pointer :: num_scalars, index_qv, nCells, nCellsSolve, nEdges, nEdgesSolve, nVertices, nVerticesSolve, nVertLevels
-      integer, pointer :: index_qc, index_qr, index_qi, index_qs, index_qg, index_qh, index_nwfa, index_nifa
-      integer, pointer :: index_nc, index_nr, index_ni, index_ns, index_ng, index_nh, index_nccn
+      integer, pointer :: index_qc, index_qr, index_qi, index_qs, index_qg, index_nr, index_ni, index_nc, index_nifa, index_nwfa
+      integer, pointer :: index_qh, index_ns, index_ng, index_nh, index_nccn
       integer, pointer :: index_volg, index_volh, index_zrw, index_zgw, index_zhw
 
       character(len=StrKIND), pointer :: config_IAU_option
@@ -601,13 +602,13 @@ module atm_time_integration
          call mpas_pool_get_dimension(state, 'index_qr', index_qr)
          call mpas_pool_get_dimension(state, 'index_qi', index_qi)
          call mpas_pool_get_dimension(state, 'index_qs', index_qs)
-         call mpas_pool_get_dimension(state, 'index_qg', index_qg)
-         call mpas_pool_get_dimension(state, 'index_qh', index_qh) 
-         call mpas_pool_get_dimension(state, 'index_nc', index_nc)  
+         call mpas_pool_get_dimension(state, 'index_qg', index_qg)  
+         call mpas_pool_get_dimension(state, 'index_qh', index_qh)
          call mpas_pool_get_dimension(state, 'index_nr', index_nr)
          call mpas_pool_get_dimension(state, 'index_ni', index_ni)
-         call mpas_pool_get_dimension(state, 'index_nwfa', index_nwfa)
+         call mpas_pool_get_dimension(state, 'index_nc', index_nc)
          call mpas_pool_get_dimension(state, 'index_nifa', index_nifa)
+         call mpas_pool_get_dimension(state, 'index_nwfa', index_nwfa)
          call mpas_pool_get_dimension(state, 'index_ns', index_ns)
          call mpas_pool_get_dimension(state, 'index_ng', index_ng)
          call mpas_pool_get_dimension(state, 'index_nh', index_nh)
@@ -777,9 +778,9 @@ module atm_time_integration
          call exchange_halo_group(domain, 'dynamics:exner')
 
 
-         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-         ! BEGIN Runge-Kutta loop
-         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
+         ! BEGIN Runge-Kutta loop 
+         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
 
          RK3_DYNAMICS : do rk_step = 1, 3  ! Runge-Kutta loop
 
@@ -862,7 +863,7 @@ module atm_time_integration
 !$OMP END PARALLEL DO
             call mpas_timer_stop('small_step_prep')
 
-
+          
 !------------------------------------------------------------------------------------------------------------------------
 
             if (config_apply_lbcs) then  ! adjust boundary tendencies for regional_MPAS dry dynamics in the specified zone
@@ -943,7 +944,7 @@ module atm_time_integration
 
                call mpas_timer_stop('atm_advance_acoustic_step')
 
-
+  
 ! rtheta_pp
 ! This is the only communications needed during the acoustic steps because we solve for u on all edges of owned cells
 
@@ -1025,7 +1026,7 @@ module atm_time_integration
             end if  ! regional_MPAS addition
 
 !-------------------------------------------------------------------
-
+            
             ! u
             if (config_apply_lbcs) then
                call exchange_halo_group(domain, 'dynamics:u_123')
@@ -1033,7 +1034,7 @@ module atm_time_integration
                call exchange_halo_group(domain, 'dynamics:u_3')
             end if
 
-            ! scalar advection: RK3 scheme of Skamarock and Gassmann (2011).
+            ! scalar advection: RK3 scheme of Skamarock and Gassmann (2011). 
             ! PD or monotonicity constraints applied only on the final Runge-Kutta substep.
 
             if (config_scalar_advection .and. (.not. config_split_dynamics_transport) ) then
@@ -1070,20 +1071,20 @@ module atm_time_integration
                   if (index_qh > 0) then
                      scalars_driving(index_qh,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qh', rk_timestep(rk_step) )
                   end if
-                  if (index_nc > 0) then
-                     scalars_driving(index_nc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nc', rk_timestep(rk_step) )
-                  end if
                   if (index_nr > 0) then
                      scalars_driving(index_nr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nr', rk_timestep(rk_step) )
                   end if
                   if (index_ni > 0) then
                      scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
                   end if
-                  if (index_nwfa > 0) then
-                     scalars_driving(index_nwfa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nwfa', rk_timestep(rk_step) )
+                  if (index_nc > 0) then
+                     scalars_driving(index_nc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nc', rk_timestep(rk_step) )
                   end if
                   if (index_nifa > 0) then
                      scalars_driving(index_nifa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nifa', rk_timestep(rk_step) )
+                  end if
+                  if (index_nwfa > 0) then
+                     scalars_driving(index_nwfa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nwfa', rk_timestep(rk_step) )
                   end if
                   if (index_ns > 0) then
                      scalars_driving(index_ns,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ns', rk_timestep(rk_step) )
@@ -1162,7 +1163,7 @@ module atm_time_integration
             end if
 
             ! set the zero-gradient condition on w for regional_MPAS
-
+            
             if ( config_apply_lbcs ) then  ! regional_MPAS addition
 
 !$OMP PARALLEL DO
@@ -1175,7 +1176,7 @@ module atm_time_integration
               ! w halo values needs resetting after regional boundary update
               call exchange_halo_group(domain, 'dynamics:w')
 
-            end if ! end of regional_MPAS addition
+            end if ! end of regional_MPAS addition 
 
          end do RK3_DYNAMICS
 
@@ -1276,20 +1277,20 @@ module atm_time_integration
                if (index_qh > 0) then
                   scalars_driving(index_qh,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qh', rk_timestep(rk_step) )
                end if
-               if (index_nc > 0) then
-                  scalars_driving(index_nc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nc', rk_timestep(rk_step) )
-               end if
                if (index_nr > 0) then
                   scalars_driving(index_nr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nr', rk_timestep(rk_step) )
                end if
                if (index_ni > 0) then
                   scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
                end if
-               if (index_nwfa > 0) then
-                  scalars_driving(index_nwfa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nwfa', rk_timestep(rk_step) )
+               if (index_nc > 0) then
+                  scalars_driving(index_nc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nc', rk_timestep(rk_step) )
                end if
                if (index_nifa > 0) then
                   scalars_driving(index_nifa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nifa', rk_timestep(rk_step) )
+               end if
+               if (index_nwfa > 0) then
+                  scalars_driving(index_nwfa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nwfa', rk_timestep(rk_step) )
                end if
                if (index_ns > 0) then
                   scalars_driving(index_ns,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ns', rk_timestep(rk_step) )
@@ -1475,20 +1476,20 @@ module atm_time_integration
          if (index_qh > 0) then
             scalars_driving(index_qh,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qh', dt)
          end if
-         if (index_nc > 0) then
-            scalars_driving(index_nc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nc', dt)
-         end if
          if (index_nr > 0) then
             scalars_driving(index_nr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nr', dt )
          end if
          if (index_ni > 0) then
             scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', dt )
          end if
-         if (index_nwfa > 0) then
-            scalars_driving(index_nwfa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nwfa', dt )
+         if (index_nc > 0) then
+            scalars_driving(index_nc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nc', dt )
          end if
          if (index_nifa > 0) then
             scalars_driving(index_nifa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nifa', dt )
+         end if
+         if (index_nwfa > 0) then
+            scalars_driving(index_nwfa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nwfa', dt )
          end if
          if (index_ns > 0) then
             scalars_driving(index_ns,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ns', dt)
@@ -1773,7 +1774,7 @@ module atm_time_integration
                                    cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
                                    cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd)
 
-      ! the moist coefficients cqu and cqw serve to transform the inverse dry density (1/rho_d)
+      ! the moist coefficients cqu and cqw serve to transform the inverse dry density (1/rho_d) 
       ! into the inverse full (moist) density (1/rho_m).
 
       implicit none
@@ -1814,7 +1815,7 @@ module atm_time_integration
                qtot(k,iCell) = qtot(k,iCell) + scalars(iq, k, iCell)
             end do
          end do
-      end do
+      end do    
 
 !      do iCell = cellSolveStart,cellSolveEnd
       do iCell = cellStart,cellEnd
@@ -1926,7 +1927,7 @@ module atm_time_integration
                                    cellSolveStart, cellSolveEnd, edgeSolveStart, edgeSolveEnd)
 
       use mpas_atm_dimensions
-
+ 
       implicit none
 
 
@@ -2046,8 +2047,8 @@ module atm_time_integration
                                    cellSolveStart, cellSolveEnd, edgeSolveStart, edgeSolveEnd)
 
       ! following Klemp et al MWR 2007, we use preturbation variables
-      ! in the acoustic-step integration.  This routine computes those
-      ! perturbation variables.  state variables are reconstituted after
+      ! in the acoustic-step integration.  This routine computes those 
+      ! perturbation variables.  state variables are reconstituted after 
       ! the acousstic steps in subroutine atm_recover_large_step_variables
 
 
@@ -2224,7 +2225,7 @@ module atm_time_integration
                                    cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd)
 
       !  This subroutine performs the entire acoustic step update, following Klemp et al MWR 2007,
-      !  using forward-backward vertically implicit integration.
+      !  using forward-backward vertically implicit integration.  
       !  The gravity-waves are included in the acoustic-step integration.
       !  The input state variables that are updated are ru_p, rw_p (note that this is (rho*omega)_p here),
       !  rtheta_p, and rho_pp.  The time averaged mass flux is accumulated in ruAvg and wwAvg
@@ -2339,7 +2340,7 @@ module atm_time_integration
       call mpas_pool_get_array(diag, 'rw_save', rw_save)
 
       ! epssm is the offcentering coefficient for the vertically implicit integration.
-      call mpas_pool_get_config(configs, 'config_epssm', epssm)
+      call mpas_pool_get_config(configs, 'config_epssm', epssm) 
 
       call atm_advance_acoustic_step_work(nCells, nEdges, nCellsSolve, cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
                                    cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd, &
@@ -2427,13 +2428,13 @@ module atm_time_integration
 
       real (kind=RKIND), dimension(nCells+1) :: specZoneMaskCell
       real (kind=RKIND), dimension(nEdges+1) :: specZoneMaskEdge
-
+      
 
       integer, intent(in) :: small_step
       real (kind=RKIND), intent(in) :: dts, epssm,cf1, cf2, cf3
       real (kind=RKIND), dimension(nVertLevels) :: ts, rs
 
-
+  
       !
       ! Local variables
       !
@@ -2447,20 +2448,20 @@ module atm_time_integration
       resm = (1.0 - epssm) / (1.0 + epssm)
       rdts = 1./dts
 
-      if(small_step /= 1) then  !  not needed on first small step
+      if(small_step /= 1) then  !  not needed on first small step 
 
         ! forward-backward acoustic step integration.
-        ! begin by updating the horizontal velocity u,
+        ! begin by updating the horizontal velocity u, 
         ! and accumulating the contribution from the updated u to the other tendencies.
 
         ! we are looping over all edges, but only computing on edges of owned cells. This will include updates of
         ! all owned edges plus some edges that are owned by other blocks.  We perform these redundant computations
-        ! so that we do not have to communicate updates of u to update the cell variables (rho, w, and theta).
+        ! so that we do not have to communicate updates of u to update the cell variables (rho, w, and theta). 
 
         !MGD this loop will not be very load balanced with if-test below
 
         do iEdge=edgeStart,edgeEnd ! MGD do we really just need edges touching owned cells?
-
+ 
            cell1 = cellsOnEdge(1,iEdge)
            cell2 = cellsOnEdge(2,iEdge)
 
@@ -2501,7 +2502,7 @@ module atm_time_integration
               end do
 !DIR$ IVDEP
               do k=1,nVertLevels
-                 ruAvg(k,iEdge) = ru_p(k,iEdge)
+                 ruAvg(k,iEdge) = ru_p(k,iEdge)                 
               end do
 
            end if ! end test for block-owned cells
@@ -2525,18 +2526,18 @@ module atm_time_integration
       do iCell=cellSolveStart,cellSolveEnd  ! loop over all owned cells to solve
 
          if(small_step == 1) then  ! initialize here on first small timestep.
-            wwAvg(1:nVertLevels+1,iCell) = 0.0
-            rho_pp(1:nVertLevels,iCell) = 0.0
-            rtheta_pp(1:nVertLevels,iCell) = 0.0
+            wwAvg(1:nVertLevels+1,iCell) = 0.0            
+            rho_pp(1:nVertLevels,iCell) = 0.0            
+            rtheta_pp(1:nVertLevels,iCell) = 0.0            
             rw_p(:,iCell) = 0.0
          end if
-
+            
          if(specZoneMaskCell(iCell) == 0.0) then  ! not specified zone, compute...
 
          ts(:) = 0.0
          rs(:) = 0.0
 
-         do i=1,nEdgesOnCell(iCell)
+         do i=1,nEdgesOnCell(iCell) 
             iEdge = edgesOnCell(i,iCell)
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
@@ -2555,7 +2556,7 @@ module atm_time_integration
 !DIR$ IVDEP
          do k=1, nVertLevels
             rs(k) = rho_pp(k,iCell) + dts*tend_rho(k,iCell) + rs(k)                  &
-                            - cofrz(k)*resm*(rw_p(k+1,iCell)-rw_p(k,iCell))
+                            - cofrz(k)*resm*(rw_p(k+1,iCell)-rw_p(k,iCell)) 
             ts(k) = rtheta_pp(k,iCell) + dts*tend_rt(k,iCell) + ts(k)                &
                                - resm*rdzw(k)*( coftz(k+1,iCell)*rw_p(k+1,iCell)     &
                                                -coftz(k,iCell)*rw_p(k,iCell))
@@ -2588,10 +2589,10 @@ module atm_time_integration
 
 !MGD VECTOR DEPENDENCE
          do k=nVertLevels,1,-1
-            rw_p(k,iCell) = rw_p(k,iCell) - gamma_tri(k,iCell)*rw_p(k+1,iCell)
+            rw_p(k,iCell) = rw_p(k,iCell) - gamma_tri(k,iCell)*rw_p(k+1,iCell)     
          end do
 
-         ! the implicit Rayleigh damping on w (gravity-wave absorbing)
+         ! the implicit Rayleigh damping on w (gravity-wave absorbing) 
 
 !DIR$ IVDEP
          do k=2,nVertLevels
@@ -2669,7 +2670,7 @@ module atm_time_integration
       call mpas_pool_get_dimension(mesh, 'nCellsSolve', nCellsSolve)
       call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
 
-      call mpas_pool_get_config(configs, 'config_smdiv', smdiv)
+      call mpas_pool_get_config(configs, 'config_smdiv', smdiv) 
       call mpas_pool_get_config(configs, 'config_len_disp', config_len_disp)
 
       rdts = 1.0_RKIND / dts
@@ -2709,7 +2710,7 @@ module atm_time_integration
                                        cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
                                        cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd)
 
-      ! reconstitute state variables from acoustic-step perturbation variables
+      ! reconstitute state variables from acoustic-step perturbation variables 
       ! after the acoustic steps.  The perturbation variables were originally set in
       ! subroutine atm_set_smlstep_pert_variables prior to their acoustic-steps update.
       ! we are also computing a few other state-derived variables here.
@@ -2839,7 +2840,7 @@ module atm_time_integration
       real (kind=RKIND), intent(in) :: dt
 
       integer, dimension(nCells+1), intent(in) :: bdyMaskCell
-
+      
       real (kind=RKIND), dimension(nVertLevels+1,nCells+1) :: wwAvg
       real (kind=RKIND), dimension(nVertLevels+1,nCells+1) :: rw_save
       real (kind=RKIND), dimension(nVertLevels+1,nCells+1) :: w
@@ -2894,7 +2895,7 @@ module atm_time_integration
       rcv = rgas/(cp-rgas)
       p0 = 1.0e+05  ! this should come from somewhere else...
 
-      ! Avoid FP errors caused by a potential division by zero below by
+      ! Avoid FP errors caused by a potential division by zero below by 
       ! initializing the "garbage cell" of rho_zz to a non-zero value
       do k=1,nVertLevels
          rho_zz(k,nCells+1) = 1.0
@@ -2923,7 +2924,7 @@ module atm_time_integration
 
           ! pick up part of diagnosed w from omega - divide by density later
             w(k,iCell) = rw(k,iCell)/(fzm(k)*zz(k,iCell)+fzp(k)*zz(k-1,iCell))
-
+                                      
          end do
 
          w(nVertLevels+1,iCell) = 0.0
@@ -2949,8 +2950,8 @@ module atm_time_integration
 
       end do
 
-      ! recover time-averaged ruAvg on all edges of owned cells (for upcoming scalar transport).
-      ! we solved for these in the acoustic-step loop.
+      ! recover time-averaged ruAvg on all edges of owned cells (for upcoming scalar transport).  
+      ! we solved for these in the acoustic-step loop.  
       ! we will compute ru and u here also, given we are here, even though we only need them on nEdgesSolve
 
 !$OMP BARRIER
@@ -3009,6 +3010,7 @@ module atm_time_integration
    end subroutine atm_recover_large_step_variables_work
 
 
+   !-----------------------------------------------------------------------
    !  routine atm_advance_scalars
    !
    !> \brief Integrate scalar equations - explicit transport plus other tendencies
@@ -3680,7 +3682,7 @@ module atm_time_integration
       end if
 
       !  for positive-definite or monotonic option, we first update scalars using the tendency from sources other than
-      !  the resolved transport (these should constitute a positive definite update).
+      !  the resolved transport (these should constitute a positive definite update).  
       !  Note, however, that we enforce positive-definiteness in this update.
       !  The transport will maintain this positive definite solution and optionally, shape preservation (monotonicity).
 
@@ -3768,7 +3770,7 @@ module atm_time_integration
                   rho_zz_int(k,iCell) = rho_zz_int(k,iCell) - edgesOnCell_sign(i,iCell) &
                                                             * uhAvg(k,iEdge) * dvEdge(iEdge) * invAreaCell(iCell)
                end do
-
+               
             end do
          end do
 
@@ -3876,7 +3878,7 @@ module atm_time_integration
                s_max(k,iCell) = max(scalar_old(k-1,iCell),scalar_old(k,iCell),scalar_old(k+1,iCell))
                s_min(k,iCell) = min(scalar_old(k-1,iCell),scalar_old(k,iCell),scalar_old(k+1,iCell))
             end do
-
+ 
             k = nVertLevels
             wdtn(k,iCell) = wwAvg(k,iCell)*(fnm(k)*scalar_new(k,iCell)+fnp(k)*scalar_new(k-1,iCell))
             s_max(k,iCell) = max(scalar_old(k,iCell),scalar_old(k-1,iCell))
@@ -3938,7 +3940,7 @@ module atm_time_integration
             cell2 = cellsOnEdge(2,iEdge)
 
             if (cell1 <= nCellsSolve .or. cell2 <= nCellsSolve) then  ! only for owned cells
-
+  
                ! special treatment of calculations involving edges between hexagonal cells
                ! original code retained in select "default" case
                ! be sure to see additional declarations near top of subroutine
@@ -4025,7 +4027,7 @@ module atm_time_integration
             end do
 
             !
-            ! scale_arr(SCALE_IN,:,:) and scale_arr(SCALE_OUT:,:) are used here to store the incoming and outgoing perturbation flux
+            ! scale_arr(SCALE_IN,:,:) and scale_arr(SCALE_OUT:,:) are used here to store the incoming and outgoing perturbation flux 
             ! contributions to the update:  first the vertical flux component, then the horizontal
             !
 
@@ -4081,7 +4083,7 @@ module atm_time_integration
                !$acc loop vector
                do k=1, nVertLevels
                   scalar_new(k,iCell) = scalar_new(k,iCell) - edgesOnCell_sign(i,iCell) * flux_upwind_tmp(k,iEdge) * invAreaCell(iCell)
-
+ 
                   scale_arr(k,SCALE_OUT,iCell) = scale_arr(k,SCALE_OUT,iCell) &
                                                  - max(0.0_RKIND,edgesOnCell_sign(i,iCell)*flux_tmp(k,iEdge)) * invAreaCell(iCell)
                   scale_arr(k,SCALE_IN, iCell) = scale_arr(k,SCALE_IN, iCell) &
@@ -4317,7 +4319,7 @@ module atm_time_integration
    subroutine atm_compute_dyn_tend(tend, tend_physics, state, diag, mesh, configs, nVertLevels, rk_step, dt, &
                                    cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
                                    cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd)
-   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
    ! Compute height and normal wind tendencies, as well as diagnostic variables
    !
    ! Input: state - current model state
@@ -4327,8 +4329,8 @@ module atm_time_integration
    ! Output: tend - tendencies: tend_u, tend_w, tend_theta and tend_rho
    !                these are all coupled-variable tendencies.
    !         various other quantities in diag: Smagorinsky eddy viscosity
-   !
-   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   !                
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
 
       implicit none
 
@@ -4357,7 +4359,7 @@ module atm_time_integration
                                                    meshScalingDel2, meshScalingDel4
       real (kind=RKIND), dimension(:,:), pointer :: weightsOnEdge, zgrid, rho_edge, rho_zz, ru, u, v, tend_u, &
                                                     divergence, vorticity, ke, pv_edge, theta_m, rw, tend_rho, &
-                                                    rt_diabatic_tend, tend_theta, tend_w, w, cqw, rb, rr, pp, pressure_b, zz, zxu, cqu, &
+                                                    rt_diabatic_tend, tend_theta, tend_w, w, cqw, rb, rr, pp, pressure_b, zz, zxu, cqu, & 
                                                     h_divergence, kdiff, edgesOnCell_sign, edgesOnVertex_sign, rw_save, ru_save
 
       real (kind=RKIND), dimension(:,:), pointer :: theta_m_save
@@ -4382,7 +4384,7 @@ module atm_time_integration
       real (kind=RKIND), dimension(:,:), pointer :: adv_coefs, adv_coefs_3rd
 
       real (kind=RKIND), dimension(:), pointer :: rdzu, rdzw, fzm, fzp, qv_init
-      real (kind=RKIND), dimension(:,:), pointer :: t_init
+      real (kind=RKIND), dimension(:,:), pointer :: t_init 
 
       real (kind=RKIND), pointer :: cf1, cf2, cf3
 
@@ -4540,7 +4542,7 @@ module atm_time_integration
          fEdge, dvEdge, dcEdge, invDcEdge, invDvEdge, invAreaCell, invAreaTriangle, meshScalingDel2, meshScalingDel4, &
          weightsOnEdge, zgrid, rho_edge, rho_zz, ru, u, v, tend_u, &
          divergence, vorticity, ke, pv_edge, theta_m, rw, tend_rho, &
-         rt_diabatic_tend, tend_theta, tend_w, w, cqw, rb, rr, pp, pressure_b, zz, zxu, cqu, &
+         rt_diabatic_tend, tend_theta, tend_w, w, cqw, rb, rr, pp, pressure_b, zz, zxu, cqu, & 
          h_divergence, kdiff, edgesOnCell_sign, edgesOnVertex_sign, rw_save, ru_save, &
          theta_m_save, exner, rr_save, scalars, tend_u_euler, tend_w_euler, tend_theta_euler, deriv_two, &
          cellsOnEdge, verticesOnEdge, edgesOnCell, edgesOnEdge, cellsOnCell, edgesOnVertex, nEdgesOnCell, nEdgesOnEdge, &
@@ -4564,7 +4566,7 @@ module atm_time_integration
       fEdge, dvEdge, dcEdge, invDcEdge, invDvEdge, invAreaCell, invAreaTriangle, meshScalingDel2, meshScalingDel4, &
       weightsOnEdge, zgrid, rho_edge, rho_zz, ru, u, v, tend_u, &
       divergence, vorticity, ke, pv_edge, theta_m, rw, tend_rho, &
-      rt_diabatic_tend, tend_theta, tend_w, w, cqw, rb, rr, pp, pressure_b, zz, zxu, cqu, &
+      rt_diabatic_tend, tend_theta, tend_w, w, cqw, rb, rr, pp, pressure_b, zz, zxu, cqu, & 
       h_divergence, kdiff, edgesOnCell_sign, edgesOnVertex_sign, rw_save, ru_save, &
       theta_m_save, exner, rr_save, scalars, tend_u_euler, tend_w_euler, tend_theta_euler, deriv_two, &
       cellsOnEdge, verticesOnEdge, edgesOnCell, edgesOnEdge, cellsOnCell, edgesOnVertex, nEdgesOnCell, nEdgesOnEdge, &
@@ -4667,7 +4669,7 @@ module atm_time_integration
       real (kind=RKIND), dimension(nVertLevels) :: fzm
       real (kind=RKIND), dimension(nVertLevels) :: fzp
       real (kind=RKIND), dimension(nVertLevels) :: qv_init
-      real (kind=RKIND), dimension(nVertLevels,nCells+1) :: t_init
+      real (kind=RKIND), dimension(nVertLevels,nCells+1) :: t_init 
 
       real (kind=RKIND) :: cf1, cf2, cf3
       real (kind=RKIND) :: prandtl_inv, r_areaCell, rgas_cprcv
@@ -4711,7 +4713,6 @@ module atm_time_integration
       ! Local variables
       !
       integer :: iEdge, iCell, iVertex, k, cell1, cell2, vertex1, vertex2, eoe, i, j, iq, iAdvCell
-      integer :: kk
 
       !real (kind=RKIND), parameter :: c_s = 0.125
       real (kind=RKIND), dimension( nVertLevels+1 ) :: d_diag, d_off_diag, flux_arr
@@ -4769,7 +4770,7 @@ module atm_time_integration
                end do
 !DIR$ IVDEP
                do k=1, nVertLevels
-                  ! here is the Smagorinsky formulation,
+                  ! here is the Smagorinsky formulation, 
                   ! followed by imposition of an upper bound on the eddy viscosity
                   kdiff(k,iCell) = min((c_s * config_len_disp)**2 * sqrt(d_diag(k)**2 + d_off_diag(k)**2),(0.01*config_len_disp**2) * invDt)
                end do
@@ -4801,7 +4802,7 @@ module atm_time_integration
             end do
 
          end if
-
+            
       end if
 
       ! tendency for density.
@@ -4828,7 +4829,7 @@ module atm_time_integration
          do k = 1,nVertLevels
             h_divergence(k,iCell) = h_divergence(k,iCell) * r
          end do
-      end do
+      end do    
 
       !
       ! dp / dz and tend_rho
@@ -4859,7 +4860,7 @@ module atm_time_integration
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
 
-         ! horizontal pressure gradient
+         ! horizontal pressure gradient 
 
          if(rk_step == 1) then
 !DIR$ IVDEP
@@ -4909,12 +4910,12 @@ module atm_time_integration
             ! of the horizontal momentum equation
             tend_u(k,iEdge) = tend_u(k,iEdge) + rho_edge(k,iEdge)* (q(k) - (ke(k,cell2) - ke(k,cell1))       &
                                                                  * invDcEdge(iEdge))                            &
-                                             - u(k,iEdge)*0.5*(h_divergence(k,cell1)+h_divergence(k,cell2))
+                                             - u(k,iEdge)*0.5*(h_divergence(k,cell1)+h_divergence(k,cell2)) 
 #ifdef CURVATURE
             ! curvature terms for the sphere
             tend_u(k,iEdge) = tend_u(k,iEdge) &
                              - 2.*omega*cos(angleEdge(iEdge))*cos(latEdge(iEdge))  &
-                               *rho_edge(k,iEdge)*.25*(w(k,cell1)+w(k+1,cell1)+w(k,cell2)+w(k+1,cell2))          &
+                               *rho_edge(k,iEdge)*.25*(w(k,cell1)+w(k+1,cell1)+w(k,cell2)+w(k+1,cell2))          & 
                              - u(k,iEdge)*.25*(w(k+1,cell1)+w(k,cell1)+w(k,cell2)+w(k+1,cell2))                  &
                                *rho_edge(k,iEdge) * inv_r_earth
 #endif
@@ -4958,7 +4959,7 @@ module atm_time_integration
 
                kdiffu = 0.5*(kdiff(k,cell1)+kdiff(k,cell2))
 
-               ! include 2nd-orer diffusion here
+               ! include 2nd-orer diffusion here 
                tend_u_euler(k,iEdge) = tend_u_euler(k,iEdge) &
                                        + rho_edge(k,iEdge)* kdiffu * u_diffusion * meshScalingDel2(iEdge)
 
@@ -4994,7 +4995,7 @@ module atm_time_integration
 
 
 
-
+         
 !$OMP BARRIER
 
             do iEdge=edgeSolveStart,edgeSolveEnd
@@ -5013,18 +5014,18 @@ module atm_time_integration
                   ! Compute diffusion, computed as \nabla divergence - k \times \nabla vorticity
                   !                    only valid for h_mom_eddy_visc4 == constant
                   !
-                  ! Here, we scale the diffusion on the divergence part a factor of config_del4u_div_factor
+                  ! Here, we scale the diffusion on the divergence part a factor of config_del4u_div_factor 
                   !    relative to the rotational part.  The stability constraint on the divergence component is much less
                   !    stringent than the rotational part, and this flexibility may be useful.
                   !
                   u_diffusion =  rho_edge(k,iEdge) *  ( ( delsq_divergence(k,cell2)  - delsq_divergence(k,cell1) ) * r_dc  &
                                                        -( delsq_vorticity(k,vertex2) - delsq_vorticity(k,vertex1) ) * r_dv )
                   tend_u_euler(k,iEdge) = tend_u_euler(k,iEdge) - u_diffusion
-
+                  
                end do
             end do
-
-         end if ! 4th order mixing is active
+         
+         end if ! 4th order mixing is active 
 
       !
       !  vertical mixing for u - 2nd order filter in physical (z) space
@@ -5228,19 +5229,19 @@ module atm_time_integration
                   do k=2,nVertLevels
                      tend_w_euler(k,iCell) = tend_w_euler(k,iCell) - edge_sign * (delsq_w(k,cell2) - delsq_w(k,cell1))
                   end do
-
+           
                end do
             end do
 
-         end if ! 4th order mixing is active
+         end if ! 4th order mixing is active 
 
       end if ! horizontal mixing for w computed in first rk_step
 
 ! Note for OpenMP parallelization: We could avoid allocating the delsq_w scratch
 !   array, and just use the delsq_theta array as was previously done; however,
 !   particularly when oversubscribing cores with threads, there is the risk that
-!   some threads may reach code further below that re-uses the delsq_theta array,
-!   in which case we would need a barrier somewhere between here and that code
+!   some threads may reach code further below that re-uses the delsq_theta array, 
+!   in which case we would need a barrier somewhere between here and that code 
 !   below to ensure correct behavior.
 
       !
@@ -5338,7 +5339,7 @@ module atm_time_integration
 
       if(rk_step > 1) then
         do iCell=cellSolveStart,cellSolveEnd
-          do i=1,nEdgesOnCell(iCell)
+          do i=1,nEdgesOnCell(iCell) 
             iEdge = edgesOnCell(i,iCell)
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
@@ -5384,7 +5385,7 @@ module atm_time_integration
           end do
 
 !$OMP BARRIER
-
+            
          if (h_theta_eddy_visc4 > 0.0) then  ! 4th order mixing is active
 
             do iCell=cellSolveStart,cellSolveEnd    ! Technically updating fewer cells than before...
@@ -5403,7 +5404,7 @@ module atm_time_integration
                end do
             end do
 
-         end if ! 4th order mixing is active
+         end if ! 4th order mixing is active 
 
       end if ! theta mixing calculated first rk_step
 
@@ -5416,7 +5417,7 @@ module atm_time_integration
          wdtz(1) = 0.0
 
          k = 2
-         wdtz(k) =  rw(k,icell)*(fzm(k)*theta_m(k,iCell)+fzp(k)*theta_m(k-1,iCell))
+         wdtz(k) =  rw(k,icell)*(fzm(k)*theta_m(k,iCell)+fzp(k)*theta_m(k-1,iCell))  
          wdtz(k) =  wdtz(k)+(rw_save(k,icell)-rw(k,icell))*(fzm(k)*theta_m_save(k,iCell)+fzp(k)*theta_m_save(k-1,iCell))
          do k=3,nVertLevels-1
             wdtz(k) = flux3( theta_m(k-2,iCell),theta_m(k-1,iCell),theta_m(k,iCell),theta_m(k+1,iCell), rw(k,iCell), coef_3rd_order )
@@ -5436,7 +5437,7 @@ module atm_time_integration
       end do
 
       !
-      !  vertical mixing for theta - 2nd order
+      !  vertical mixing for theta - 2nd order 
       !
 
       if (rk_step == 1) then
@@ -5501,13 +5502,13 @@ module atm_time_integration
    subroutine atm_compute_solve_diagnostics(dt, state, time_lev, diag, mesh, configs, &
                                             cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
                                             rk_step )
-   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
    ! Compute diagnostic fields used in the tendency computations
    !
    ! Input: state (s), grid - grid metadata
    !
    ! Output: diag - computed diagnostics
-   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
 
       implicit none
 
@@ -5754,7 +5755,7 @@ module atm_time_integration
          ! Replace 2.0 with 2 in exponentiation to avoid outside chance that
          ! compiler will actually allow "float raised to float" operation
          do iVertex=vertexStart,vertexEnd
-            r = 0.25 * invAreaTriangle(iVertex)
+            r = 0.25 * invAreaTriangle(iVertex) 
             do k=1,nVertLevels
 
 !               ke_vertex(k,iVertex) = (  dcEdge(EdgesOnVertex(1,iVertex))*dvEdge(EdgesOnVertex(1,iVertex))*u(k,EdgesOnVertex(1,iVertex))**2  &
@@ -5827,7 +5828,7 @@ module atm_time_integration
 !DIR$ IVDEP
          do k=1,nVertLevels
 !
-! the following commented code is for the PV conserving shallow water solver.
+! the following commented code is for the PV conserving shallow water solver.  
 !            h_vertex = 0.0
 !            do i=1,vertexDegree
 !               h_vertex = h_vertex + h(k,cellsOnVertex(i,iVertex)) * kiteAreasOnVertex(i,iVertex)
@@ -5874,7 +5875,7 @@ module atm_time_integration
 !$OMP BARRIER
 
          !
-         ! Modify PV edge with upstream bias.
+         ! Modify PV edge with upstream bias. 
          !
          ! Compute gradient of PV in the tangent direction
          !   ( this computes gradPVt at all edges bounding real cells )
@@ -5909,7 +5910,7 @@ module atm_time_integration
                                        cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd)
 
       implicit none
-
+   
       type (mpas_pool_type), intent(inout) :: state
       integer, intent(in) :: time_lev                    ! which time level to use from state
       type (mpas_pool_type), intent(inout) :: diag
@@ -6019,7 +6020,7 @@ module atm_time_integration
                           * (fzp(k) * zz(k-1,iCell) + fzm(k) * zz(k,iCell))
          end do
       end do
-
+  
       ! next, the piece that depends on ru
       do iCell=cellStart,cellEnd
          do i=1,nEdgesOnCell(iCell)
@@ -6091,7 +6092,7 @@ module atm_time_integration
       integer, intent(in) :: cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd
 
       real (kind=RKIND) :: inv_dynamics_split
-
+      
       real (kind=RKIND), dimension(:,:), pointer :: ru
       real (kind=RKIND), dimension(:,:), pointer :: ru_save
       real (kind=RKIND), dimension(:,:), pointer :: rw
@@ -6131,7 +6132,7 @@ module atm_time_integration
       call mpas_pool_get_array(state, 'rho_zz', rho_zz_2, 2)
 
       inv_dynamics_split = 1.0_RKIND / real(dynamics_split)
-
+      
       if (dynamics_substep < dynamics_split) then
 
          ru_save(:,edgeStart:edgeEnd) = ru(:,edgeStart:edgeEnd)
@@ -6166,10 +6167,10 @@ module atm_time_integration
 !-------------------------------------------------------------------------
 !
 ! these next 2 routines set an approximate zero gradient boundary condition for w for regional_MPAS
-!
+!   
    subroutine atm_zero_gradient_w_bdy( state, mesh, cellSolveStart, cellSolveEnd )
 
-      ! reconstitute state variables from acoustic-step perturbation variables
+      ! reconstitute state variables from acoustic-step perturbation variables 
       ! after the acoustic steps.  The perturbation variables were originally set in
       ! subroutine atm_set_smlstep_pert_variables prior to their acoustic-steps update.
       ! we are also computing a few other state-derived variables here.
@@ -6189,7 +6190,7 @@ module atm_time_integration
       call mpas_pool_get_array(mesh, 'bdyMaskCell', bdyMaskCell)
       call mpas_pool_get_array(mesh, 'nearestRelaxationCell', nearestRelaxationCell)
       call mpas_pool_get_dimension(mesh, 'nCells', nCells)
-
+      
       call atm_zero_gradient_w_bdy_work( w, bdyMaskCell, nearestRelaxationCell, nCells, cellSolveStart, cellSolveEnd )
 
    end subroutine atm_zero_gradient_w_bdy
@@ -6219,7 +6220,7 @@ module atm_time_integration
             do k = 2, nVertLevels
               w(k,iCell) = w(k,nearestRelaxationCell(iCell))
             end do
-         end if
+         end if  
       end do
 
    end subroutine atm_zero_gradient_w_bdy_work
@@ -6259,7 +6260,7 @@ module atm_time_integration
       call mpas_pool_get_array(mesh, 'bdyMaskCell', bdyMaskCell)
       call mpas_pool_get_array(mesh, 'bdyMaskEdge', bdyMaskEdge)
       call mpas_pool_get_array(tend, 'rt_diabatic_tend', rt_diabatic_tend)
-
+      
       do iCell = cellSolveStart, cellSolveEnd
          if(bdyMaskCell(iCell) > nRelaxZone) then
             do k=1, nVertLevels
@@ -6278,7 +6279,7 @@ module atm_time_integration
             end do
          end if
       end do
-
+      
     end subroutine atm_bdy_adjust_dynamics_speczone_tend
 
 !-------------------------------------------------------------------------
@@ -6315,7 +6316,7 @@ module atm_time_integration
       integer, dimension(:), pointer :: bdyMaskCell, bdyMaskEdge, nEdgesOnCell
       integer, dimension(:,:), pointer :: cellsOnEdge, verticesOnEdge, edgesOnCell, edgesOnVertex
       integer, pointer :: vertexDegree
-
+      
 
       real (kind=RKIND) :: edge_sign, laplacian_filter_coef, rayleigh_damping_coef, r_dc, r_dv, invArea
       real (kind=RKIND), pointer :: divdamp_coef
@@ -6376,7 +6377,7 @@ module atm_time_integration
             end do
          end if
       end do
-
+      
       !  Second, the horizontal filter for rtheta_m and rho_zz
 
       do iCell = cellSolveStart, cellSolveEnd ! threaded over cells
@@ -6442,7 +6443,7 @@ module atm_time_integration
                   divergence2(k) = divergence2(k) + edge_sign * (ru(k,iEdge_div) - ru_driving_values(k,iEdge_div))
                end do
             end do
-
+            
             iVertex = vertex1
             vorticity1(1:nVertLevels) = 0.
             do i=1,vertexDegree
@@ -6474,9 +6475,9 @@ module atm_time_integration
           end if  !  end test for relaxation-zone edge
 
        end do  !  end of loop over edges
-
+       
    end subroutine atm_bdy_adjust_dynamics_relaxzone_tend
-
+      
 
    subroutine atm_bdy_reset_speczone_values( state, diag, mesh, nVertLevels, &
                                              rt_driving_values, rho_driving_values, &
@@ -6500,14 +6501,14 @@ module atm_time_integration
 
       real (kind=RKIND), dimension(:,:), pointer :: theta_m, rtheta_p, rtheta_base
       integer, dimension(:), pointer :: bdyMaskCell
-
+      
       integer :: iCell, k
 
       call mpas_pool_get_array(mesh, 'bdyMaskCell', bdyMaskCell)
       call mpas_pool_get_array(state, 'theta_m', theta_m, 2)
       call mpas_pool_get_array(diag, 'rtheta_p', rtheta_p)
       call mpas_pool_get_array(diag, 'rtheta_base', rtheta_base)
-
+      
       do iCell = cellSolveStart, cellSolveEnd
          if( bdyMaskCell(iCell) > nRelaxZone) then
             do k=1, nVertLevels
@@ -6643,7 +6644,7 @@ module atm_time_integration
             end do
 
          else  if ( bdyMaskCell(iCell) > nRelaxZone) then ! specified zone
-
+            
             !  update the specified-zone values
             !
 !DIR$ IVDEP
@@ -6656,7 +6657,7 @@ module atm_time_integration
          end if
 
       end do  ! updates now in temp storage
-
+            
 !$OMP BARRIER
 
       do iCell = cellSolveStart, cellSolveEnd ! threaded over cells
@@ -6741,7 +6742,7 @@ module atm_time_integration
       do iCell = cellSolveStart, cellSolveEnd ! threaded over cells
 
          if ( bdyMaskCell(iCell) > nRelaxZone) then ! specified zone
-
+            
             !  update the specified-zone values
             !
 !DIR$ IVDEP
@@ -6754,7 +6755,7 @@ module atm_time_integration
          end if
 
       end do  ! updates now in temp storage
-
+            
    end subroutine atm_bdy_set_scalars_work
 
 !-------------------------------------------------------------------------
@@ -6783,12 +6784,10 @@ module atm_time_integration
        real (kind=RKIND) :: scalar_min, scalar_max
        real (kind=RKIND) :: global_scalar_min, global_scalar_max
 
-       real (kind=RKIND), pointer :: config_dt
        real (kind=RKIND), dimension(:), pointer :: latCell
        real (kind=RKIND), dimension(:), pointer :: lonCell
        real (kind=RKIND), dimension(:), pointer :: latEdge
        real (kind=RKIND), dimension(:), pointer :: lonEdge
-       real (kind=RKIND), dimension(:), pointer :: dcEdge
        integer, dimension(:), pointer :: indexToCellID
        integer :: indexMax, indexMax_global
        integer :: kMax, kMax_global
@@ -6796,14 +6795,10 @@ module atm_time_integration
        real (kind=RKIND) :: lonMax, lonMax_global
        real (kind=RKIND), dimension(5) :: localVals, globalVals
 
-       real (kind=RKIND) :: spd, courant, lipschitz, uEdge, rdz
-       real (kind=RKIND), dimension(:,:), pointer :: w, t, p
+       real (kind=RKIND) :: spd
+       real (kind=RKIND), dimension(:,:), pointer :: w
        real (kind=RKIND), dimension(:,:), pointer :: u, v, uReconstructZonal, uReconstructMeridional, uReconstructX, uReconstructY, uReconstructZ
        real (kind=RKIND), dimension(:,:,:), pointer :: scalars, scalars_1, scalars_2
-       real (kind=RKIND), dimension(:,:), pointer :: rho_zz, wwavg, uhAvg, zz
-       real (kind=RKIND), dimension(:), pointer :: rdzw, rdzu, fzm, fzp
-       integer, dimension(:,:), pointer :: cellsOnEdge
-       integer :: cell1, cell2
 
        call mpas_pool_get_config(block % configs, 'config_print_global_minmax_vel', config_print_global_minmax_vel)
        call mpas_pool_get_config(block % configs, 'config_print_detailed_minmax_vel', config_print_detailed_minmax_vel)

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
@@ -154,10 +154,32 @@
        if(.not.allocated(recloud_p)) allocate(recloud_p(ims:ime,kms:kme,jms:jme))
        if(.not.allocated(reice_p)  ) allocate(reice_p(ims:ime,kms:kme,jms:jme)  )
        if(.not.allocated(resnow_p) ) allocate(resnow_p(ims:ime,kms:kme,jms:jme) )
+       if(.not.allocated(refl10cm_p)) allocate(refl10cm_p(ims:ime,kms:kme,jms:jme) )
 
        !precipitation flux:
        if(.not.allocated(rainprod_p)) allocate(rainprod_p(ims:ime,kms:kme,jms:jme))
        if(.not.allocated(evapprod_p)) allocate(evapprod_p(ims:ime,kms:kme,jms:jme))
+
+    microp2_select: select case(trim(microp_scheme))
+       case("mp_thompson","mp_thompson_aerosols")
+          if(.not.allocated(ntc_p)) allocate(ntc_p(ims:ime,jms:jme))
+          if(.not.allocated(muc_p)) allocate(muc_p(ims:ime,jms:jme))
+          if(.not.allocated(ni_p) ) allocate(ni_p(ims:ime,kms:kme,jms:jme))
+          if(.not.allocated(nr_p) ) allocate(nr_p(ims:ime,kms:kme,jms:jme))
+
+         microp3_select: select case(trim(microp_scheme))
+            case("mp_thompson_aerosols")
+               if(.not.allocated(nifa2d_p)) allocate(nifa2d_p(ims:ime,jms:jme))
+               if(.not.allocated(nwfa2d_p)) allocate(nwfa2d_p(ims:ime,jms:jme))
+               if(.not.allocated(nc_p)    ) allocate(nc_p(ims:ime,kms:kme,jms:jme)  )
+               if(.not.allocated(nifa_p)  ) allocate(nifa_p(ims:ime,kms:kme,jms:jme))
+               if(.not.allocated(nwfa_p)  ) allocate(nwfa_p(ims:ime,kms:kme,jms:jme))
+
+            case default
+         end select microp3_select
+
+       case default
+    end select microp2_select
 
     case ("mp_tempo","mp_nssl2m")
        !mass mixing ratios:
@@ -181,13 +203,7 @@
        if(.not.allocated(rainprod_p)) allocate(rainprod_p(ims:ime,kms:kme,jms:jme))
        if(.not.allocated(evapprod_p)) allocate(evapprod_p(ims:ime,kms:kme,jms:jme))
 
-    microp2_select: select case(trim(microp_scheme))
-       case("mp_thompson","mp_thompson_aerosols")
-          if(.not.allocated(ntc_p)) allocate(ntc_p(ims:ime,jms:jme))
-          if(.not.allocated(muc_p)) allocate(muc_p(ims:ime,jms:jme))
-          if(.not.allocated(ni_p) ) allocate(ni_p(ims:ime,kms:kme,jms:jme))
-          if(.not.allocated(nr_p) ) allocate(nr_p(ims:ime,kms:kme,jms:jme))
-
+    microp2a_select: select case(trim(microp_scheme))
        case("mp_tempo")
 !          if(.not.allocated(ntc_p)) allocate(ntc_p(ims:ime,jms:jme))
 !          if(.not.allocated(muc_p)) allocate(muc_p(ims:ime,jms:jme))
@@ -231,19 +247,8 @@
             if(.not.allocated(zhw_p) ) allocate(zhw_p(ims:ime,kms:kme,jms:jme))
           endif
 
-          microp3_select: select case(trim(microp_scheme))
-             case("mp_thompson_aerosols")
-                if(.not.allocated(nifa2d_p)) allocate(nifa2d_p(ims:ime,jms:jme))
-                if(.not.allocated(nwfa2d_p)) allocate(nwfa2d_p(ims:ime,jms:jme))
-                if(.not.allocated(nc_p)    ) allocate(nc_p(ims:ime,kms:kme,jms:jme)  )
-                if(.not.allocated(nifa_p)  ) allocate(nifa_p(ims:ime,kms:kme,jms:jme))
-                if(.not.allocated(nwfa_p)  ) allocate(nwfa_p(ims:ime,kms:kme,jms:jme))
-
           case default
-       end select microp3_select
-
-       case default
-    end select microp2_select
+    end select microp2a_select
 
     case default
  end select microp_select
@@ -310,6 +315,28 @@
        if(allocated(rainprod_p)) deallocate(rainprod_p)
        if(allocated(evapprod_p)) deallocate(evapprod_p)
 
+    microp2_select: select case(trim(microp_scheme))
+       case("mp_thompson","mp_thompson_aerosols")
+          if(allocated(ntc_p)) deallocate(ntc_p)
+          if(allocated(muc_p)) deallocate(muc_p)
+          if(allocated(ni_p) ) deallocate(ni_p )
+          if(allocated(nr_p) ) deallocate(nr_p )
+          if(allocated(refl10cm_p)  ) deallocate(refl10cm_p  )
+
+          microp3_select: select case(trim(microp_scheme))
+             case("mp_thompson_aerosols")
+                if(allocated(nifa2d_p)) deallocate(nifa2d_p)
+                if(allocated(nwfa2d_p)) deallocate(nwfa2d_p)
+                if(allocated(nc_p)    ) deallocate(nc_p    )
+                if(allocated(nifa_p)  ) deallocate(nifa_p  )
+                if(allocated(nwfa_p)  ) deallocate(nwfa_p  )
+
+             case default
+          end select microp3_select
+
+       case default
+    end select microp2_select
+
     case ("mp_tempo","mp_nssl2m")
        !mass mixing ratios:
        if(allocated(qi_p)) deallocate(qi_p)
@@ -332,13 +359,7 @@
        if(allocated(rainprod_p)) deallocate(rainprod_p)
        if(allocated(evapprod_p)) deallocate(evapprod_p)
 
-    microp2_select: select case(trim(microp_scheme))
-       case("mp_thompson","mp_thompson_aerosols")
-          if(allocated(ntc_p)) deallocate(ntc_p)
-          if(allocated(muc_p)) deallocate(muc_p)
-          if(allocated(ni_p) ) deallocate(ni_p )
-          if(allocated(nr_p) ) deallocate(nr_p )
-
+    microp2a_select: select case(trim(microp_scheme))
        case("mp_tempo")
 !          if(allocated(ntc_p)) deallocate(ntc_p)
 !          if(allocated(muc_p)) deallocate(muc_p)
@@ -383,19 +404,8 @@
             if(allocated(zhw_p) ) deallocate(zhw_p)
           endif
 
-          microp3_select: select case(trim(microp_scheme))
-             case("mp_thompson_aerosols")
-                if(allocated(nifa2d_p)) deallocate(nifa2d_p)
-                if(allocated(nwfa2d_p)) deallocate(nwfa2d_p)
-                if(allocated(nc_p)    ) deallocate(nc_p    )
-                if(allocated(nifa_p)  ) deallocate(nifa_p  )
-                if(allocated(nwfa_p)  ) deallocate(nwfa_p  )
-
-          case default
-       end select microp3_select
-
        case default
-    end select microp2_select
+    end select microp2a_select
 
     case default
  end select microp_select
@@ -475,9 +485,8 @@
           call nssl_2mom_init(ipctmp=5,mixphase=0,ihvol=1, myrank=dminfo % my_proc_id, mpiroot = IO_NODE)
        endif
 
-     case default
-
-  end select microp_select
+    case default
+ end select microp_select
 
 !call mpas_log_write('--- end subroutine init_microphysics:')
 
@@ -687,15 +696,15 @@
                   sr        = sr_p        , rainprod   = rainprod_p   , evapprod   = evapprod_p   , &
                   re_cloud  = recloud_p   , re_ice     = reice_p      , re_snow    = resnow_p     , &
                   has_reqc  = has_reqc    , has_reqi   = has_reqi     , has_reqs   = has_reqs     , &
-                  ntc        = ntc_p      , muc        = muc_p                                    , &
+                  ntc       = ntc_p       , muc        = muc_p                                    , &
                   ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde           , &
                   ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme           , &
                   its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte             &
                            )
-          istep = istep + 1
-          enddo
-          call mpas_timer_stop('mp_thompson')
-          
+       istep = istep + 1
+       enddo
+       call mpas_timer_stop('mp_thompson')
+
     case ("mp_thompson_aerosols")
        call mpas_timer_start('mp_thompson_aerosols')
        istep = 1
@@ -1254,7 +1263,7 @@
              dBZ1d(k) = refl10cm_p(i,k,j)
              zp(k) = z_p(i,k,j) - z_p(i,1,j)+0.5*dz_p(i,k,j) ! height AGL at mid-layer
           enddo
-          
+
           call calc_refl10cm(qv1d,qc1d,qr1d,nr1d,qs1d,qg1d,t1d,p1d,dBZ1d,kts,kte,i,j)
 
           kp = 1

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
@@ -204,8 +204,8 @@
        if(.not.allocated(rainprod_p)) allocate(rainprod_p(ims:ime,kms:kme,jms:jme))
        if(.not.allocated(evapprod_p)) allocate(evapprod_p(ims:ime,kms:kme,jms:jme))
 
-    microp2a_select: select case(trim(microp_scheme))
-       case("mp_tempo")
+       microp2a_select: select case(trim(microp_scheme))
+        case("mp_tempo")
 !          if(.not.allocated(ntc_p)) allocate(ntc_p(ims:ime,jms:jme))
 !          if(.not.allocated(muc_p)) allocate(muc_p(ims:ime,jms:jme))
           if(.not.allocated(ni_p) ) allocate(ni_p(ims:ime,kms:kme,jms:jme))
@@ -236,7 +236,7 @@
              if(.not.allocated(nwfa_p)  ) allocate(nwfa_p(ims:ime,kms:kme,jms:jme))
           endif
 
-       case("mp_nssl2m")
+        case("mp_nssl2m")
           if(.not.allocated(qh_p) ) allocate(qh_p(ims:ime,kms:kme,jms:jme))
           if(.not.allocated(nc_p) ) allocate(nc_p(ims:ime,kms:kme,jms:jme))
           if(.not.allocated(ni_p) ) allocate(ni_p(ims:ime,kms:kme,jms:jme))
@@ -369,8 +369,8 @@
        if(allocated(rainprod_p)) deallocate(rainprod_p)
        if(allocated(evapprod_p)) deallocate(evapprod_p)
 
-    microp2a_select: select case(trim(microp_scheme))
-       case("mp_tempo")
+       microp2a_select: select case(trim(microp_scheme))
+        case("mp_tempo")
 !          if(allocated(ntc_p)) deallocate(ntc_p)
 !          if(allocated(muc_p)) deallocate(muc_p)
           if(allocated(ni_p) ) deallocate(ni_p )
@@ -399,7 +399,7 @@
              if(allocated(nwfa_p)  ) deallocate(nwfa_p  )
           endif
 
-       case("mp_nssl2m")
+        case("mp_nssl2m")
           if(allocated(qh_p) ) deallocate(qh_p )
           if(allocated(nc_p) ) deallocate(nc_p )
           if(allocated(nr_p) ) deallocate(nr_p )

--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -1303,6 +1303,53 @@
        enddo
        enddo
 
+       mp2_select: select case(trim(mp_scheme))
+          case("mp_thompson","mp_thompson_aerosols")
+             call mpas_pool_get_dimension(state,'index_ni',index_ni)
+             call mpas_pool_get_dimension(state,'index_nr',index_nr)
+             ni   => scalars(index_ni,:,:)
+             nr   => scalars(index_nr,:,:)
+
+             do j = jts,jte
+             do k = kts,kte
+             do i = its,ite
+                ni(k,i) = ni_p(i,k,j)
+                nr(k,i) = nr_p(i,k,j)
+             enddo
+             enddo
+             enddo
+
+             mp3_select: select case(trim(mp_scheme))
+                case("mp_thompson_aerosols")
+                   call mpas_pool_get_dimension(state,'index_nc'  ,index_nc  )
+                   call mpas_pool_get_dimension(state,'index_nifa',index_nifa)
+                   call mpas_pool_get_dimension(state,'index_nwfa',index_nwfa)
+                   nc   => scalars(index_nc,:,:)
+                   nifa => scalars(index_nifa,:,:)
+                   nwfa => scalars(index_nwfa,:,:)
+
+                   call mpas_pool_get_array(diag_physics,'nifa2d',nifa2d)
+                   call mpas_pool_get_array(diag_physics,'nwfa2d',nwfa2d)
+                   do j = jts,jte
+                   do i = its,ite
+                      nifa2d(i) = nifa2d_p(i,j)
+                      nwfa2d(i) = nwfa2d_p(i,j)
+                   enddo
+                   do k = kts, kte
+                   do i = its, ite
+                      nc(k,i)   = nc_p(i,k,j)
+                      nifa(k,i) = nifa_p(i,k,j)
+                      nwfa(k,i) = nwfa_p(i,k,j)
+                   enddo
+                   enddo
+                   enddo
+
+                case default
+             end select mp3_select
+
+          case default
+       end select mp2_select
+
     case("mp_tempo","mp_nssl2m")
        call mpas_pool_get_dimension(state,'index_qi',index_qi)
        call mpas_pool_get_dimension(state,'index_qs',index_qs)
@@ -1335,22 +1382,7 @@
        enddo
        enddo
 
-       mp2_select: select case(trim(mp_scheme))
-          case("mp_thompson","mp_thompson_aerosols")
-             call mpas_pool_get_dimension(state,'index_ni',index_ni)
-             call mpas_pool_get_dimension(state,'index_nr',index_nr)
-             ni   => scalars(index_ni,:,:)
-             nr   => scalars(index_nr,:,:)
-
-             do j = jts,jte
-             do k = kts,kte
-             do i = its,ite
-                ni(k,i) = ni_p(i,k,j)
-                nr(k,i) = nr_p(i,k,j)
-             enddo
-             enddo
-             enddo
-
+       mp2a_select: select case(trim(mp_scheme))
           case("mp_tempo")
              call mpas_pool_get_dimension(state,'index_ni',index_ni)
              call mpas_pool_get_dimension(state,'index_nr',index_nr)
@@ -1476,36 +1508,8 @@
                 enddo
              endif
 
-             mp3_select: select case(trim(mp_scheme))
-                case("mp_thompson_aerosols")
-                   call mpas_pool_get_dimension(state,'index_nc'  ,index_nc  )
-                   call mpas_pool_get_dimension(state,'index_nifa',index_nifa)
-                   call mpas_pool_get_dimension(state,'index_nwfa',index_nwfa)
-                   nc   => scalars(index_nc,:,:)
-                   nifa => scalars(index_nifa,:,:)
-                   nwfa => scalars(index_nwfa,:,:)
-
-                   call mpas_pool_get_array(diag_physics,'nifa2d',nifa2d)
-                   call mpas_pool_get_array(diag_physics,'nwfa2d',nwfa2d)
-                   do j = jts,jte
-                   do i = its,ite
-                      nifa2d(i) = nifa2d_p(i,j)
-                      nwfa2d(i) = nwfa2d_p(i,j)
-                   enddo
-                   do k = kts, kte
-                   do i = its, ite
-                      nc(k,i)   = nc_p(i,k,j)
-                      nifa(k,i) = nifa_p(i,k,j)
-                      nwfa(k,i) = nwfa_p(i,k,j)
-                   enddo
-                   enddo
-                   enddo
-
-                case default
-             end select mp3_select
-
           case default
-       end select mp2_select
+       end select mp2a_select
 
     case default
  end select mp_select
@@ -1513,27 +1517,6 @@
 !end calculation of cloud microphysics tendencies:
  mp_tend_select: select case(trim(mp_scheme))
     case("mp_thompson","mp_thompson_aerosols","mp_wsm6")
-       call mpas_pool_get_array(tend_physics,'rthmpten',rthmpten)
-       call mpas_pool_get_array(tend_physics,'rqvmpten',rqvmpten)
-       call mpas_pool_get_array(tend_physics,'rqcmpten',rqcmpten)
-       call mpas_pool_get_array(tend_physics,'rqrmpten',rqrmpten)
-       call mpas_pool_get_array(tend_physics,'rqimpten',rqimpten)
-       call mpas_pool_get_array(tend_physics,'rqsmpten',rqsmpten)
-       call mpas_pool_get_array(tend_physics,'rqgmpten',rqgmpten)
-
-       do k = kts,kte
-       do i = its,ite
-          rthmpten(k,i) = (theta_m(k,i)/(1._RKIND+R_v/R_d*max(0._RKIND,qv(k,i)))-rthmpten(k,i))/dt_dyn
-          rqvmpten(k,i) = (qv(k,i)-rqvmpten(k,i))/dt_dyn
-          rqcmpten(k,i) = (qc(k,i)-rqcmpten(k,i))/dt_dyn
-          rqrmpten(k,i) = (qr(k,i)-rqrmpten(k,i))/dt_dyn
-          rqimpten(k,i) = (qi(k,i)-rqimpten(k,i))/dt_dyn
-          rqsmpten(k,i) = (qs(k,i)-rqsmpten(k,i))/dt_dyn
-          rqgmpten(k,i) = (qg(k,i)-rqgmpten(k,i))/dt_dyn
-       enddo
-       enddo
-
-    case("mp_tempo","mp_nssl2m")
        call mpas_pool_get_array(tend_physics,'rthmpten',rthmpten)
        call mpas_pool_get_array(tend_physics,'rqvmpten',rqvmpten)
        call mpas_pool_get_array(tend_physics,'rqcmpten',rqcmpten)
@@ -1566,17 +1549,6 @@
              enddo
              enddo
 
-          case("mp_tempo")
-             call mpas_pool_get_array(tend_physics,'rnimpten',rnimpten)
-             call mpas_pool_get_array(tend_physics,'rnrmpten',rnrmpten)
-
-             do k = kts,kte
-             do i = its,ite
-                rnimpten(k,i) = (ni(k,i)-rnimpten(k,i))/dt_dyn
-                rnrmpten(k,i) = (nr(k,i)-rnrmpten(k,i))/dt_dyn
-             enddo
-             enddo
-
              mp3_tend_select: select case(trim(mp_scheme))
                 case("mp_thompson_aerosols")
                    call mpas_pool_get_array(tend_physics,'rncmpten',rncmpten)
@@ -1590,7 +1562,47 @@
                       rnwfampten(k,i) = (nwfa(k,i)-rnwfampten(k,i))/dt_dyn
                    enddo
                    enddo
-                
+
+                case default
+             end select mp3_tend_select
+
+          case default
+       end select mp2_tend_select
+
+    case("mp_tempo","mp_nssl2m")
+       call mpas_pool_get_array(tend_physics,'rthmpten',rthmpten)
+       call mpas_pool_get_array(tend_physics,'rqvmpten',rqvmpten)
+       call mpas_pool_get_array(tend_physics,'rqcmpten',rqcmpten)
+       call mpas_pool_get_array(tend_physics,'rqrmpten',rqrmpten)
+       call mpas_pool_get_array(tend_physics,'rqimpten',rqimpten)
+       call mpas_pool_get_array(tend_physics,'rqsmpten',rqsmpten)
+       call mpas_pool_get_array(tend_physics,'rqgmpten',rqgmpten)
+
+       do k = kts,kte
+       do i = its,ite
+          rthmpten(k,i) = (theta_m(k,i)/(1._RKIND+R_v/R_d*max(0._RKIND,qv(k,i)))-rthmpten(k,i))/dt_dyn
+          rqvmpten(k,i) = (qv(k,i)-rqvmpten(k,i))/dt_dyn
+          rqcmpten(k,i) = (qc(k,i)-rqcmpten(k,i))/dt_dyn
+          rqrmpten(k,i) = (qr(k,i)-rqrmpten(k,i))/dt_dyn
+          rqimpten(k,i) = (qi(k,i)-rqimpten(k,i))/dt_dyn
+          rqsmpten(k,i) = (qs(k,i)-rqsmpten(k,i))/dt_dyn
+          rqgmpten(k,i) = (qg(k,i)-rqgmpten(k,i))/dt_dyn
+       enddo
+       enddo
+
+       mp2a_tend_select: select case(trim(mp_scheme))
+          case("mp_tempo")
+             call mpas_pool_get_array(tend_physics,'rnimpten',rnimpten)
+             call mpas_pool_get_array(tend_physics,'rnrmpten',rnrmpten)
+
+             do k = kts,kte
+             do i = its,ite
+                rnimpten(k,i) = (ni(k,i)-rnimpten(k,i))/dt_dyn
+                rnrmpten(k,i) = (nr(k,i)-rnrmpten(k,i))/dt_dyn
+             enddo
+             enddo
+
+             mp3a_tend_select: select case(trim(mp_scheme))
                 case("mp_tempo")
                    if(config_tempo_aerosolaware) then
                       call mpas_pool_get_array(tend_physics,'rncmpten',rncmpten)
@@ -1607,10 +1619,10 @@
                    endif
 
                 case default
-             end select mp3_tend_select
+             end select mp3a_tend_select
 
           case default
-       end select mp2_tend_select
+       end select mp2a_tend_select
 
     case default
  end select mp_tend_select

--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -1602,24 +1602,19 @@
              enddo
              enddo
 
-             mp3a_tend_select: select case(trim(mp_scheme))
-                case("mp_tempo")
-                   if(config_tempo_aerosolaware) then
-                      call mpas_pool_get_array(tend_physics,'rncmpten',rncmpten)
-                      call mpas_pool_get_array(tend_physics,'rnifampten',rnifampten)
-                      call mpas_pool_get_array(tend_physics,'rnwfampten',rnwfampten)
+             if(config_tempo_aerosolaware) then
+                call mpas_pool_get_array(tend_physics,'rncmpten',rncmpten)
+                call mpas_pool_get_array(tend_physics,'rnifampten',rnifampten)
+                call mpas_pool_get_array(tend_physics,'rnwfampten',rnwfampten)
 
-                      do k = kts,kte
-                      do i = its,ite
-                         rncmpten(k,i)   = (nc(k,i)-rncmpten(k,i))/dt_dyn
-                         rnifampten(k,i) = (nifa(k,i)-rnifampten(k,i))/dt_dyn
-                         rnwfampten(k,i) = (nwfa(k,i)-rnwfampten(k,i))/dt_dyn
-                      enddo
-                      enddo
-                   endif
-
-                case default
-             end select mp3a_tend_select
+                do k = kts,kte
+                do i = its,ite
+                   rncmpten(k,i)   = (nc(k,i)-rncmpten(k,i))/dt_dyn
+                   rnifampten(k,i) = (nifa(k,i)-rnifampten(k,i))/dt_dyn
+                   rnwfampten(k,i) = (nwfa(k,i)-rnwfampten(k,i))/dt_dyn
+                enddo
+                enddo
+             endif
 
           case default
        end select mp2a_tend_select

--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -36,9 +36,9 @@
 !
 ! add-ons and modifications to sourcecode:
 ! ----------------------------------------
-! * in subroutine MPAS_to_physics, moved the calculation of the local arrays qv_p,qc_p, and qr_p above the
+! * in subroutine MPAS_to_physics, moved the calculation of the local arrays qv_p,qc_p, and qr_p above the 
 !   calculation of th_p so that we do not need to use the pointer qv.
-! * in subroutine microphysics_from_MPAS, moved the calculation of the local arrays qv_p,qc_p, and qr_p above
+! * in subroutine microphysics_from_MPAS, moved the calculation of the local arrays qv_p,qc_p, and qr_p above 
 !   the calculation of th_p so that we do not need to use the pointer qv.
 ! * in subroutine microphysics_to_MPAS, since microphysics schemes update the temperature and water vapor
 !   mixing ratio, we first update the total pressure and exner functions. Then, we update the modified
@@ -50,15 +50,15 @@
 !   Laura D. Fowler (laura@ucar.edu) / 2014-04-22.
 ! * modified sourcecode to use pools.
 !   Laura D. Fowler (laura@ucar.edu) / 2014-05-15.
-! * added calculation of the surface pressure tendency. Moved the calculation of znu_p below the calculation
+! * added calculation of the surface pressure tendency. Moved the calculation of znu_p below the calculation 
 !   of the surface pressure to avoid dividing by zero if the surface pressure is not output in the init file.
-!   Laura D. Fowler (birch.mmm.ucar.ecu) / 2014-06-23.
+!   Laura D. Fowler (birch.mmm.ucar.ecu) / 2014-06-23. 
 ! * renamed module mpas_atmphys_interface_nhyd to mpas_atmphys_interface.
 !   Laura D. Fowler (laura@ucar.edu) / 2014-09-19.
-! * in subroutine microphysics_to_MPAS, reverted the calculation of cloud microphysics tendency rt_diabatic_tend,
+! * in subroutine microphysics_to_MPAS, reverted the calculation of cloud microphysics tendency rt_diabatic_tend, 
 !   and update of the state variables to git hash identifier 7a66f273e182f4. This change reflects the fact that
 !   we want to compute rt_diabatic_tend at constant volume.
-!   Laura D. Fowler (laura@ucar.edu) / 2014-01-015.
+!   Laura D. Fowler (laura@ucar.edu) / 2014-01-015. 
 ! * added the initialization of local variables needed in the parameterization of the MYNN surface layer scheme
 !   and planetary boundary layer scheme from WRF 3.6.1.
 !   Laura D. Fowler (laura@ucar.edu) / 2016-04-11.
@@ -109,7 +109,7 @@
  if(.not.allocated(w_p)    ) allocate(w_p(ims:ime,kms:kme,jms:jme)    )
  if(.not.allocated(pres2_p)) allocate(pres2_p(ims:ime,kms:kme,jms:jme))
  if(.not.allocated(t2_p)   ) allocate(t2_p(ims:ime,kms:kme,jms:jme)   )
-
+ 
  if(.not.allocated(qv_p)   ) allocate(qv_p(ims:ime,kms:kme,jms:jme)   )
  if(.not.allocated(qc_p)   ) allocate(qc_p(ims:ime,kms:kme,jms:jme)   )
  if(.not.allocated(qr_p)   ) allocate(qr_p(ims:ime,kms:kme,jms:jme)   )
@@ -155,7 +155,7 @@
  if(.not.allocated(pres2_hyd_p) ) allocate(pres2_hyd_p(ims:ime,kms:kme,jms:jme) )
  if(.not.allocated(pres2_hydd_p)) allocate(pres2_hydd_p(ims:ime,kms:kme,jms:jme))
  if(.not.allocated(znu_hyd_p)   ) allocate(znu_hyd_p(ims:ime,kms:kme,jms:jme)   )
-
+ 
  end subroutine allocate_forall_physics
 
 !=================================================================================================================
@@ -191,8 +191,8 @@
  if(allocated(t_p)     ) deallocate(t_p     )
  if(allocated(th_p)    ) deallocate(th_p    )
  if(allocated(al_p)    ) deallocate(al_p    )
- if(allocated(rho_p)   ) deallocate(rho_p   )
- if(allocated(rh_p)    ) deallocate(rh_p    )
+ if(allocated(rho_p)   ) deallocate(rho_p   ) 
+ if(allocated(rh_p)    ) deallocate(rh_p    ) 
  if(allocated(znu_p)   ) deallocate(znu_p   )
 
  if(allocated(w_p)     ) deallocate(w_p     )
@@ -243,7 +243,7 @@
  if(allocated(pres2_hyd_p) ) deallocate(pres2_hyd_p )
  if(allocated(pres2_hydd_p)) deallocate(pres2_hydd_p)
  if(allocated(znu_hyd_p)   ) deallocate(znu_hyd_p   )
-
+ 
  end subroutine deallocate_forall_physics
 
 !=================================================================================================================
@@ -518,7 +518,7 @@
                     * (rho1 - 0.5*(rho2-rho1)*tem1/(tem1+tem2))
     surface_pressure(i) = surface_pressure(i) + pressure_p(1,i) + pressure_b(1,i)
  enddo
-
+ 
  do k = kts,kte
  do i = its,ite
     znu_p(i,k,j)  = pres_p(i,k,j) / surface_pressure(i)
@@ -576,7 +576,7 @@
  do j = jts,jte
  do i = its,ite
     z0 = zgrid(k,i)
-    z1 = 0.5*(zgrid(k,i)+zgrid(k-1,i))
+    z1 = 0.5*(zgrid(k,i)+zgrid(k-1,i)) 
     z2 = 0.5*(zgrid(k-1,i)+zgrid(k-2,i))
     w1 = (z0-z2)/(z1-z2)
     w2 = 1.-w1
@@ -592,7 +592,7 @@
  do j = jts,jte
  do i = its,ite
     z0 = zgrid(k,i)
-    z1 = 0.5*(zgrid(k,i)+zgrid(k+1,i))
+    z1 = 0.5*(zgrid(k,i)+zgrid(k+1,i)) 
     z2 = 0.5*(zgrid(k+1,i)+zgrid(k+2,i))
     w1 = (z0-z2)/(z1-z2)
     w2 = 1.-w1
@@ -625,7 +625,7 @@
     psfc_hydd_p(i,j) = pres2_hydd_p(i,1,j)
     !znu:
     do k = kte,1,-1
-       znu_hyd_p(i,k,j) = pres_hyd_p(i,k,j) / psfc_hyd_p(i,j)
+       znu_hyd_p(i,k,j) = pres_hyd_p(i,k,j) / psfc_hyd_p(i,j) 
     enddo
  enddo
  enddo
@@ -633,7 +633,7 @@
 !save the model-top pressure:
  do j = jts,jte
  do i = its,ite
-    plrad(i) = pres2_p(i,kte+1,j)
+    plrad(i) = pres2_p(i,kte+1,j) 
  enddo
  enddo
 
@@ -672,10 +672,13 @@
  real(kind=RKIND),dimension(:,:),pointer  :: zgrid,w
  real(kind=RKIND),dimension(:,:),pointer  :: zz,exner,pressure_b
  real(kind=RKIND),dimension(:,:),pointer  :: rho_zz,theta_m,pressure_p
- real(kind=RKIND),dimension(:,:),pointer  :: qv,qc,qr,qi,qs,qg,qh
- real(kind=RKIND),dimension(:,:),pointer  :: ni,nr,nc,ns,ng,nh,nccn,nwfa,nifa
+ real(kind=RKIND),dimension(:,:),pointer  :: qv,qc,qr,qi,qs,qg
+ real(kind=RKIND),dimension(:,:),pointer  :: qh
+ real(kind=RKIND),dimension(:,:),pointer  :: nc,ni,nr,nifa,nwfa
+ real(kind=RKIND),dimension(:,:),pointer  :: ns,ng,nh,nccn
  real(kind=RKIND),dimension(:,:),pointer  :: volg,volh,zrw,zgw,zhw
- real(kind=RKIND),dimension(:,:),pointer  :: rainprod,evapprod,refl10cm
+ real(kind=RKIND),dimension(:,:),pointer  :: rainprod,evapprod
+ real(kind=RKIND),dimension(:,:),pointer  :: refl10cm
  real(kind=RKIND),dimension(:,:),pointer  :: re_cloud,re_ice,re_snow
  real(kind=RKIND),dimension(:,:),pointer  :: rthmpten,rqvmpten,rqcmpten,rqrmpten,rqimpten,rqsmpten,rqgmpten
  real(kind=RKIND),dimension(:,:),pointer  :: rncmpten,rnimpten,rnrmpten,rnifampten,rnwfampten
@@ -702,10 +705,9 @@
  call mpas_pool_get_array(state,'theta_m',theta_m,time_lev)
  call mpas_pool_get_array(state,'w'      ,w      ,time_lev)
 
- call mpas_pool_get_dimension(state,'index_qv'  ,index_qv  )
- call mpas_pool_get_dimension(state,'index_qc'  ,index_qc  )
- call mpas_pool_get_dimension(state,'index_qr'  ,index_qr  )
-
+ call mpas_pool_get_dimension(state,'index_qv',index_qv)
+ call mpas_pool_get_dimension(state,'index_qc',index_qc)
+ call mpas_pool_get_dimension(state,'index_qr',index_qr)
  call mpas_pool_get_array(state,'scalars',scalars,time_lev)
  qv => scalars(index_qv,:,:)
  qc => scalars(index_qc,:,:)
@@ -747,37 +749,7 @@
        call mpas_pool_get_array(diag_physics,'re_cloud',re_cloud)
        call mpas_pool_get_array(diag_physics,'re_ice'  ,re_ice  )
        call mpas_pool_get_array(diag_physics,'re_snow' ,re_snow )
-
-       do j = jts, jte
-       do k = kts, kte
-       do i = its, ite
-          qi_p(i,k,j) = qi(k,i)
-          qs_p(i,k,j) = qs(k,i)
-          qg_p(i,k,j) = qg(k,i)
-
-          rainprod_p(i,k,j) = rainprod(k,i)
-          evapprod_p(i,k,j) = evapprod(k,k)
-          recloud_p(i,k,j)  = re_cloud(k,i)
-          reice_p(i,k,j)    = re_ice(k,i)
-          resnow_p(i,k,j)   = re_snow(k,i)
-       enddo
-       enddo
-       enddo
-
-    case("mp_tempo","mp_nssl2m")
-       call mpas_pool_get_dimension(state,'index_qi',index_qi)
-       call mpas_pool_get_dimension(state,'index_qs',index_qs)
-       call mpas_pool_get_dimension(state,'index_qg',index_qg)
-       qi => scalars(index_qi,:,:)
-       qs => scalars(index_qs,:,:)
-       qg => scalars(index_qg,:,:)
-
-       call mpas_pool_get_array(diag_physics,'rainprod',rainprod)
-       call mpas_pool_get_array(diag_physics,'evapprod',evapprod)
-       call mpas_pool_get_array(diag_physics,'re_cloud',re_cloud)
-       call mpas_pool_get_array(diag_physics,'re_ice'  ,re_ice  )
-       call mpas_pool_get_array(diag_physics,'re_snow' ,re_snow )
-       call mpas_pool_get_array(diag_physics,'refl10cm' ,refl10cm )
+       call mpas_pool_get_array(diag_physics,'refl10cm',refl10cm)
 
        do j = jts, jte
        do k = kts, kte
@@ -818,6 +790,70 @@
              enddo
              enddo
 
+          mp3_select: select case(trim(mp_scheme))
+             case("mp_thompson_aerosols")
+                call mpas_pool_get_dimension(state,'index_nc'  ,index_nc  )
+                call mpas_pool_get_dimension(state,'index_nifa',index_nifa)
+                call mpas_pool_get_dimension(state,'index_nwfa',index_nwfa)
+                nc   => scalars(index_nc,:,:)
+                nifa => scalars(index_nifa,:,:)
+                nwfa => scalars(index_nwfa,:,:)
+
+                call mpas_pool_get_array(diag_physics,'nifa2d',nifa2d)
+                call mpas_pool_get_array(diag_physics,'nwfa2d',nwfa2d)
+                do j = jts,jte
+                do i = its,ite
+                   nifa2d_p(i,j) = nifa2d(i)
+                   nwfa2d_p(i,j) = nwfa2d(i)
+                enddo
+                do k = kts, kte
+                do i = its, ite
+                   nc_p(i,k,j) = nc(k,i)
+                   nifa_p(i,k,j) = nifa(k,i)
+                   nwfa_p(i,k,j) = nwfa(k,i)
+                enddo
+                enddo
+                enddo
+
+             case default
+          end select mp3_select
+
+          case default
+       end select mp2_select
+
+    case("mp_tempo","mp_nssl2m")
+       call mpas_pool_get_dimension(state,'index_qi',index_qi)
+       call mpas_pool_get_dimension(state,'index_qs',index_qs)
+       call mpas_pool_get_dimension(state,'index_qg',index_qg)
+       qi => scalars(index_qi,:,:)
+       qs => scalars(index_qs,:,:)
+       qg => scalars(index_qg,:,:)
+
+       call mpas_pool_get_array(diag_physics,'rainprod',rainprod)
+       call mpas_pool_get_array(diag_physics,'evapprod',evapprod)
+       call mpas_pool_get_array(diag_physics,'re_cloud',re_cloud)
+       call mpas_pool_get_array(diag_physics,'re_ice'  ,re_ice  )
+       call mpas_pool_get_array(diag_physics,'re_snow' ,re_snow )
+       call mpas_pool_get_array(diag_physics,'refl10cm' ,refl10cm )
+
+       do j = jts, jte
+       do k = kts, kte
+       do i = its, ite
+          qi_p(i,k,j) = qi(k,i)
+          qs_p(i,k,j) = qs(k,i)
+          qg_p(i,k,j) = qg(k,i)
+
+          rainprod_p(i,k,j) = rainprod(k,i)
+          evapprod_p(i,k,j) = evapprod(k,k)
+          recloud_p(i,k,j)  = re_cloud(k,i)
+          reice_p(i,k,j)    = re_ice(k,i)
+          resnow_p(i,k,j)   = re_snow(k,i)
+          refl10cm_p(i,k,j) = refl10cm(k,i)
+       enddo
+       enddo
+       enddo
+
+       mp2a_select: select case(trim(mp_scheme))
           case("mp_tempo")
              call mpas_pool_get_dimension(state,'index_ni',index_ni)
              call mpas_pool_get_dimension(state,'index_nr',index_nr)
@@ -942,36 +978,8 @@
                 enddo
              endif
 
-          mp3_select: select case(trim(mp_scheme))
-             case("mp_thompson_aerosols")
-                call mpas_pool_get_dimension(state,'index_nc'  ,index_nc  )
-                call mpas_pool_get_dimension(state,'index_nifa',index_nifa)
-                call mpas_pool_get_dimension(state,'index_nwfa',index_nwfa)
-                nc   => scalars(index_nc,:,:)
-                nifa => scalars(index_nifa,:,:)
-                nwfa => scalars(index_nwfa,:,:)
-
-                call mpas_pool_get_array(diag_physics,'nifa2d',nifa2d)
-                call mpas_pool_get_array(diag_physics,'nwfa2d',nwfa2d)
-                do j = jts,jte
-                do i = its,ite
-                   nifa2d_p(i,j) = nifa2d(i)
-                   nwfa2d_p(i,j) = nwfa2d(i)
-                enddo
-                do k = kts, kte
-                do i = its, ite
-                   nc_p(i,k,j) = nc(k,i)
-                   nifa_p(i,k,j) = nifa(k,i)
-                   nwfa_p(i,k,j) = nwfa(k,i)
-                enddo
-                enddo
-                enddo
-
-             case default
-          end select mp3_select
-
           case default
-       end select mp2_select
+       end select mp2a_select
 
     case default
  end select mp_select
@@ -979,27 +987,6 @@
 !begin calculation of cloud microphysics tendencies:
  mp_tend_select: select case(trim(mp_scheme))
     case("mp_thompson","mp_thompson_aerosols","mp_wsm6")
-       call mpas_pool_get_array(tend_physics,'rthmpten',rthmpten)
-       call mpas_pool_get_array(tend_physics,'rqvmpten',rqvmpten)
-       call mpas_pool_get_array(tend_physics,'rqcmpten',rqcmpten)
-       call mpas_pool_get_array(tend_physics,'rqrmpten',rqrmpten)
-       call mpas_pool_get_array(tend_physics,'rqimpten',rqimpten)
-       call mpas_pool_get_array(tend_physics,'rqsmpten',rqsmpten)
-       call mpas_pool_get_array(tend_physics,'rqgmpten',rqgmpten)
-
-       do k = kts,kte
-       do i = its,ite
-          rthmpten(k,i) = theta_m(k,i)/(1._RKIND+R_v/R_d*max(0._RKIND,qv(k,i)))
-          rqvmpten(k,i) = qv(k,i)
-          rqcmpten(k,i) = qc(k,i)
-          rqrmpten(k,i) = qr(k,i)
-          rqimpten(k,i) = qi(k,i)
-          rqsmpten(k,i) = qs(k,i)
-          rqgmpten(k,i) = qg(k,i)
-       enddo
-       enddo
-
-    case("mp_tempo","mp_nssl2m")
        call mpas_pool_get_array(tend_physics,'rthmpten',rthmpten)
        call mpas_pool_get_array(tend_physics,'rqvmpten',rqvmpten)
        call mpas_pool_get_array(tend_physics,'rqcmpten',rqcmpten)
@@ -1032,17 +1019,6 @@
              enddo
              enddo
 
-          case("mp_tempo","mp_nssl2m")
-             call mpas_pool_get_array(tend_physics,'rnimpten',rnimpten)
-             call mpas_pool_get_array(tend_physics,'rnrmpten',rnrmpten)
-
-             do k = kts,kte
-             do i = its,ite
-                rnimpten(k,i) = ni(k,i)
-                rnrmpten(k,i) = nr(k,i)
-             enddo
-             enddo
-
              mp3_tend_select: select case(trim(mp_scheme))
                 case("mp_thompson_aerosols")
                    call mpas_pool_get_array(tend_physics,'rncmpten',rncmpten)
@@ -1057,35 +1033,70 @@
                    enddo
                    enddo
 
-                case("mp_tempo")
-                   if(config_tempo_aerosolaware) then
-                      call mpas_pool_get_array(tend_physics,'rncmpten',rncmpten)
-                      call mpas_pool_get_array(tend_physics,'rnifampten',rnifampten)
-                      call mpas_pool_get_array(tend_physics,'rnwfampten',rnwfampten)
-
-                      do k = kts,kte
-                      do i = its,ite
-                         rncmpten(k,i) = nc(k,i)
-                         rnifampten(k,i) = nifa(k,i)
-                         rnwfampten(k,i) = nwfa(k,i)
-                      enddo
-                      enddo
-                   endif
-
-                case("mp_nssl2m")
-                   call mpas_pool_get_array(tend_physics,'rncmpten',rncmpten)
-
-                   do k = kts,kte
-                   do i = its,ite
-                      rncmpten(k,i) = nc(k,i)
-                   enddo
-                   enddo
-
                 case default
              end select mp3_tend_select
 
           case default
        end select mp2_tend_select
+
+    case("mp_tempo","mp_nssl2m")
+       call mpas_pool_get_array(tend_physics,'rthmpten',rthmpten)
+       call mpas_pool_get_array(tend_physics,'rqvmpten',rqvmpten)
+       call mpas_pool_get_array(tend_physics,'rqcmpten',rqcmpten)
+       call mpas_pool_get_array(tend_physics,'rqrmpten',rqrmpten)
+       call mpas_pool_get_array(tend_physics,'rqimpten',rqimpten)
+       call mpas_pool_get_array(tend_physics,'rqsmpten',rqsmpten)
+       call mpas_pool_get_array(tend_physics,'rqgmpten',rqgmpten)
+
+       do k = kts,kte
+       do i = its,ite
+          rthmpten(k,i) = theta_m(k,i)/(1._RKIND+R_v/R_d*max(0._RKIND,qv(k,i)))
+          rqvmpten(k,i) = qv(k,i)
+          rqcmpten(k,i) = qc(k,i)
+          rqrmpten(k,i) = qr(k,i)
+          rqimpten(k,i) = qi(k,i)
+          rqsmpten(k,i) = qs(k,i)
+          rqgmpten(k,i) = qg(k,i)
+       enddo
+       enddo
+
+       call mpas_pool_get_array(tend_physics,'rnimpten',rnimpten)
+       call mpas_pool_get_array(tend_physics,'rnrmpten',rnrmpten)
+
+       do k = kts,kte
+       do i = its,ite
+          rnimpten(k,i) = ni(k,i)
+          rnrmpten(k,i) = nr(k,i)
+       enddo
+       enddo
+
+       mp2a_tend_select: select case(trim(mp_scheme))
+          case("mp_tempo")
+             if(config_tempo_aerosolaware) then
+                call mpas_pool_get_array(tend_physics,'rncmpten',rncmpten)
+                call mpas_pool_get_array(tend_physics,'rnifampten',rnifampten)
+                call mpas_pool_get_array(tend_physics,'rnwfampten',rnwfampten)
+
+                do k = kts,kte
+                do i = its,ite
+                   rncmpten(k,i) = nc(k,i)
+                   rnifampten(k,i) = nifa(k,i)
+                   rnwfampten(k,i) = nwfa(k,i)
+                enddo
+                enddo
+             endif
+
+           case("mp_nssl2m")
+             call mpas_pool_get_array(tend_physics,'rncmpten',rncmpten)
+
+             do k = kts,kte
+             do i = its,ite
+                rncmpten(k,i) = nc(k,i)
+             enddo
+             enddo
+
+          case default
+       end select mp2a_tend_select
 
     case default
  end select mp_tend_select
@@ -1130,10 +1141,13 @@
  real(kind=RKIND),dimension(:,:),pointer  :: rho_zz,theta_m,pressure_p
  real(kind=RKIND),dimension(:,:),pointer  :: rt_diabatic_tend
  real(kind=RKIND),dimension(:,:),pointer  :: dtheta_dt_mp
- real(kind=RKIND),dimension(:,:),pointer  :: qv,qc,qr,qi,qs,qg,qh
- real(kind=RKIND),dimension(:,:),pointer  :: ni,nr,nc,ns,ng,nh,nccn,nwfa,nifa
+ real(kind=RKIND),dimension(:,:),pointer  :: qv,qc,qr,qi,qs,qg
+ real(kind=RKIND),dimension(:,:),pointer  :: qh
+ real(kind=RKIND),dimension(:,:),pointer  :: nc,ni,nr,nifa,nwfa
+ real(kind=RKIND),dimension(:,:),pointer  :: ns,ng,nh,nccn
  real(kind=RKIND),dimension(:,:),pointer  :: volg,volh,zrw,zgw,zhw
- real(kind=RKIND),dimension(:,:),pointer  :: rainprod,evapprod,refl10cm
+ real(kind=RKIND),dimension(:,:),pointer  :: rainprod,evapprod
+ real(kind=RKIND),dimension(:,:),pointer  :: refl10cm
  real(kind=RKIND),dimension(:,:),pointer  :: re_cloud,re_ice,re_snow
  real(kind=RKIND),dimension(:,:),pointer  :: rthmpten,rqvmpten,rqcmpten,rqrmpten,rqimpten,rqsmpten,rqgmpten
  real(kind=RKIND),dimension(:,:),pointer  :: rncmpten,rnimpten,rnrmpten,rnifampten,rnwfampten

--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -763,7 +763,7 @@
           qg_p(i,k,j) = qg(k,i)
 
           rainprod_p(i,k,j) = rainprod(k,i)
-          evapprod_p(i,k,j) = evapprod(k,k)
+          evapprod_p(i,k,j) = evapprod(k,i)
           recloud_p(i,k,j)  = re_cloud(k,i)
           reice_p(i,k,j)    = re_ice(k,i)
           resnow_p(i,k,j)   = re_snow(k,i)
@@ -848,7 +848,7 @@
           qg_p(i,k,j) = qg(k,i)
 
           rainprod_p(i,k,j) = rainprod(k,i)
-          evapprod_p(i,k,j) = evapprod(k,k)
+          evapprod_p(i,k,j) = evapprod(k,i)
           recloud_p(i,k,j)  = re_cloud(k,i)
           reice_p(i,k,j)    = re_ice(k,i)
           resnow_p(i,k,j)   = re_snow(k,i)


### PR DESCRIPTION
Nested case statements were causing an issue with allocation of arrays necessary for Thompson microphysics. This cleans up the case statements, preserving the NCAR code and extending for TEMPO and NSSL MP. Because GF convection code is changed, we won't be able to reproduce NCAR suite so a new test will be proposed.

In addition, a few other things are added (may be bugs):
- add mp_thompson_aers to the registry for nr and tend_nr (I think these came from the v8.2.2 merge)
- clean up some diff lines in mpas_atmphys_interface
- add refl10cm to the Thompson allocation in a few places

Addresses #75 

No answer changes to the existing tests, but the convection permitting test will now run. TBD what we should compare it to since GF is changed from the NCAR version.

<details>
  <summary>
    regression test case results
  </summary>
  
```


     version_to_compare = v8.2.2-3.10
   gsl_version_baseline = v8.2.2-3.9
  ncar_version_baseline = v8.2.2
         test_directory = /lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/
 gsl_baseline_directory = /lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/
ncar_baseline_directory = /lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/
           compile_flag = -intdebug
         test_repo_name = gsl

######################################################################
# compare to previous GSL CONUS mesoscale_reference baselines A1GSL   
######################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/gsl-v8.2.2-3.10-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.9-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/gsl-v8.2.2-3.10-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.9-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/gsl-v8.2.2-3.10-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.9-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

#############################################################################
# compare to previous GSL CONUS convection_permitting_none baselines F1GSL   
#############################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/gsl-v8.2.2-3.10-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.9-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/gsl-v8.2.2-3.10-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.9-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/gsl-v8.2.2-3.10-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.9-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

#############################################################################
# compare to previous GSL CONUS mesoscale_reference_noahmp baselines E1GSL   
#############################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/gsl-v8.2.2-3.10-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.9-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/gsl-v8.2.2-3.10-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.9-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/gsl-v8.2.2-3.10-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.9-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

######################################################################
# compare to previous GSL CONUS hrrrv5 GFS baselines C5GSL            
######################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/gsl-v8.2.2-3.10-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.9-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/gsl-v8.2.2-3.10-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.9-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/gsl-v8.2.2-3.10-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.9-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

######################################################################
# compare to previous GSL CONUS hrrrv5 RAP winter baselines C7GSL     
######################################################################

  === history.2024-02-02_18.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/gsl-v8.2.2-3.10-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.9-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.00.00.nc" are identical.

  === history.2024-02-02_18.12.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/gsl-v8.2.2-3.10-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.9-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.12.00.nc" are identical.

  === history.2024-02-02_19.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/gsl-v8.2.2-3.10-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_19.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.9-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_19.00.00.nc" are identical.

######################################################################
# compare to previous GSL CONUS hrrrv5 RAP summer baselines C8GSL     
######################################################################

  === history.2024-08-15_18.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/gsl-v8.2.2-3.10-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.9-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.00.00.nc" are identical.

  === history.2024-08-15_18.12.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/gsl-v8.2.2-3.10-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.9-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.12.00.nc" are identical.

  === history.2024-08-15_19.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/gsl-v8.2.2-3.10-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_19.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.9-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_19.00.00.nc" are identical.

########################################################################
# compare to previous NCAR CONUS mesoscale_reference baselines A1NCAR   
########################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/gsl-v8.2.2-3.10-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.2.2-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/gsl-v8.2.2-3.10-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.2.2-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/gsl-v8.2.2-3.10-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.2.2-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

###############################################################################
# compare to previous NCAR CONUS convection_permitting_none baselines F1NCAR   
###############################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/gsl-v8.2.2-3.10-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.2.2-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/gsl-v8.2.2-3.10-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.2.2-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/gsl-v8.2.2-3.10-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.2.2-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.



```
</details>
