### PR TITLE
add options for treatment of w on lateral boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MPAS-v8.3.0-1.1
+MPAS-v8.3.0-1.2
 ====
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -303,6 +303,11 @@
                      units="-"
                      description="Whether to apply lateral boundary conditions"
                      possible_values="true or false; this option must be set to true for limited-area simulations and false for global simulations"/>
+
+                <nml_option name="config_lbc_w" type="character" default_value="nearest"
+                     units="-"
+                     description="Options for w on lateral boundaries"
+                     possible_values="`nearest',`zero'"/>
 	</nml_record>
 
         <nml_record name="io" in_defaults="true">

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.3.0-1.1">
+<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.3.0-1.2">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -1477,7 +1477,7 @@ module atm_time_integration
 
 !$OMP PARALLEL DO
               do thread=1,nThreads
-                 call atm_zero_gradient_w_bdy( state, mesh, &
+                 call atm_zero_gradient_w_bdy( state, mesh, block % configs, &
                                                cellSolveThreadStart(thread), cellSolveThreadEnd(thread) )
               end do
 !$OMP END PARALLEL DO
@@ -7194,7 +7194,7 @@ module atm_time_integration
 !
 ! these next 2 routines set an approximate zero gradient boundary condition for w for regional_MPAS
 !
-   subroutine atm_zero_gradient_w_bdy( state, mesh, cellSolveStart, cellSolveEnd )
+   subroutine atm_zero_gradient_w_bdy( state, mesh, configs, cellSolveStart, cellSolveEnd )
 
       ! reconstitute state variables from acoustic-step perturbation variables
       ! after the acoustic steps.  The perturbation variables were originally set in
@@ -7205,25 +7205,28 @@ module atm_time_integration
 
       type (mpas_pool_type), intent(inout) :: state
       type (mpas_pool_type), intent(inout) :: mesh
+      type (mpas_pool_type), intent(in)    :: configs
       integer, intent(in) :: cellSolveStart, cellSolveEnd
 
       real (kind=RKIND), dimension(:,:), pointer :: w
 
       integer, dimension(:), pointer :: bdyMaskCell, nearestRelaxationCell
       integer, pointer :: nCells
+      character (len=StrKIND), pointer :: config_lbc_w
 
       call mpas_pool_get_array(state, 'w', w, 2)
       call mpas_pool_get_array(mesh, 'bdyMaskCell', bdyMaskCell)
       call mpas_pool_get_array(mesh, 'nearestRelaxationCell', nearestRelaxationCell)
       call mpas_pool_get_dimension(mesh, 'nCells', nCells)
+      call mpas_pool_get_config(configs, 'config_lbc_w', config_lbc_w)
 
-      call atm_zero_gradient_w_bdy_work( w, bdyMaskCell, nearestRelaxationCell, nCells, cellSolveStart, cellSolveEnd )
+      call atm_zero_gradient_w_bdy_work( w, bdyMaskCell, nearestRelaxationCell, nCells, cellSolveStart, cellSolveEnd, config_lbc_w )
 
    end subroutine atm_zero_gradient_w_bdy
 
 !-------------------------------------------------------------------------
 
-   subroutine atm_zero_gradient_w_bdy_work( w, bdyMaskCell, nearestRelaxationCell, nCells, cellSolveStart, cellSolveEnd )
+   subroutine atm_zero_gradient_w_bdy_work( w, bdyMaskCell, nearestRelaxationCell, nCells, cellSolveStart, cellSolveEnd, config_lbc_w )
 
       use mpas_atm_dimensions
 
@@ -7235,6 +7238,7 @@ module atm_time_integration
       integer, intent(in) :: cellSolveStart, cellSolveEnd, nCells
       integer, dimension(nCells+1), intent(in) :: bdyMaskCell, nearestRelaxationCell
       real (kind=RKIND), dimension(nVertLevels+1,nCells+1), intent(inout) :: w
+      character (len=StrKIND) :: config_lbc_w
 
       ! local variables
 
@@ -7251,8 +7255,13 @@ module atm_time_integration
 !DIR$ IVDEP
             !$acc loop vector
             do k = 2, nVertLevels
-               ! w(k,iCell) = w(k,nearestRelaxationCell(iCell))
-               w(k,iCell) = 0.0  ! WCS fix for instabilities caused by zero-gradient condition on inflow, 20240806
+              lbc_w_select: select case(trim(config_lbc_w))
+                case ("nearest")
+                  w(k,iCell) = w(k,nearestRelaxationCell(iCell))
+                case ("zero")
+                  w(k,iCell) = 0.0  ! WCS fix for instabilities caused by zero-gradient condition on inflow, 20240806
+                case default    
+              end select lbc_w_select
             end do
          end if
       end do

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -7260,7 +7260,8 @@ module atm_time_integration
                   w(k,iCell) = w(k,nearestRelaxationCell(iCell))
                 case ("zero")
                   w(k,iCell) = 0.0  ! WCS fix for instabilities caused by zero-gradient condition on inflow, 20240806
-                case default    
+                case default
+                  call mpas_log_write('unknown lbc_w option: '//trim(config_lbc_w), messageType=MPAS_LOG_CRIT)
               end select lbc_w_select
             end do
          end if

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.3.0-1.1">
+<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.3.0-1.2">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->


### PR DESCRIPTION
Add options for treatment of w on lateral boundaries, effectively returning the "nearest cell" option present before v8.3.0. There are now two options:
- `nearest` : pre v8.3.0 treatment
- `zero` : v8.3.0 treatment 

Tests with `zero` produce the same answers as the v8.3.0-1.0 code. Tests below using the default, which is set to `nearest`, per @joeolson42 request (some test results removed because they are too long, apparently).

Will create an issue and propose change to NCAR.

<details>
  <summary>
    regression test case results when namelist option set to "zero"
  </summary>
  
```

     version_to_compare = lbcfinal
   gsl_version_baseline = v8.3.0-1.1
  ncar_version_baseline = v8.3.0
         test_directory = /lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/
 gsl_baseline_directory = /lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/
ncar_baseline_directory = /lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/
           compile_flag = -intdebug
         test_repo_name = barlage

######################################################################
# compare to previous GSL CONUS mesoscale_reference baselines A1GSL   
######################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/barlage-lbcfinal-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.1-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/barlage-lbcfinal-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.1-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/barlage-lbcfinal-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.1-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

#############################################################################
# compare to previous GSL CONUS convection_permitting_none baselines F1GSL   
#############################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/barlage-lbcfinal-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.1-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/barlage-lbcfinal-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.1-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/barlage-lbcfinal-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.1-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

#############################################################################
# compare to previous GSL CONUS mesoscale_reference_noahmp baselines E1GSL   
#############################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/barlage-lbcfinal-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.1-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/barlage-lbcfinal-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.1-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/barlage-lbcfinal-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.1-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

######################################################################
# compare to previous GSL CONUS hrrrv5 GFS baselines C5GSL            
######################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/barlage-lbcfinal-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.1-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/barlage-lbcfinal-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.1-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/barlage-lbcfinal-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.1-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

######################################################################
# compare to previous GSL CONUS hrrrv5 RAP winter baselines C7GSL     
######################################################################

  === history.2024-02-02_18.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/barlage-lbcfinal-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.1-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.00.00.nc" are identical.

  === history.2024-02-02_18.12.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/barlage-lbcfinal-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.1-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.12.00.nc" are identical.

  === history.2024-02-02_19.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/barlage-lbcfinal-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_19.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.1-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_19.00.00.nc" are identical.

######################################################################
# compare to previous GSL CONUS hrrrv5 RAP summer baselines C8GSL     
######################################################################

  === history.2024-08-15_18.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/barlage-lbcfinal-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.1-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.00.00.nc" are identical.

  === history.2024-08-15_18.12.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/barlage-lbcfinal-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.1-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.12.00.nc" are identical.

  === history.2024-08-15_19.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/barlage-lbcfinal-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_19.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.1-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_19.00.00.nc" are identical.

########################################################################
# compare to previous NCAR CONUS mesoscale_reference baselines A1NCAR   
########################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/barlage-lbcfinal-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/barlage-lbcfinal-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/barlage-lbcfinal-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

###############################################################################
# compare to previous NCAR CONUS convection_permitting_none baselines F1NCAR   
###############################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/barlage-lbcfinal-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/barlage-lbcfinal-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/barlage-lbcfinal-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

###############################################################################
# compare to previous NCAR CONUS mesoscale_reference_noahmp baselines E1NCAR   
###############################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/barlage-lbcfinal-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/barlage-lbcfinal-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/mpas_testcase/run_case/barlage-lbcfinal-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.


```
</details>
