### PR TITLE
Passing knob_ugwp_tauamp into ugwpv1_ngw_init as namelist variable

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,8 @@
 	url = https://github.com/NCAR/TEMPO.git
 [submodule "src/core_atmosphere/physics/UGWP"]
 	path = src/core_atmosphere/physics/UGWP
-	url = https://github.com/mdtoyNOAA/UGWP.git
+	url = https://github.com/NOAA-GSL/UGWP.git
+        branch = main_knob_ugwp_tauamp_namelist
 [submodule "src/core_atmosphere/physics/MYNN-EDMF"]
 	path = src/core_atmosphere/physics/MYNN-EDMF
 	url = https://github.com/NCAR/MYNN-EDMF.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 [submodule "src/core_atmosphere/physics/UGWP"]
 	path = src/core_atmosphere/physics/UGWP
 	url = https://github.com/NOAA-GSL/UGWP.git
-        branch = main_knob_ugwp_tauamp_namelist
+        branch = main_MPAS_2024_12_23
 [submodule "src/core_atmosphere/physics/MYNN-EDMF"]
 	path = src/core_atmosphere/physics/MYNN-EDMF
 	url = https://github.com/NCAR/MYNN-EDMF.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,6 @@
 [submodule "src/core_atmosphere/physics/UGWP"]
 	path = src/core_atmosphere/physics/UGWP
 	url = https://github.com/NOAA-GSL/UGWP.git
-        branch = main_MPAS_2024_12_23
 [submodule "src/core_atmosphere/physics/MYNN-EDMF"]
 	path = src/core_atmosphere/physics/MYNN-EDMF
 	url = https://github.com/NCAR/MYNN-EDMF.git

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MPAS-v8.2.2-3.3
+MPAS-v8.2.2-3.4
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for
 developing atmosphere, ocean, and other earth-system simulation components for

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.2.2-3.3">
+<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.2.2-3.4">
 
 
 <!-- **************************************************************************************** -->

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -2503,6 +2503,11 @@
                      description="logical for non-stationary gravity wave drag scheme"
                      possible_values=".true. or .false."/>
 
+                <nml_option name="config_knob_ugwp_tauamp" type="real" default_value="0.13e-3" in_defaults="false"
+                     units="-"
+                     description="non-stationary gravity wave drag absolute momentum flux at launch level"
+                     possible_values="Non-negative real values"/>
+
                 <nml_option name="config_ugwp_diags" type="logical" default_value="false" in_defaults="false"
                      units="-"
                      description="logical for outputting ugwp drag suite diagnostic variables"

--- a/src/core_atmosphere/physics/mpas_atmphys_init.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_init.F
@@ -144,6 +144,7 @@ use mpas_stream_manager
  character(len=StrKIND),pointer:: gwdo_scheme
  logical,pointer:: ngw_scheme
  integer,pointer:: ntau_d1y
+ real(kind=RKIND),pointer:: knob_ugwp_tauamp
  real(kind=RKIND),dimension(:),pointer:: ugwp_taulat
  integer,dimension(:),pointer:: jindx1_tau, jindx2_tau
  real(kind=RKIND),dimension(:),pointer:: ddy_j1tau, ddy_j2tau
@@ -440,6 +441,7 @@ use mpas_stream_manager
        call mpas_log_write('Initializing non-stationary GWD scheme',masterOnly=.true.)
        call MPAS_stream_mgr_read(stream_manager, streamID='ugwp_ngw_in', whence=MPAS_STREAM_NEAREST, ierr=ierr)
        call MPAS_stream_mgr_reset_alarms(stream_manager, streamID='ugwp_ngw_in', direction=MPAS_STREAM_INPUT, ierr=ierr)
+       call mpas_pool_get_config(configs,'config_knob_ugwp_tauamp', knob_ugwp_tauamp)
        call mpas_pool_get_dimension(mesh,'lat',ntau_d1y)
        call mpas_pool_get_array(ngw_input,'LATS',ugwp_taulat)
        call mpas_pool_get_array(ngw_input,'jindx1_tau'  ,jindx1_tau  )
@@ -448,8 +450,8 @@ use mpas_stream_manager
        call mpas_pool_get_array(ngw_input,'ddy_j2tau'   ,ddy_j2tau   )
        call mpas_pool_get_array(mesh,'latCell',latCell)
        call mpas_log_write('--- Initializing UGWP non-stationary GWD parameters ---',masterOnly=.true.)
-       call ugwpv1_ngw_init(latCell,nVertLevels,config_dt,rdzw,dzu,           &
-               ntau_d1y,ugwp_taulat,jindx1_tau,jindx2_tau,ddy_j1tau,ddy_j2tau)
+       call ugwpv1_ngw_init(latCell,nVertLevels,config_dt,rdzw,dzu,ntau_d1y,          &
+               knob_ugwp_tauamp,ugwp_taulat,jindx1_tau,jindx2_tau,ddy_j1tau,ddy_j2tau)
        call mpas_log_write('--- UGWP non-stationary GWD parameters initialized ---',masterOnly=.true.)
     endif
  endif

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.2.2-3.3">
+<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.2.2-3.4">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->


### PR DESCRIPTION
Modified code to pass in knob_ugwp_tauamp non-stationary GWD variable as a namelist option.  Files modified:
src/core_atmosphere/Registry.xml
src/core_atmosphere/physics/mpas_atmphys_init.F

Updated .gitmodules to point to new UGWP submodule location at: https://github.com/NOAA-GSL/UGWP.git
and now pointing to updated UGWP version.

This code has been tested on Jet with Intel compiler.  There are no changes to the baseline.

'mpas_testcase' tests passed, which demonstrate no changes to baseline:

<details>
  <summary>
    regression test case results
  </summary>
  
```

     version_to_compare = v8.2.2-3.4
   gsl_version_baseline = v8.2.2-3.3
  ncar_version_baseline = v8.2.2
         test_directory = /lfs5/BMC/rtwbl/mtoy/git_local/MPAS-Model/mpas_testcase/run_case/
 gsl_baseline_directory = /lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/
ncar_baseline_directory = /lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/
           compile_flag = -intdebug
         test_repo_name = gsl

######################################################################
# compare to previous GSL CONUS mesoscale_reference baselines A1GSL   
######################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/lfs5/BMC/rtwbl/mtoy/git_local/MPAS-Model/mpas_testcase/run_case/gsl-v8.2.2-3.4-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.3-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/lfs5/BMC/rtwbl/mtoy/git_local/MPAS-Model/mpas_testcase/run_case/gsl-v8.2.2-3.4-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.3-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/lfs5/BMC/rtwbl/mtoy/git_local/MPAS-Model/mpas_testcase/run_case/gsl-v8.2.2-3.4-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.3-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

#############################################################################
# compare to previous GSL CONUS mesoscale_reference_noahmp baselines E1GSL   
#############################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/lfs5/BMC/rtwbl/mtoy/git_local/MPAS-Model/mpas_testcase/run_case/gsl-v8.2.2-3.4-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.3-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/lfs5/BMC/rtwbl/mtoy/git_local/MPAS-Model/mpas_testcase/run_case/gsl-v8.2.2-3.4-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.3-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/lfs5/BMC/rtwbl/mtoy/git_local/MPAS-Model/mpas_testcase/run_case/gsl-v8.2.2-3.4-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.3-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

######################################################################
# compare to previous GSL CONUS hrrrv5 GFS baselines C5GSL            
######################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/lfs5/BMC/rtwbl/mtoy/git_local/MPAS-Model/mpas_testcase/run_case/gsl-v8.2.2-3.4-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.3-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/lfs5/BMC/rtwbl/mtoy/git_local/MPAS-Model/mpas_testcase/run_case/gsl-v8.2.2-3.4-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.3-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/lfs5/BMC/rtwbl/mtoy/git_local/MPAS-Model/mpas_testcase/run_case/gsl-v8.2.2-3.4-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.3-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

######################################################################
# compare to previous GSL CONUS hrrrv5 RAP winter baselines C7GSL     
######################################################################

  === history.2024-02-02_18.00.00.nc comparison
Files "/lfs5/BMC/rtwbl/mtoy/git_local/MPAS-Model/mpas_testcase/run_case/gsl-v8.2.2-3.4-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.3-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.00.00.nc" are identical.

  === history.2024-02-02_18.12.00.nc comparison
Files "/lfs5/BMC/rtwbl/mtoy/git_local/MPAS-Model/mpas_testcase/run_case/gsl-v8.2.2-3.4-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.3-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.12.00.nc" are identical.

  === history.2024-02-02_19.00.00.nc comparison
Files "/lfs5/BMC/rtwbl/mtoy/git_local/MPAS-Model/mpas_testcase/run_case/gsl-v8.2.2-3.4-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_19.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.3-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_19.00.00.nc" are identical.

######################################################################
# compare to previous GSL CONUS hrrrv5 RAP winter baselines C8GSL     
######################################################################

  === history.2024-08-15_18.00.00.nc comparison
Files "/lfs5/BMC/rtwbl/mtoy/git_local/MPAS-Model/mpas_testcase/run_case/gsl-v8.2.2-3.4-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.3-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.00.00.nc" are identical.

  === history.2024-08-15_18.12.00.nc comparison
Files "/lfs5/BMC/rtwbl/mtoy/git_local/MPAS-Model/mpas_testcase/run_case/gsl-v8.2.2-3.4-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.3-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.12.00.nc" are identical.

  === history.2024-08-15_19.00.00.nc comparison
Files "/lfs5/BMC/rtwbl/mtoy/git_local/MPAS-Model/mpas_testcase/run_case/gsl-v8.2.2-3.4-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_19.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.2.2-3.3-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_19.00.00.nc" are identical.

########################################################################
# compare to previous NCAR CONUS mesoscale_reference baselines A1NCAR   
########################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/lfs5/BMC/rtwbl/mtoy/git_local/MPAS-Model/mpas_testcase/run_case/gsl-v8.2.2-3.4-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.2.2-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/lfs5/BMC/rtwbl/mtoy/git_local/MPAS-Model/mpas_testcase/run_case/gsl-v8.2.2-3.4-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.2.2-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/lfs5/BMC/rtwbl/mtoy/git_local/MPAS-Model/mpas_testcase/run_case/gsl-v8.2.2-3.4-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.2.2-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

```
</details>
