### PR TITLE
Prognostic cloud fraction for TEMPO microphysics

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1867,17 +1867,13 @@
                              description="Water-friendly aerosol number concentration"
                              packages="mp_thompson_aers_in;tempo_aerosolaware_in"/>
 
-                        <var name="qa_sgs" array_group="passive" units=""
-                             description="SGS prognostic cloud fraction"
+                        <var name="qal_sgs" array_group="passive" units=""
+                             description="SGS prognostic cloud liquid fraction"
                              packages="tempo_cldfra_in"/>
 
-                        <var name="qc_sgs" array_group="passive" units="kg kg^{-1}"
-                             description="SGS prognostic cloud water mixing ratio"
-                             packages="tempo_cldfra_in"/>
-
-                        <var name="qi_sgs" array_group="passive" units="kg kg^{-1}"
-                             description="SGS prognostic cloud ice mixing ratio"
-                             packages="tempo_cldfra_in"/>
+                        <var name="qai_sgs" array_group="passive" units=""
+                             description="SGS prognostic cloud ice fraction"
+                             packages="tempo_cldfra_in"/>			
                 </var_array>
 #endif
 
@@ -2270,17 +2266,13 @@
                              description="Tendency of water-friendly aerosol number concentration multiplied by dry air density divided by d(zeta)/dz"
                              packages="mp_thompson_aers_in;tempo_aerosolaware_in"/>
 
-                        <var name="tend_qasgs" name_in_code="qa_sgs" array_group="passive" units=""
-                             description="Tendency of sgs prognostic cloud fraction multiplied by dry air density divided by d(zeta)/dz"
+                        <var name="tend_qalsgs" name_in_code="qal_sgs" array_group="passive" units=""
+                             description="Tendency of sgs prognostic cloud liquid fraction multiplied by dry air density divided by d(zeta)/dz"
                              packages="tempo_cldfra_in"/>
 
-                        <var name="tend_qcsgs" name_in_code="qc_sgs" array_group="passive" units="kg m^{-3} s^{-1}"
-                             description="Tendency of sgs prognostic cloud water mass per unit volume multiplied by dry air density divided by d(zeta)/dz"
-                             packages="tempo_cldfra_in"/>
-
-                        <var name="tend_qisgs" name_in_code="qi_sgs" array_group="passive" units="kg m^{-3} s^{-1}"
-                             description="Tendency of sgs prognostic cloud ice mass per unit volume multiplied by dry air density divided by d(zeta)/dz"
-                             packages="tempo_cldfra_in"/>
+                        <var name="tend_qaisgs" name_in_code="qai_sgs" array_group="passive" units=""
+                             description="Tendency of sgs prognostic cloud ice fraction multiplied by dry air density divided by d(zeta)/dz"
+                             packages="tempo_cldfra_in"/>			
                 </var_array>
 #endif
         </var_struct>
@@ -2381,17 +2373,13 @@
                              units="m^{-3} s^{-1}"
                              description="Lateral boundary tendency of water-friendly aerosol number concentration"/>
 
-                        <var name="lbc_qasgs" name_in_code="qa_sgs" array_group="passive" packages="tempo_cldfra_in"
+                        <var name="lbc_qalsgs" name_in_code="qal_sgs" array_group="passive" packages="tempo_cldfra_in"
                              units=""
-                             description="Lateral boundary tendency of sgs prognostic cloud fraction"/>
+                             description="Lateral boundary tendency of sgs prognostic cloud liquid fraction"/>
 
-                        <var name="lbc_qcsgs" name_in_code="qc_sgs" array_group="passive" packages="tempo_cldfra_in"
-                             units="kg kg^{-1} s^{-1}"
-                             description="Lateral boundary tendency of sgs prognostic cloud water mixing ratio"/>
-
-                        <var name="lbc_qisgs" name_in_code="qi_sgs" array_group="passive" packages="tempo_cldfra_in"
-                             units="kg kg^{-1} s^{-1}"
-                             description="Lateral boundary tendency of sgs prognostic cloud ice mixing ratio"/>
+                        <var name="lbc_qaisgs" name_in_code="qai_sgs" array_group="passive" packages="tempo_cldfra_in"
+                             units=""
+                             description="Lateral boundary tendency of sgs prognostic cloud ice fraction"/>			
                 </var_array>
         </var_struct>
 

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1867,12 +1867,12 @@
                              description="Water-friendly aerosol number concentration"
                              packages="mp_thompson_aers_in;tempo_aerosolaware_in"/>
 
-                        <var name="qal_sgs" array_group="passive" units=""
-                             description="SGS prognostic cloud liquid fraction"
+                        <var name="qal" array_group="passive" units=""
+                             description="Prognostic loud liquid fraction"
                              packages="tempo_cldfra_in"/>
 
-                        <var name="qai_sgs" array_group="passive" units=""
-                             description="SGS prognostic cloud ice fraction"
+                        <var name="qai" array_group="passive" units=""
+                             description="Prognostic cloud ice fraction"
                              packages="tempo_cldfra_in"/>			
                 </var_array>
 #endif
@@ -2266,13 +2266,13 @@
                              description="Tendency of water-friendly aerosol number concentration multiplied by dry air density divided by d(zeta)/dz"
                              packages="mp_thompson_aers_in;tempo_aerosolaware_in"/>
 
-                        <var name="tend_qalsgs" name_in_code="qal_sgs" array_group="passive" units=""
-                             description="Tendency of sgs prognostic cloud liquid fraction multiplied by dry air density divided by d(zeta)/dz"
+                        <var name="tend_qal" name_in_code="qal" array_group="passive" units=""
+                             description="Tendency of prognostic cloud liquid fraction multiplied by dry air density divided by d(zeta)/dz"
                              packages="tempo_cldfra_in"/>
 
-                        <var name="tend_qaisgs" name_in_code="qai_sgs" array_group="passive" units=""
-                             description="Tendency of sgs prognostic cloud ice fraction multiplied by dry air density divided by d(zeta)/dz"
-                             packages="tempo_cldfra_in"/>			
+                        <var name="tend_qai" name_in_code="qai" array_group="passive" units=""
+                             description="Tendency of prognostic cloud ice fraction multiplied by dry air density divided by d(zeta)/dz"
+                             packages="tempo_cldfra_in"/>
                 </var_array>
 #endif
         </var_struct>
@@ -2373,13 +2373,13 @@
                              units="m^{-3} s^{-1}"
                              description="Lateral boundary tendency of water-friendly aerosol number concentration"/>
 
-                        <var name="lbc_qalsgs" name_in_code="qal_sgs" array_group="passive" packages="tempo_cldfra_in"
+                        <var name="lbc_qal" name_in_code="qal" array_group="passive" packages="tempo_cldfra_in"
                              units=""
-                             description="Lateral boundary tendency of sgs prognostic cloud liquid fraction"/>
+                             description="Lateral boundary tendency of prognostic cloud liquid fraction"/>
 
-                        <var name="lbc_qaisgs" name_in_code="qai_sgs" array_group="passive" packages="tempo_cldfra_in"
+                        <var name="lbc_qai" name_in_code="qai" array_group="passive" packages="tempo_cldfra_in"
                              units=""
-                             description="Lateral boundary tendency of sgs prognostic cloud ice fraction"/>			
+                             description="Lateral boundary tendency of prognostic cloud ice fraction"/>
                 </var_array>
         </var_struct>
 
@@ -2940,6 +2940,9 @@
                 <var name="precipw" type="real" dimensions="nCells Time" units="kg m^{-2}"
                      description="precipitable water"/>
 
+                <var name="precipfrac" type="real" dimensions="nVertLevels nCells Time" units=""
+                     description="rain/snow precipitation fraction"
+                     packages="tempo_cldfra_in"/>
 
                 <!-- ================================================================================================== -->
                 <!-- ... PARAMETERIZATION OF CONVECTION:                                                                -->

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1874,6 +1874,10 @@
                         <var name="qc_sgs" array_group="passive" units="kg kg^{-1}"
                              description="SGS prognostic cloud water mixing ratio"
                              packages="tempo_cldfra_in"/>
+
+                        <var name="qi_sgs" array_group="passive" units="kg kg^{-1}"
+                             description="SGS prognostic cloud ice mixing ratio"
+                             packages="tempo_cldfra_in"/>
                 </var_array>
 #endif
 
@@ -2271,7 +2275,11 @@
                              packages="tempo_cldfra_in"/>
 
                         <var name="tend_qcsgs" name_in_code="qc_sgs" array_group="passive" units="kg m^{-3} s^{-1}"
-                             description="Tendency of sgs prognostic cloud water mass per unit volume  multiplied by dry air density divided by d(zeta)/dz"
+                             description="Tendency of sgs prognostic cloud water mass per unit volume multiplied by dry air density divided by d(zeta)/dz"
+                             packages="tempo_cldfra_in"/>
+
+                        <var name="tend_qisgs" name_in_code="qi_sgs" array_group="passive" units="kg m^{-3} s^{-1}"
+                             description="Tendency of sgs prognostic cloud ice mass per unit volume multiplied by dry air density divided by d(zeta)/dz"
                              packages="tempo_cldfra_in"/>
                 </var_array>
 #endif
@@ -2380,6 +2388,10 @@
                         <var name="lbc_qcsgs" name_in_code="qc_sgs" array_group="passive" packages="tempo_cldfra_in"
                              units="kg kg^{-1} s^{-1}"
                              description="Lateral boundary tendency of sgs prognostic cloud water mixing ratio"/>
+
+                        <var name="lbc_qisgs" name_in_code="qi_sgs" array_group="passive" packages="tempo_cldfra_in"
+                             units="kg kg^{-1} s^{-1}"
+                             description="Lateral boundary tendency of sgs prognostic cloud ice mixing ratio"/>
                 </var_array>
         </var_struct>
 

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -2553,6 +2553,11 @@
                      description="Logical flag to turn on/off prognostic cloud fraction"
                      possible_values=".true. or .false."/>
 
+		<nml_option name="config_tempo_incld" type="logical" default_value="false" in_defaults="false"
+		     units="-"
+                     description="Logical flag to turn on/off in-cloud microphysics when config_tempo_cldfra is true"
+                     possible_values=".true. or .false."/>
+
 		<nml_option name="config_tempo_ml_nc_pbl" type="logical" default_value="false" in_defaults="false"
 		     units="-"
                      description="Logical flag to turn on/off ML prediction of boundary layer cloud number concentrations"

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -414,6 +414,7 @@
 		<package name="mp_tempo_in" description="parameterization of TEMPO cloud microphysics."/>
 		<package name="tempo_aerosolaware_in" description="variables for TEMPO with aerosol-aware microphysics."/>
 		<package name="tempo_hailaware_in" description="variables for TEMPO hail-aware microphysics."/>
+		<package name="tempo_cldfra_in" description="variables for TEMPO prognostic cloud fraction  microphysics."/>
                 <package name="mp_wsm6_in" description="parameterization of WSM6 cloud microphysics."/>
                 <package name="mp_nssl2m_in" description="parameterization of NSSL 2-moment microphysics."/>
                 <package name="nssl3m_in" description="variables for NSSL 3-moment microphysics."/>
@@ -1865,6 +1866,14 @@
                         <var name="nwfa" array_group="number" units="nb kg^{-1}"
                              description="Water-friendly aerosol number concentration"
                              packages="mp_thompson_aers_in;tempo_aerosolaware_in"/>
+
+                        <var name="qa_sgs" array_group="passive" units=""
+                             description="SGS prognostic cloud fraction"
+                             packages="tempo_cldfra_in"/>
+
+                        <var name="qc_sgs" array_group="passive" units="kg kg^{-1}"
+                             description="SGS prognostic cloud water mixing ratio"
+                             packages="tempo_cldfra_in"/>
                 </var_array>
 #endif
 
@@ -2256,6 +2265,14 @@
                         <var name="tend_nwfa" name_in_code="nwfa" array_group="number" units="nb m^{-3} s^{-1}"
                              description="Tendency of water-friendly aerosol number concentration multiplied by dry air density divided by d(zeta)/dz"
                              packages="mp_thompson_aers_in;tempo_aerosolaware_in"/>
+
+                        <var name="tend_qasgs" name_in_code="qa_sgs" array_group="passive" units=""
+                             description="Tendency of sgs prognostic cloud fraction multiplied by dry air density divided by d(zeta)/dz"
+                             packages="tempo_cldfra_in"/>
+
+                        <var name="tend_qcsgs" name_in_code="qc_sgs" array_group="passive" units="kg m^{-3} s^{-1}"
+                             description="Tendency of sgs prognostic cloud water mass per unit volume  multiplied by dry air density divided by d(zeta)/dz"
+                             packages="tempo_cldfra_in"/>
                 </var_array>
 #endif
         </var_struct>
@@ -2355,6 +2372,14 @@
                         <var name="lbc_nwfa" name_in_code="nwfa" array_group="number" packages="mp_thompson_aers_in;tempo_aerosolaware_in"
                              units="m^{-3} s^{-1}"
                              description="Lateral boundary tendency of water-friendly aerosol number concentration"/>
+
+                        <var name="lbc_qasgs" name_in_code="qa_sgs" array_group="passive" packages="tempo_cldfra_in"
+                             units=""
+                             description="Lateral boundary tendency of sgs prognostic cloud fraction"/>
+
+                        <var name="lbc_qcsgs" name_in_code="qc_sgs" array_group="passive" packages="tempo_cldfra_in"
+                             units="kg kg^{-1} s^{-1}"
+                             description="Lateral boundary tendency of sgs prognostic cloud water mixing ratio"/>
                 </var_array>
         </var_struct>
 
@@ -2521,6 +2546,11 @@
 		<nml_option name="config_tempo_hailaware" type="logical" default_value="false" in_defaults="false"
 		     units="-"
                      description="Logical flag to turn on/off prognostic graupel number concentration and rime density"
+                     possible_values=".true. or .false."/>
+
+		<nml_option name="config_tempo_cldfra" type="logical" default_value="false" in_defaults="false"
+		     units="-"
+                     description="Logical flag to turn on/off prognostic cloud fraction"
                      possible_values=".true. or .false."/>
 
 		<nml_option name="config_tempo_ml_nc_pbl" type="logical" default_value="false" in_defaults="false"

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -2633,7 +2633,7 @@
                 <nml_option name="config_radt_cld_scheme" type="character" default_value="suite" in_defaults="false"
                      units="-"
                      description="configuration for calculation of horizontal cloud fraction"
-                     possible_values="`suite',`cld_fraction',`cld_incidence',`cld_fraction_thompson',`cld_fraction_mynn'"/>
+                     possible_values="`suite',`cld_fraction',`cld_incidence',`cld_fraction_thompson',`cld_fraction_mynn',`cld_tempo'"/>
 
                 <nml_option name="config_radt_lw_scheme" type="character" default_value="suite" in_defaults="false"
                      units="-"

--- a/src/core_atmosphere/physics/mpas_atmphys_control.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_control.F
@@ -124,7 +124,7 @@
  call mpas_pool_get_config(configs,'config_radt_sw_scheme'   ,config_radt_sw_scheme   )
  call mpas_pool_get_config(configs,'config_sfclayer_scheme'  ,config_sfclayer_scheme  )
  call mpas_pool_get_config(configs,'config_tempo_cldfra'  ,config_tempo_cldfra  )
- call mpas_pool_get_config(configs,'config_mynn_cloudpdf'  ,config_mynn_cloudpdf  )      
+ call mpas_pool_get_config(configs,'config_mynn_cloudpdf'  ,config_mynn_cloudpdf  )
 
  call mpas_log_write('')
  call mpas_log_write('----- Setting up physics suite '''//trim(config_physics_suite)//''' -----')

--- a/src/core_atmosphere/physics/mpas_atmphys_control.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_control.F
@@ -108,7 +108,7 @@
                                   config_sfclayer_scheme
 
  logical,pointer:: config_tempo_cldfra
-
+ integer,pointer:: config_mynn_cloudpdf
 !-----------------------------------------------------------------------------------------------------------------
 !call mpas_log_write('')
 !call mpas_log_write('--- enter subroutine physics_namelist_check:')
@@ -124,6 +124,7 @@
  call mpas_pool_get_config(configs,'config_radt_sw_scheme'   ,config_radt_sw_scheme   )
  call mpas_pool_get_config(configs,'config_sfclayer_scheme'  ,config_sfclayer_scheme  )
  call mpas_pool_get_config(configs,'config_tempo_cldfra'  ,config_tempo_cldfra  )
+ call mpas_pool_get_config(configs,'config_mynn_cloudpdf'  ,config_mynn_cloudpdf  )      
 
  call mpas_log_write('')
  call mpas_log_write('----- Setting up physics suite '''//trim(config_physics_suite)//''' -----')
@@ -303,6 +304,12 @@
       '     setting cloud fraction to config_radt_cld_scheme = cld_tempo'
     call physics_message(mpas_err_message)
     config_radt_cld_scheme = "cld_tempo"
+    if ((config_pbl_scheme == 'bl_mynn') .and. (config_mynn_cloudpdf .ge. 0)) then
+       write(mpas_err_message,'(A,A20)') &
+         '     setting config_mynn_cloudpdf to -2 when using tempo prognostic clouds'
+       call physics_message(mpas_err_message)
+       config_mynn_cloudpdf = -2
+    endif
  endif
 
 !surface-layer scheme:

--- a/src/core_atmosphere/physics/mpas_atmphys_control.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_control.F
@@ -107,6 +107,8 @@
                                   config_radt_sw_scheme,    &
                                   config_sfclayer_scheme
 
+ logical,pointer:: config_tempo_cldfra
+
 !-----------------------------------------------------------------------------------------------------------------
 !call mpas_log_write('')
 !call mpas_log_write('--- enter subroutine physics_namelist_check:')
@@ -121,6 +123,7 @@
  call mpas_pool_get_config(configs,'config_radt_lw_scheme'   ,config_radt_lw_scheme   )
  call mpas_pool_get_config(configs,'config_radt_sw_scheme'   ,config_radt_sw_scheme   )
  call mpas_pool_get_config(configs,'config_sfclayer_scheme'  ,config_sfclayer_scheme  )
+ call mpas_pool_get_config(configs,'config_tempo_cldfra'  ,config_tempo_cldfra  )
 
  call mpas_log_write('')
  call mpas_log_write('----- Setting up physics suite '''//trim(config_physics_suite)//''' -----')
@@ -264,6 +267,7 @@
            config_radt_cld_scheme .eq. 'cld_incidence'         .or. &
            config_radt_cld_scheme .eq. 'cld_fraction'          .or. &
            config_radt_cld_scheme .eq. 'cld_fraction_thompson' .or. &
+           config_radt_cld_scheme .eq. 'cld_tempo' .or. &
            config_radt_cld_scheme .eq. 'cld_fraction_mynn')) then
 
     write(mpas_err_message,'(A,A20)') 'illegal value for calculation of cloud fraction: ', &
@@ -292,6 +296,13 @@
                 trim(config_pbl_scheme)
           call physics_error_fatal(mpas_err_message)
 
+ endif
+
+ if ((config_microp_scheme .eq. 'mp_tempo') .and. (config_tempo_cldfra)) then
+    write(mpas_err_message,'(A,A20)') &
+      '     setting cloud fraction to config_radt_cld_scheme = cld_tempo'
+    call physics_message(mpas_err_message)
+    config_radt_cld_scheme = "cld_tempo"
  endif
 
 !surface-layer scheme:

--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -232,7 +232,7 @@
        call allocate_cloudiness(block%configs)
 !$OMP PARALLEL DO
        do thread=1,nThreads
-          call driver_cloudiness(itimestep,block%configs,mesh,diag_physics,sfc_input, &
+          call driver_cloudiness(itimestep,block%configs,mesh,state,diag_physics,sfc_input, &
                                  cellSolveThreadStart(thread),cellSolveThreadEnd(thread))
        end do
 !$OMP END PARALLEL DO

--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -337,7 +337,7 @@
        call allocate_pbl(block%configs)
 !$OMP PARALLEL DO
        do thread=1,nThreads
-          call driver_pbl(itimestep,block%configs,mesh,sfc_input,diag_physics,tend_physics, &
+          call driver_pbl(itimestep,block%configs,mesh,state,sfc_input,diag_physics,tend_physics, &
                           cellSolveThreadStart(thread),cellSolveThreadEnd(thread))
        end do
 !$OMP END PARALLEL DO

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_cloudiness.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_cloudiness.F
@@ -86,6 +86,11 @@
     case("cld_fraction_mynn")
        if(.not.allocated(qibl_p)) allocate(qibl_p(ims:ime,kms:kme,jms:jme))
        if(.not.allocated(qcbl_p)) allocate(qcbl_p(ims:ime,kms:kme,jms:jme))
+
+    case("cld_tempo")
+       if(.not.allocated(qasgs_p)) allocate(qasgs_p(ims:ime,kms:kme,jms:jme))
+       if(.not.allocated(qcsgs_p)) allocate(qcsgs_p(ims:ime,kms:kme,jms:jme))
+       if(.not.allocated(qisgs_p)) allocate(qisgs_p(ims:ime,kms:kme,jms:jme))
     case default
 
  end select cld_fraction_select
@@ -124,6 +129,11 @@
 
        if(allocated(qibl_p)) deallocate(qibl_p)
        if(allocated(qcbl_p)) deallocate(qcbl_p)
+
+    case("cld_tempo")
+       if(allocated(qasgs_p)) deallocate(qasgs_p)
+       if(allocated(qcsgs_p)) deallocate(qcsgs_p)
+       if(allocated(qisgs_p)) deallocate(qisgs_p)
     case default
 
  end select cld_fraction_select
@@ -137,7 +147,7 @@
  end subroutine deallocate_cloudiness
 
 !=================================================================================================================
- subroutine cloudiness_from_MPAS(itimestep,configs,mesh,diag_physics,sfc_input,its,ite)
+ subroutine cloudiness_from_MPAS(itimestep,configs,mesh,state,diag_physics,sfc_input,its,ite)
 !=================================================================================================================
 
 !input arguments:
@@ -147,6 +157,7 @@
 !input and inout arguments:
  type(mpas_pool_type),intent(in)   :: configs
  type(mpas_pool_type),intent(in)   :: mesh
+ type(mpas_pool_type),intent(in)   :: state
  type(mpas_pool_type),intent(in)   :: sfc_input
 
 !inout arguments:
@@ -163,6 +174,10 @@
 
  character(len=StrKIND),pointer:: radt_cld_scheme
  character(len=StrKIND),pointer:: convection_scheme
+
+ integer,pointer:: index_qa_sgs, index_qc_sgs, index_qi_sgs
+ real(kind=RKIND),dimension(:,:,:),pointer:: scalars
+ real(kind=RKIND),dimension(:,:),pointer:: qasgs, qcsgs, qisgs
 
 !-----------------------------------------------------------------------------------------------------------------
 
@@ -235,6 +250,25 @@
        enddo
        enddo
 
+    case("cld_tempo")
+       call mpas_pool_get_array(state,'scalars',scalars)
+       call mpas_pool_get_dimension(state,'index_qa_sgs',index_qa_sgs)
+       call mpas_pool_get_dimension(state,'index_qc_sgs',index_qc_sgs)
+       call mpas_pool_get_dimension(state,'index_qi_sgs',index_qi_sgs)
+
+       qasgs   => scalars(index_qa_sgs,:,:)
+       qcsgs   => scalars(index_qc_sgs,:,:)
+       qisgs   => scalars(index_qi_sgs,:,:)
+       do j = jts,jte
+          do k = kts,kte
+             do i = its,ite
+                qasgs_p(i,k,j) = qasgs(k,i)
+                cldfrac_p(i,k,j) = qasgs(k,i)
+                qcsgs_p(i,k,j) = qcsgs(k,i)
+                qisgs_p(i,k,j) = qisgs(k,i)
+             enddo
+          enddo
+       enddo
     case default
 
  end select cld_fraction_select  
@@ -288,12 +322,13 @@
  end subroutine cloudiness_to_MPAS
 
 !=================================================================================================================
- subroutine driver_cloudiness(itimestep,configs,mesh,diag_physics,sfc_input,its,ite)
+ subroutine driver_cloudiness(itimestep,configs,mesh,state,diag_physics,sfc_input,its,ite)
 !=================================================================================================================
 
 !input arguments:
  type(mpas_pool_type),intent(in)   :: configs
  type(mpas_pool_type),intent(in)   :: mesh
+ type(mpas_pool_type),intent(in)   :: state
  type(mpas_pool_type),intent(in)   :: sfc_input
 
  integer,intent(in):: its,ite
@@ -316,7 +351,7 @@
  call mpas_pool_get_config(configs,'config_convection_scheme',convection_scheme)
 
 !copy MPAS arrays to local arrays:
- call cloudiness_from_MPAS(itimestep,configs,mesh,diag_physics,sfc_input,its,ite)
+ call cloudiness_from_MPAS(itimestep,configs,mesh,state,diag_physics,sfc_input,its,ite)
 
  cld_fraction_select: select case (trim(radt_cld_scheme))
     case("cld_incidence")
@@ -349,6 +384,12 @@
                        its,  ite , jts , jte , kts , kte  )
       call mpas_timer_stop('cal_mynncld')
 
+    case("cld_tempo")
+      call mpas_timer_start('cal_cldfra_tempo')
+      call cal_cldfra_tempo(qasgs_p , qcrad_p   , qirad_p    , &
+                       qcsgs_p    , qisgs_p    ,              &
+                       its,  ite , jts , jte , kts , kte  )
+      call mpas_timer_stop('cal_cldfra_tempo')
     case default
 
  end select cld_fraction_select
@@ -573,6 +614,41 @@
  enddo
 
  end subroutine cal_gflcld
+!=================================================================================================================
+!=================================================================================================================
+ subroutine cal_cldfra_tempo(cldfrac,qc,qi,qc_sgs,qi_sgs,its,ite,jts,jte,kts,kte)
+!=================================================================================================================
+
+!input arguments:
+ integer,intent(in):: its,ite,jts,jte,kts,kte
+ real(kind=RKIND),intent(inout),dimension(ims:ime,kms:kme,jms:jme):: qc,qi
+ real(kind=RKIND),intent(in),   dimension(ims:ime,kms:kme,jms:jme):: qc_sgs,qi_sgs
+ real(kind=RKIND),intent(in),   dimension(ims:ime,kms:kme,jms:jme):: cldfrac
+
+!local variables:
+ integer:: i,j,k
+
+ real(kind=RKIND),parameter:: qc_thresh  = 1.e-06
+ real(kind=RKIND),parameter:: qi_thresh  = 1.e-09
+ real(kind=RKIND),parameter:: cld_thresh = 1.e-03
+
+ do j = jts,jte
+ do k = kts,kte
+ do i = its,ite
+
+    if (qc(i,k,j) < qc_thresh .AND. cldfrac(i,k,j) > cld_thresh) THEN
+       !call mpas_log_write("Adding in cldfra_bl to qc at $i,$i,$i", intArgs=(/i,j,k/))
+       qc(i,k,j)=qc(i,k,j) + qc_sgs(i,k,j)
+    endif
+    if (qi(i,k,j) < qi_thresh .AND. cldfrac(i,k,j) > cld_thresh) THEN
+       !call mpas_log_write("Adding in cldfra_bl to qi at $i,$i,$i", intArgs=(/i,j,k/))
+       qi(i,k,j)=qi(i,k,j) + qi_sgs(i,k,j)
+    endif
+ enddo
+ enddo
+ enddo
+
+ end subroutine cal_cldfra_tempo
 !=================================================================================================================
  end module mpas_atmphys_driver_cloudiness
 !=================================================================================================================

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_cloudiness.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_cloudiness.F
@@ -88,9 +88,8 @@
        if(.not.allocated(qcbl_p)) allocate(qcbl_p(ims:ime,kms:kme,jms:jme))
 
     case("cld_tempo")
-       if(.not.allocated(qasgs_p)) allocate(qasgs_p(ims:ime,kms:kme,jms:jme))
-       if(.not.allocated(qcsgs_p)) allocate(qcsgs_p(ims:ime,kms:kme,jms:jme))
-       if(.not.allocated(qisgs_p)) allocate(qisgs_p(ims:ime,kms:kme,jms:jme))
+       if(.not.allocated(qalsgs_p)) allocate(qalsgs_p(ims:ime,kms:kme,jms:jme))
+       if(.not.allocated(qaisgs_p)) allocate(qaisgs_p(ims:ime,kms:kme,jms:jme))
     case default
 
  end select cld_fraction_select
@@ -131,9 +130,8 @@
        if(allocated(qcbl_p)) deallocate(qcbl_p)
 
     case("cld_tempo")
-       if(allocated(qasgs_p)) deallocate(qasgs_p)
-       if(allocated(qcsgs_p)) deallocate(qcsgs_p)
-       if(allocated(qisgs_p)) deallocate(qisgs_p)
+       if(allocated(qalsgs_p)) deallocate(qalsgs_p)
+       if(allocated(qaisgs_p)) deallocate(qaisgs_p)
     case default
 
  end select cld_fraction_select
@@ -175,9 +173,9 @@
  character(len=StrKIND),pointer:: radt_cld_scheme
  character(len=StrKIND),pointer:: convection_scheme
 
- integer,pointer:: index_qa_sgs, index_qc_sgs, index_qi_sgs
+ integer,pointer:: index_qal_sgs, index_qai_sgs
  real(kind=RKIND),dimension(:,:,:),pointer:: scalars
- real(kind=RKIND),dimension(:,:),pointer:: qasgs, qcsgs, qisgs
+ real(kind=RKIND),dimension(:,:),pointer:: qalsgs, qaisgs
 
 !-----------------------------------------------------------------------------------------------------------------
 
@@ -252,20 +250,17 @@
 
     case("cld_tempo")
        call mpas_pool_get_array(state,'scalars',scalars)
-       call mpas_pool_get_dimension(state,'index_qa_sgs',index_qa_sgs)
-       call mpas_pool_get_dimension(state,'index_qc_sgs',index_qc_sgs)
-       call mpas_pool_get_dimension(state,'index_qi_sgs',index_qi_sgs)
+       call mpas_pool_get_dimension(state,'index_qal_sgs',index_qal_sgs)
+       call mpas_pool_get_dimension(state,'index_qai_sgs',index_qai_sgs)
 
-       qasgs   => scalars(index_qa_sgs,:,:)
-       qcsgs   => scalars(index_qc_sgs,:,:)
-       qisgs   => scalars(index_qi_sgs,:,:)
+       qalsgs   => scalars(index_qal_sgs,:,:)
+       qaisgs   => scalars(index_qai_sgs,:,:)
        do j = jts,jte
           do k = kts,kte
              do i = its,ite
-                qasgs_p(i,k,j) = qasgs(k,i)
-                cldfrac_p(i,k,j) = qasgs(k,i)
-                qcsgs_p(i,k,j) = qcsgs(k,i)
-                qisgs_p(i,k,j) = qisgs(k,i)
+                qalsgs_p(i,k,j) = qalsgs(k,i)
+                qaisgs_p(i,k,j) = qaisgs(k,i)                
+                cldfrac_p(i,k,j) = max(qalsgs(k,i), qaisgs(k,i))
              enddo
           enddo
        enddo
@@ -386,8 +381,7 @@
 
     case("cld_tempo")
       call mpas_timer_start('cal_cldfra_tempo')
-      call cal_cldfra_tempo(qasgs_p , qcrad_p   , qirad_p    , &
-                       qcsgs_p    , qisgs_p    ,              &
+      call cal_cldfra_tempo(qalsgs_p , qaisgs_p, qcrad_p   , qirad_p    , &
                        its,  ite , jts , jte , kts , kte  )
       call mpas_timer_stop('cal_cldfra_tempo')
     case default
@@ -616,33 +610,32 @@
  end subroutine cal_gflcld
 !=================================================================================================================
 !=================================================================================================================
- subroutine cal_cldfra_tempo(cldfrac,qc,qi,qc_sgs,qi_sgs,its,ite,jts,jte,kts,kte)
+ subroutine cal_cldfra_tempo(cldfracl,cldfraci,qc,qi,its,ite,jts,jte,kts,kte)
 !=================================================================================================================
 
 !input arguments:
  integer,intent(in):: its,ite,jts,jte,kts,kte
  real(kind=RKIND),intent(inout),dimension(ims:ime,kms:kme,jms:jme):: qc,qi
- real(kind=RKIND),intent(in),   dimension(ims:ime,kms:kme,jms:jme):: qc_sgs,qi_sgs
- real(kind=RKIND),intent(in),   dimension(ims:ime,kms:kme,jms:jme):: cldfrac
+ real(kind=RKIND),intent(in),   dimension(ims:ime,kms:kme,jms:jme):: cldfracl, cldfraci
 
 !local variables:
  integer:: i,j,k
 
  real(kind=RKIND),parameter:: qc_thresh  = 1.e-06
  real(kind=RKIND),parameter:: qi_thresh  = 1.e-09
- real(kind=RKIND),parameter:: cld_thresh = 1.e-03
+ real(kind=RKIND),parameter:: cld_thresh = 1.e-02
 
  do j = jts,jte
  do k = kts,kte
  do i = its,ite
 
-    if (qc(i,k,j) < qc_thresh .AND. cldfrac(i,k,j) > cld_thresh) THEN
+    if (qc(i,k,j) < qc_thresh .AND. cldfracl(i,k,j) > cld_thresh) THEN
        !call mpas_log_write("Adding in cldfra_bl to qc at $i,$i,$i", intArgs=(/i,j,k/))
-       qc(i,k,j)=qc(i,k,j) + qc_sgs(i,k,j)
+       qc(i,k,j)=qc(i,k,j)
     endif
-    if (qi(i,k,j) < qi_thresh .AND. cldfrac(i,k,j) > cld_thresh) THEN
+    if (qi(i,k,j) < qi_thresh .AND. cldfraci(i,k,j) > cld_thresh) THEN
        !call mpas_log_write("Adding in cldfra_bl to qi at $i,$i,$i", intArgs=(/i,j,k/))
-       qi(i,k,j)=qi(i,k,j) + qi_sgs(i,k,j)
+       qi(i,k,j)=qi(i,k,j)
     endif
  enddo
  enddo

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_cloudiness.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_cloudiness.F
@@ -88,8 +88,8 @@
        if(.not.allocated(qcbl_p)) allocate(qcbl_p(ims:ime,kms:kme,jms:jme))
 
     case("cld_tempo")
-       if(.not.allocated(qalsgs_p)) allocate(qalsgs_p(ims:ime,kms:kme,jms:jme))
-       if(.not.allocated(qaisgs_p)) allocate(qaisgs_p(ims:ime,kms:kme,jms:jme))
+       if(.not.allocated(qal_p)) allocate(qal_p(ims:ime,kms:kme,jms:jme))
+       if(.not.allocated(qai_p)) allocate(qai_p(ims:ime,kms:kme,jms:jme))
     case default
 
  end select cld_fraction_select
@@ -130,8 +130,8 @@
        if(allocated(qcbl_p)) deallocate(qcbl_p)
 
     case("cld_tempo")
-       if(allocated(qalsgs_p)) deallocate(qalsgs_p)
-       if(allocated(qaisgs_p)) deallocate(qaisgs_p)
+       if(allocated(qal_p)) deallocate(qal_p)
+       if(allocated(qai_p)) deallocate(qai_p)
     case default
 
  end select cld_fraction_select
@@ -173,9 +173,9 @@
  character(len=StrKIND),pointer:: radt_cld_scheme
  character(len=StrKIND),pointer:: convection_scheme
 
- integer,pointer:: index_qal_sgs, index_qai_sgs
+ integer,pointer:: index_qal, index_qai
  real(kind=RKIND),dimension(:,:,:),pointer:: scalars
- real(kind=RKIND),dimension(:,:),pointer:: qalsgs, qaisgs
+ real(kind=RKIND),dimension(:,:),pointer:: qal, qai
 
 !-----------------------------------------------------------------------------------------------------------------
 
@@ -250,17 +250,17 @@
 
     case("cld_tempo")
        call mpas_pool_get_array(state,'scalars',scalars)
-       call mpas_pool_get_dimension(state,'index_qal_sgs',index_qal_sgs)
-       call mpas_pool_get_dimension(state,'index_qai_sgs',index_qai_sgs)
+       call mpas_pool_get_dimension(state,'index_qal',index_qal)
+       call mpas_pool_get_dimension(state,'index_qai',index_qai)
 
-       qalsgs   => scalars(index_qal_sgs,:,:)
-       qaisgs   => scalars(index_qai_sgs,:,:)
+       qal   => scalars(index_qal,:,:)
+       qai   => scalars(index_qai,:,:)
        do j = jts,jte
           do k = kts,kte
              do i = its,ite
-                qalsgs_p(i,k,j) = qalsgs(k,i)
-                qaisgs_p(i,k,j) = qaisgs(k,i)                
-                cldfrac_p(i,k,j) = max(qalsgs(k,i), qaisgs(k,i))
+                qal_p(i,k,j) = qal(k,i)
+                qai_p(i,k,j) = qai(k,i)
+                cldfrac_p(i,k,j) = max(qal(k,i), qai(k,i))
              enddo
           enddo
        enddo
@@ -379,11 +379,6 @@
                        its,  ite , jts , jte , kts , kte  )
       call mpas_timer_stop('cal_mynncld')
 
-    case("cld_tempo")
-      call mpas_timer_start('cal_cldfra_tempo')
-      call cal_cldfra_tempo(qalsgs_p , qaisgs_p, qcrad_p   , qirad_p    , &
-                       its,  ite , jts , jte , kts , kte  )
-      call mpas_timer_stop('cal_cldfra_tempo')
     case default
 
  end select cld_fraction_select
@@ -608,40 +603,6 @@
  enddo
 
  end subroutine cal_gflcld
-!=================================================================================================================
-!=================================================================================================================
- subroutine cal_cldfra_tempo(cldfracl,cldfraci,qc,qi,its,ite,jts,jte,kts,kte)
-!=================================================================================================================
-
-!input arguments:
- integer,intent(in):: its,ite,jts,jte,kts,kte
- real(kind=RKIND),intent(inout),dimension(ims:ime,kms:kme,jms:jme):: qc,qi
- real(kind=RKIND),intent(in),   dimension(ims:ime,kms:kme,jms:jme):: cldfracl, cldfraci
-
-!local variables:
- integer:: i,j,k
-
- real(kind=RKIND),parameter:: qc_thresh  = 1.e-06
- real(kind=RKIND),parameter:: qi_thresh  = 1.e-09
- real(kind=RKIND),parameter:: cld_thresh = 1.e-02
-
- do j = jts,jte
- do k = kts,kte
- do i = its,ite
-
-    if (qc(i,k,j) < qc_thresh .AND. cldfracl(i,k,j) > cld_thresh) THEN
-       !call mpas_log_write("Adding in cldfra_bl to qc at $i,$i,$i", intArgs=(/i,j,k/))
-       qc(i,k,j)=qc(i,k,j)
-    endif
-    if (qi(i,k,j) < qi_thresh .AND. cldfraci(i,k,j) > cld_thresh) THEN
-       !call mpas_log_write("Adding in cldfra_bl to qi at $i,$i,$i", intArgs=(/i,j,k/))
-       qi(i,k,j)=qi(i,k,j)
-    endif
- enddo
- enddo
- enddo
-
- end subroutine cal_cldfra_tempo
 !=================================================================================================================
  end module mpas_atmphys_driver_cloudiness
 !=================================================================================================================

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_cloudiness.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_cloudiness.F
@@ -260,13 +260,17 @@
              do i = its,ite
                 qal_p(i,k,j) = qal(k,i)
                 qai_p(i,k,j) = qai(k,i)
-                cldfrac_p(i,k,j) = max(qal(k,i), qai(k,i))
-
-                if (qirad_p(i,k,j) > 1.e-7) then
-                   qirad_p(i,k,j) = qirad_p(i,k,j) + qsrad_p(i,k,j)
-                   qsrad_p(i,k,j) = 0.
+                cldfrac_p(i,k,j) = max(0., max(qal(k,i), qai(k,i))) ! Avoid cldfrac < 0
+                if (cldfrac_p(i,k,j) > 0.) then
+                   if (qirad_p(i,k,j) > 1.e-7) then
+                      qirad_p(i,k,j) = max(0. , qirad_p(i,k,j) + qsrad_p(i,k,j))
+                      qsrad_p(i,k,j) = 0.
+                   endif
+                else
+                   qcrad_p(i,k,j) = 0. ! No cloud
+                   qirad_p(i,k,j) = 0. ! No cloud
+                   qsrad_p(i,k,j) = 0. ! No cloud
                 endif
-
              enddo
           enddo
        enddo

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_cloudiness.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_cloudiness.F
@@ -261,6 +261,12 @@
                 qal_p(i,k,j) = qal(k,i)
                 qai_p(i,k,j) = qai(k,i)
                 cldfrac_p(i,k,j) = max(qal(k,i), qai(k,i))
+
+                if (qirad_p(i,k,j) > 1.e-7) then
+                   qirad_p(i,k,j) = qirad_p(i,k,j) + qsrad_p(i,k,j)
+                   qsrad_p(i,k,j) = 0.
+                endif
+
              enddo
           enddo
        enddo

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
@@ -483,6 +483,7 @@
  logical,pointer:: do_restart
  character(len=StrKIND),pointer:: microp_scheme
  logical,pointer:: config_tempo_hailaware, config_tempo_aerosolaware
+ logical,pointer:: config_tempo_cldfra, config_tempo_incld
  character(len=StrKIND),pointer:: nssl_moments
 
  logical :: outputon = .false.
@@ -502,6 +503,8 @@
  call mpas_pool_get_config(configs,'config_microp_scheme',microp_scheme)
  call mpas_pool_get_config(configs,'config_tempo_hailaware',config_tempo_hailaware)
  call mpas_pool_get_config(configs,'config_tempo_aerosolaware',config_tempo_aerosolaware)
+ call mpas_pool_get_config(configs,'config_tempo_cldfra',config_tempo_cldfra)
+ call mpas_pool_get_config(configs,'config_tempo_incld',config_tempo_incld)
  call mpas_pool_get_config(configs,'config_nssl_moments',nssl_moments)
  call mpas_pool_get_config(configs,'config_do_restart'   ,do_restart   )
 
@@ -519,7 +522,8 @@
 
     case("mp_tempo")
        call tempo_init(l_mp_tables=l_mp_tables, &
-            hail_aware_flag=config_tempo_hailaware, aerosol_aware_flag=config_tempo_aerosolaware)
+            hail_aware_flag=config_tempo_hailaware, aerosol_aware_flag=config_tempo_aerosolaware, &
+            cldfra_flag=config_tempo_cldfra, incld_flag=config_tempo_incld)
 
        if (config_tempo_aerosolaware) then
           call init_tempo_aerosols_forMPAS(do_restart,dminfo,mesh,state,time_lev,diag_physics)

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
@@ -228,6 +228,7 @@
           if (config_tempo_cldfra) then
              if(.not.allocated(qasgs_p)) allocate(qasgs_p(ims:ime,kms:kme,jms:jme))
              if(.not.allocated(qcsgs_p)) allocate(qcsgs_p(ims:ime,kms:kme,jms:jme))
+             if(.not.allocated(qisgs_p)) allocate(qisgs_p(ims:ime,kms:kme,jms:jme))
           endif
 
           if (config_tempo_ml_nc_pbl) then
@@ -398,6 +399,7 @@
           if (config_tempo_cldfra) then
              if(allocated(qasgs_p)) deallocate(qasgs_p)
              if(allocated(qcsgs_p)) deallocate(qcsgs_p)
+             if(allocated(qisgs_p)) deallocate(qisgs_p)
           endif
 
           if (config_tempo_ml_nc_pbl) then
@@ -621,7 +623,7 @@
                      th        = th_p        , qv         = qv_p         , qc         = qc_p         , &
                      qr        = qr_p        , qi         = qi_p         , qs         = qs_p         , &
                      qg        = qg_p        , ni         = ni_p         , nr         = nr_p         , &
-                     qasgs     = qasgs_p     , qcsgs      = qcsgs_p                                  , &
+                     qasgs     = qasgs_p     , qcsgs      = qcsgs_p      , qisgs      = qisgs_p      , &
                      !! ng        = ng_p        , qb         = volg_p                                   , &
                      !! nc        = nc_p        , nwfa       = nwfa_p       , nifa       = nifa_p       , &
                      !! nwfa2d    = nwfa2d_p    , nifa2d     = nifa2d_p                                 , &
@@ -644,7 +646,7 @@
                         th        = th_p        , qv         = qv_p         , qc         = qc_p         , &
                         qr        = qr_p        , qi         = qi_p         , qs         = qs_p         , &
                         qg        = qg_p        , ni         = ni_p         , nr         = nr_p         , &
-                        qasgs     = qasgs_p     , qcsgs      = qcsgs_p                                  , &
+                        qasgs     = qasgs_p     , qcsgs      = qcsgs_p      , qisgs      = qisgs_p      , &
                         !! ng        = ng_p        , qb         = volg_p                                   , &
                         nc        = nc_p        , nwfa       = nwfa_p       , nifa       = nifa_p       , &
                         nwfa2d    = nwfa2d_p    , nifa2d     = nifa2d_p                                 , &
@@ -668,7 +670,7 @@
                         qr        = qr_p        , qi         = qi_p         , qs         = qs_p         , &
                         qg        = qg_p        , ni         = ni_p         , nr         = nr_p         , &
                         ng        = ng_p        , qb         = volg_p                                   , &
-                        qasgs     = qasgs_p     , qcsgs      = qcsgs_p                                  , &
+                        qasgs     = qasgs_p     , qcsgs      = qcsgs_p      , qisgs      = qisgs_p      , &
                         !! nc        = nc_p        , nwfa       = nwfa_p       , nifa       = nifa_p       , &
                         !! nwfa2d    = nwfa2d_p    , nifa2d     = nifa2d_p                                 , &
                         pii       = pi_p        , p          = pres_p       , dz         = dz_p         , &
@@ -696,7 +698,7 @@
                      ng        = ng_p        , qb         = volg_p                                   , &
                      nc        = nc_p        , nwfa       = nwfa_p       , nifa       = nifa_p       , &
                      nwfa2d    = nwfa2d_p    , nifa2d     = nifa2d_p                                 , &
-                     qasgs     = qasgs_p     , qcsgs      = qcsgs_p                                  , &
+                     qasgs     = qasgs_p     , qcsgs      = qcsgs_p      , qisgs      = qisgs_p      , &
                      pii       = pi_p        , p          = pres_p       , dz         = dz_p         , &
                      w         = w_p         , dt_in      = dt_microp    , itimestep  = itimestep    , &
                      rainnc    = rainnc_p    , rainncv    = rainncv_p    , snownc     = snownc_p     , &

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
@@ -226,9 +226,17 @@
           endif
 
           if (config_tempo_cldfra) then
-             if(.not.allocated(qasgs_p)) allocate(qasgs_p(ims:ime,kms:kme,jms:jme))
-             if(.not.allocated(qcsgs_p)) allocate(qcsgs_p(ims:ime,kms:kme,jms:jme))
-             if(.not.allocated(qisgs_p)) allocate(qisgs_p(ims:ime,kms:kme,jms:jme))
+             if(.not.allocated(qalsgs_p)) allocate(qalsgs_p(ims:ime,kms:kme,jms:jme))
+             if(.not.allocated(qaisgs_p)) allocate(qaisgs_p(ims:ime,kms:kme,jms:jme))
+
+             if(.not.allocated(rthblten_p)) allocate(rthblten_p(ims:ime,kms:kme,jms:jme))
+             if(.not.allocated(rqvblten_p)) allocate(rqvblten_p(ims:ime,kms:kme,jms:jme))
+             if(.not.allocated(rqcblten_p)) allocate(rqcblten_p(ims:ime,kms:kme,jms:jme))
+             if(.not.allocated(rqiblten_p)) allocate(rqiblten_p(ims:ime,kms:kme,jms:jme))
+             if(.not.allocated(rthratenlw_p)) allocate(rthratenlw_p(ims:ime,kms:kme,jms:jme))
+             if(.not.allocated(rthratensw_p)) allocate(rthratensw_p(ims:ime,kms:kme,jms:jme))                                                    
+!             if(.not.allocated(cldfrac_p) ) allocate(cldfrac_p(ims:ime,kms:kme,jms:jme))
+!             if(.not.allocated(qcbl_p) ) allocate(qcbl_p(ims:ime,kms:kme,jms:jme))             
           endif
 
           if (config_tempo_ml_nc_pbl) then
@@ -397,9 +405,17 @@
           endif
 
           if (config_tempo_cldfra) then
-             if(allocated(qasgs_p)) deallocate(qasgs_p)
-             if(allocated(qcsgs_p)) deallocate(qcsgs_p)
-             if(allocated(qisgs_p)) deallocate(qisgs_p)
+             if(allocated(qalsgs_p)) deallocate(qalsgs_p)
+             if(allocated(qaisgs_p)) deallocate(qaisgs_p)
+
+             if(allocated(rthblten_p)) deallocate(rthblten_p)
+             if(allocated(rqvblten_p)) deallocate(rqvblten_p)
+             if(allocated(rqcblten_p)) deallocate(rqcblten_p)
+             if(allocated(rqiblten_p)) deallocate(rqiblten_p)
+             if(allocated(rthratenlw_p)) deallocate(rthratenlw_p)
+             if(allocated(rthratensw_p)) deallocate(rthratensw_p)             
+!             if(allocated(cldfrac_p) ) deallocate(cldfrac_p)
+!             if(allocated(qcbl_p) ) deallocate(qcbl_p)             
           endif
 
           if (config_tempo_ml_nc_pbl) then
@@ -623,7 +639,7 @@
                      th        = th_p        , qv         = qv_p         , qc         = qc_p         , &
                      qr        = qr_p        , qi         = qi_p         , qs         = qs_p         , &
                      qg        = qg_p        , ni         = ni_p         , nr         = nr_p         , &
-                     qasgs     = qasgs_p     , qcsgs      = qcsgs_p      , qisgs      = qisgs_p      , &
+                     qalsgs     = qalsgs_p     , qaisgs      = qaisgs_p      , &
                      !! ng        = ng_p        , qb         = volg_p                                   , &
                      !! nc        = nc_p        , nwfa       = nwfa_p       , nifa       = nifa_p       , &
                      !! nwfa2d    = nwfa2d_p    , nifa2d     = nifa2d_p                                 , &
@@ -646,7 +662,7 @@
                         th        = th_p        , qv         = qv_p         , qc         = qc_p         , &
                         qr        = qr_p        , qi         = qi_p         , qs         = qs_p         , &
                         qg        = qg_p        , ni         = ni_p         , nr         = nr_p         , &
-                        qasgs     = qasgs_p     , qcsgs      = qcsgs_p      , qisgs      = qisgs_p      , &
+                        qalsgs     = qalsgs_p     , qaisgs      = qaisgs_p      , &
                         !! ng        = ng_p        , qb         = volg_p                                   , &
                         nc        = nc_p        , nwfa       = nwfa_p       , nifa       = nifa_p       , &
                         nwfa2d    = nwfa2d_p    , nifa2d     = nifa2d_p                                 , &
@@ -670,7 +686,7 @@
                         qr        = qr_p        , qi         = qi_p         , qs         = qs_p         , &
                         qg        = qg_p        , ni         = ni_p         , nr         = nr_p         , &
                         ng        = ng_p        , qb         = volg_p                                   , &
-                        qasgs     = qasgs_p     , qcsgs      = qcsgs_p      , qisgs      = qisgs_p      , &
+                        qalsgs     = qalsgs_p     , qaisgs      = qaisgs_p      , &
                         !! nc        = nc_p        , nwfa       = nwfa_p       , nifa       = nifa_p       , &
                         !! nwfa2d    = nwfa2d_p    , nifa2d     = nifa2d_p                                 , &
                         pii       = pi_p        , p          = pres_p       , dz         = dz_p         , &
@@ -698,7 +714,9 @@
                      ng        = ng_p        , qb         = volg_p                                   , &
                      nc        = nc_p        , nwfa       = nwfa_p       , nifa       = nifa_p       , &
                      nwfa2d    = nwfa2d_p    , nifa2d     = nifa2d_p                                 , &
-                     qasgs     = qasgs_p     , qcsgs      = qcsgs_p      , qisgs      = qisgs_p      , &
+                     qalsgs     = qalsgs_p     , qaisgs      = qaisgs_p      , &                     
+                     rthbl = rthblten_p, rqvbl = rqvblten_p, rqcbl = rqcblten_p, rqibl = rqiblten_p  , &
+                     rthlw = rthratenlw_p, rthsw = rthratensw_p , &
                      pii       = pi_p        , p          = pres_p       , dz         = dz_p         , &
                      w         = w_p         , dt_in      = dt_microp    , itimestep  = itimestep    , &
                      rainnc    = rainnc_p    , rainncv    = rainncv_p    , snownc     = snownc_p     , &

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
@@ -226,17 +226,18 @@
           endif
 
           if (config_tempo_cldfra) then
-             if(.not.allocated(qalsgs_p)) allocate(qalsgs_p(ims:ime,kms:kme,jms:jme))
-             if(.not.allocated(qaisgs_p)) allocate(qaisgs_p(ims:ime,kms:kme,jms:jme))
+             if(.not.allocated(qal_p)) allocate(qal_p(ims:ime,kms:kme,jms:jme))
+             if(.not.allocated(qai_p)) allocate(qai_p(ims:ime,kms:kme,jms:jme))
+             if(.not.allocated(precipfrac_p)) allocate(precipfrac_p(ims:ime,kms:kme,jms:jme))
 
              if(.not.allocated(rthblten_p)) allocate(rthblten_p(ims:ime,kms:kme,jms:jme))
              if(.not.allocated(rqvblten_p)) allocate(rqvblten_p(ims:ime,kms:kme,jms:jme))
              if(.not.allocated(rqcblten_p)) allocate(rqcblten_p(ims:ime,kms:kme,jms:jme))
              if(.not.allocated(rqiblten_p)) allocate(rqiblten_p(ims:ime,kms:kme,jms:jme))
              if(.not.allocated(rthratenlw_p)) allocate(rthratenlw_p(ims:ime,kms:kme,jms:jme))
-             if(.not.allocated(rthratensw_p)) allocate(rthratensw_p(ims:ime,kms:kme,jms:jme))                                                    
+             if(.not.allocated(rthratensw_p)) allocate(rthratensw_p(ims:ime,kms:kme,jms:jme))
 !             if(.not.allocated(cldfrac_p) ) allocate(cldfrac_p(ims:ime,kms:kme,jms:jme))
-!             if(.not.allocated(qcbl_p) ) allocate(qcbl_p(ims:ime,kms:kme,jms:jme))             
+!             if(.not.allocated(qcbl_p) ) allocate(qcbl_p(ims:ime,kms:kme,jms:jme))
           endif
 
           if (config_tempo_ml_nc_pbl) then
@@ -405,17 +406,18 @@
           endif
 
           if (config_tempo_cldfra) then
-             if(allocated(qalsgs_p)) deallocate(qalsgs_p)
-             if(allocated(qaisgs_p)) deallocate(qaisgs_p)
+             if(allocated(qal_p)) deallocate(qal_p)
+             if(allocated(qai_p)) deallocate(qai_p)
+             if(allocated(precipfrac_p)) deallocate(precipfrac_p)
 
              if(allocated(rthblten_p)) deallocate(rthblten_p)
              if(allocated(rqvblten_p)) deallocate(rqvblten_p)
              if(allocated(rqcblten_p)) deallocate(rqcblten_p)
              if(allocated(rqiblten_p)) deallocate(rqiblten_p)
              if(allocated(rthratenlw_p)) deallocate(rthratenlw_p)
-             if(allocated(rthratensw_p)) deallocate(rthratensw_p)             
+             if(allocated(rthratensw_p)) deallocate(rthratensw_p)
 !             if(allocated(cldfrac_p) ) deallocate(cldfrac_p)
-!             if(allocated(qcbl_p) ) deallocate(qcbl_p)             
+!             if(allocated(qcbl_p) ) deallocate(qcbl_p)
           endif
 
           if (config_tempo_ml_nc_pbl) then
@@ -639,7 +641,7 @@
                      th        = th_p        , qv         = qv_p         , qc         = qc_p         , &
                      qr        = qr_p        , qi         = qi_p         , qs         = qs_p         , &
                      qg        = qg_p        , ni         = ni_p         , nr         = nr_p         , &
-                     qalsgs     = qalsgs_p     , qaisgs      = qaisgs_p      , &
+                     qal       = qal_p       , qai        = qai_p        , precipfrac = precipfrac_p , &
                      !! ng        = ng_p        , qb         = volg_p                                   , &
                      !! nc        = nc_p        , nwfa       = nwfa_p       , nifa       = nifa_p       , &
                      !! nwfa2d    = nwfa2d_p    , nifa2d     = nifa2d_p                                 , &
@@ -662,7 +664,7 @@
                         th        = th_p        , qv         = qv_p         , qc         = qc_p         , &
                         qr        = qr_p        , qi         = qi_p         , qs         = qs_p         , &
                         qg        = qg_p        , ni         = ni_p         , nr         = nr_p         , &
-                        qalsgs     = qalsgs_p     , qaisgs      = qaisgs_p      , &
+                        qal       = qal_p       , qai        = qai_p        , precipfrac = precipfrac_p , &
                         !! ng        = ng_p        , qb         = volg_p                                   , &
                         nc        = nc_p        , nwfa       = nwfa_p       , nifa       = nifa_p       , &
                         nwfa2d    = nwfa2d_p    , nifa2d     = nifa2d_p                                 , &
@@ -686,7 +688,7 @@
                         qr        = qr_p        , qi         = qi_p         , qs         = qs_p         , &
                         qg        = qg_p        , ni         = ni_p         , nr         = nr_p         , &
                         ng        = ng_p        , qb         = volg_p                                   , &
-                        qalsgs     = qalsgs_p     , qaisgs      = qaisgs_p      , &
+                        qal       = qal_p       , qai        = qai_p        , precipfrac = precipfrac_p , &
                         !! nc        = nc_p        , nwfa       = nwfa_p       , nifa       = nifa_p       , &
                         !! nwfa2d    = nwfa2d_p    , nifa2d     = nifa2d_p                                 , &
                         pii       = pi_p        , p          = pres_p       , dz         = dz_p         , &
@@ -714,7 +716,7 @@
                      ng        = ng_p        , qb         = volg_p                                   , &
                      nc        = nc_p        , nwfa       = nwfa_p       , nifa       = nifa_p       , &
                      nwfa2d    = nwfa2d_p    , nifa2d     = nifa2d_p                                 , &
-                     qalsgs     = qalsgs_p     , qaisgs      = qaisgs_p      , &                     
+                     qal       = qal_p       , qai        = qai_p        , precipfrac = precipfrac_p , &
                      rthbl = rthblten_p, rqvbl = rqvblten_p, rqcbl = rqcblten_p, rqibl = rqiblten_p  , &
                      rthlw = rthratenlw_p, rthsw = rthratensw_p , &
                      pii       = pi_p        , p          = pres_p       , dz         = dz_p         , &

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
@@ -111,6 +111,7 @@
  character(len=StrKIND),pointer:: nssl_moments
  logical,pointer:: config_tempo_hailaware, config_tempo_aerosolaware
  logical,pointer:: config_tempo_ml_nc_pbl
+ logical,pointer:: config_tempo_cldfra
 !-----------------------------------------------------------------------------------------------------------------
 
  call mpas_pool_get_config(configs,'config_microp_scheme',microp_scheme)
@@ -118,6 +119,7 @@
  call mpas_pool_get_config(configs,'config_tempo_hailaware',config_tempo_hailaware)
  call mpas_pool_get_config(configs,'config_tempo_aerosolaware',config_tempo_aerosolaware)
  call mpas_pool_get_config(configs,'config_tempo_ml_nc_pbl',config_tempo_ml_nc_pbl)
+ call mpas_pool_get_config(configs,'config_tempo_cldfra',config_tempo_cldfra)
 
 !sounding variables:
  if(.not.allocated(rho_p) ) allocate(rho_p(ims:ime,kms:kme,jms:jme) )
@@ -223,6 +225,11 @@
              if(.not.allocated(volg_p)) allocate(volg_p(ims:ime,kms:kme,jms:jme))
           endif
 
+          if (config_tempo_cldfra) then
+             if(.not.allocated(qasgs_p)) allocate(qasgs_p(ims:ime,kms:kme,jms:jme))
+             if(.not.allocated(qcsgs_p)) allocate(qcsgs_p(ims:ime,kms:kme,jms:jme))
+          endif
+
           if (config_tempo_ml_nc_pbl) then
              if(.not.allocated(cldfrac_p) ) allocate(cldfrac_p(ims:ime,kms:kme,jms:jme))
              if(.not.allocated(qcbl_p) ) allocate(qcbl_p(ims:ime,kms:kme,jms:jme))
@@ -275,6 +282,7 @@
  character(len=StrKIND),pointer:: nssl_moments
  logical,pointer:: config_tempo_hailaware, config_tempo_aerosolaware
  logical,pointer:: config_tempo_ml_nc_pbl
+ logical,pointer:: config_tempo_cldfra
 
 !-----------------------------------------------------------------------------------------------------------------
 
@@ -283,6 +291,7 @@
  call mpas_pool_get_config(configs,'config_tempo_hailaware',config_tempo_hailaware)
  call mpas_pool_get_config(configs,'config_tempo_aerosolaware',config_tempo_aerosolaware)
  call mpas_pool_get_config(configs,'config_tempo_ml_nc_pbl',config_tempo_ml_nc_pbl)
+ call mpas_pool_get_config(configs,'config_tempo_cldfra',config_tempo_cldfra)
 
 !sounding variables:
  if(allocated(rho_p) ) deallocate(rho_p )
@@ -384,6 +393,11 @@
           if (config_tempo_hailaware) then
              if(allocated(ng_p) ) deallocate(ng_p )
              if(allocated(volg_p) ) deallocate(volg_p )
+          endif
+
+          if (config_tempo_cldfra) then
+             if(allocated(qasgs_p)) deallocate(qasgs_p)
+             if(allocated(qcsgs_p)) deallocate(qcsgs_p)
           endif
 
           if (config_tempo_ml_nc_pbl) then
@@ -607,6 +621,7 @@
                      th        = th_p        , qv         = qv_p         , qc         = qc_p         , &
                      qr        = qr_p        , qi         = qi_p         , qs         = qs_p         , &
                      qg        = qg_p        , ni         = ni_p         , nr         = nr_p         , &
+                     qasgs     = qasgs_p     , qcsgs      = qcsgs_p                                  , &
                      !! ng        = ng_p        , qb         = volg_p                                   , &
                      !! nc        = nc_p        , nwfa       = nwfa_p       , nifa       = nifa_p       , &
                      !! nwfa2d    = nwfa2d_p    , nifa2d     = nifa2d_p                                 , &
@@ -629,6 +644,7 @@
                         th        = th_p        , qv         = qv_p         , qc         = qc_p         , &
                         qr        = qr_p        , qi         = qi_p         , qs         = qs_p         , &
                         qg        = qg_p        , ni         = ni_p         , nr         = nr_p         , &
+                        qasgs     = qasgs_p     , qcsgs      = qcsgs_p                                  , &
                         !! ng        = ng_p        , qb         = volg_p                                   , &
                         nc        = nc_p        , nwfa       = nwfa_p       , nifa       = nifa_p       , &
                         nwfa2d    = nwfa2d_p    , nifa2d     = nifa2d_p                                 , &
@@ -652,6 +668,7 @@
                         qr        = qr_p        , qi         = qi_p         , qs         = qs_p         , &
                         qg        = qg_p        , ni         = ni_p         , nr         = nr_p         , &
                         ng        = ng_p        , qb         = volg_p                                   , &
+                        qasgs     = qasgs_p     , qcsgs      = qcsgs_p                                  , &
                         !! nc        = nc_p        , nwfa       = nwfa_p       , nifa       = nifa_p       , &
                         !! nwfa2d    = nwfa2d_p    , nifa2d     = nifa2d_p                                 , &
                         pii       = pi_p        , p          = pres_p       , dz         = dz_p         , &
@@ -679,6 +696,7 @@
                      ng        = ng_p        , qb         = volg_p                                   , &
                      nc        = nc_p        , nwfa       = nwfa_p       , nifa       = nifa_p       , &
                      nwfa2d    = nwfa2d_p    , nifa2d     = nifa2d_p                                 , &
+                     qasgs     = qasgs_p     , qcsgs      = qcsgs_p                                  , &
                      pii       = pi_p        , p          = pres_p       , dz         = dz_p         , &
                      w         = w_p         , dt_in      = dt_microp    , itimestep  = itimestep    , &
                      rainnc    = rainnc_p    , rainncv    = rainncv_p    , snownc     = snownc_p     , &

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
@@ -440,12 +440,13 @@
  end subroutine deallocate_pbl
 
 !=================================================================================================================
- subroutine pbl_from_MPAS(configs,mesh,sfc_input,diag_physics,tend_physics,its,ite)
+ subroutine pbl_from_MPAS(configs,mesh,state,sfc_input,diag_physics,tend_physics,its,ite)
 !=================================================================================================================
 
 !input arguments:
  type(mpas_pool_type),intent(in):: configs
  type(mpas_pool_type),intent(in):: mesh
+ type(mpas_pool_type),intent(in):: state
  type(mpas_pool_type),intent(in):: diag_physics
  type(mpas_pool_type),intent(in):: sfc_input
  type(mpas_pool_type),intent(in):: tend_physics
@@ -474,7 +475,10 @@
  real(kind=RKIND),dimension(:,:),pointer:: cldfrac_bl,qc_bl,qi_bl
  real(kind=RKIND),dimension(:,:),pointer:: edmf_a,edmf_ent,edmf_qc,edmf_qt,edmf_thl,edmf_w
  real(kind=RKIND),dimension(:,:),pointer:: sub_thl,sub_qv,det_thl,det_qv
-      
+ real(kind=RKIND),dimension(:,:),pointer  :: qal, qai
+ real(kind=RKIND),dimension(:,:,:),pointer  :: scalars
+ integer,pointer:: index_qal, index_qai
+
 !local pointers for MYJ scheme:
  real(kind=RKIND),dimension(:),pointer   :: chlowq,thz0,qz0,uz0,vz0,ct,akhs,akms,lh,mixht
  real(kind=RKIND),dimension(:,:),pointer :: zgrid
@@ -675,6 +679,13 @@
        call mpas_pool_get_array(diag_physics,'det_thl'   ,det_thl   )
        call mpas_pool_get_array(diag_physics,'det_qv'    ,det_qv    )
 
+       call mpas_pool_get_array(state,'scalars',scalars)
+       call mpas_pool_get_dimension(state,'index_qal' ,index_qal  )
+       call mpas_pool_get_dimension(state,'index_qai' ,index_qai  )
+
+       qal => scalars(index_qal,:,:)
+       qai => scalars(index_qai,:,:)
+
        do j = jts,jte
        do i = its,ite
           dx_p(i,j)   = len_disp / meshDensity(i)**0.25
@@ -695,7 +706,8 @@
           qkeadv_p(i,k,j)   = qke_adv(k,i)
           sh3d_p(i,k,j)     = sh3d(k,i)
           sm3d_p(i,k,j)     = sm3d(k,i)
-          cldfrabl_p(i,k,j) = cldfrac_bl(k,i)
+!          cldfrabl_p(i,k,j) = cldfrac_bl(k,i)
+          cldfrabl_p(i,k,j) = max(qal(k,i), qai(k,i))
           qcbl_p(i,k,j)     = qc_bl(k,i)
           qibl_p(i,k,j)     = qi_bl(k,i)
           edmfa_p(i,k,j)    = edmf_a(k,i)
@@ -1176,12 +1188,13 @@
  end subroutine init_pbl
 
 !=================================================================================================================
- subroutine driver_pbl(itimestep,configs,mesh,sfc_input,diag_physics,tend_physics,its,ite)
+ subroutine driver_pbl(itimestep,configs,mesh,state,sfc_input,diag_physics,tend_physics,its,ite)
 !=================================================================================================================
 
 !input arguments:
  type(mpas_pool_type),intent(in):: configs
  type(mpas_pool_type),intent(in):: mesh
+ type(mpas_pool_type),intent(in):: state
 
  integer,intent(in):: its,ite
  integer,intent(in):: itimestep
@@ -1241,7 +1254,7 @@
  call mpas_pool_get_config(configs,'config_pbl_scheme'  ,pbl_scheme         )
 
 !copy MPAS arrays to local arrays:
- call pbl_from_MPAS(configs,mesh,sfc_input,diag_physics,tend_physics,its,ite)
+ call pbl_from_MPAS(configs,mesh,state,sfc_input,diag_physics,tend_physics,its,ite)
 
  initflag = 1
  if(config_do_restart .or. itimestep > 1) initflag = 0

--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -670,7 +670,7 @@
  integer,pointer:: index_zrw,index_zgw,index_zhw
  integer,pointer:: index_ns,index_ng,index_nh,index_nccn
  integer,pointer:: index_volg,index_volh
- integer,pointer:: index_qal_sgs, index_qai_sgs
+ integer,pointer:: index_qal, index_qai
 
  real(kind=RKIND),dimension(:,:),pointer  :: zgrid,w
  real(kind=RKIND),dimension(:,:),pointer  :: zz,exner,pressure_b
@@ -678,7 +678,7 @@
  real(kind=RKIND),dimension(:,:),pointer  :: qv,qc,qr,qi,qs,qg
  real(kind=RKIND),dimension(:,:),pointer  :: qh
  real(kind=RKIND),dimension(:,:),pointer  :: nc,ni,nr,nifa,nwfa
- real(kind=RKIND),dimension(:,:),pointer  :: qal_sgs, qai_sgs
+ real(kind=RKIND),dimension(:,:),pointer  :: qal, qai, precipfrac
  real(kind=RKIND),dimension(:,:),pointer  :: ns,ng,nh,nccn
  real(kind=RKIND),dimension(:,:),pointer  :: volg,volh,zrw,zgw,zhw
  real(kind=RKIND),dimension(:,:),pointer  :: rainprod,evapprod
@@ -949,36 +949,37 @@
              endif
 
              if (config_tempo_cldfra) then
-                call mpas_pool_get_dimension(state,'index_qal_sgs' ,index_qal_sgs  )
-                call mpas_pool_get_dimension(state,'index_qai_sgs' ,index_qai_sgs  )
-
+                call mpas_pool_get_dimension(state,'index_qal' ,index_qal  )
+                call mpas_pool_get_dimension(state,'index_qai' ,index_qai  )
+                call mpas_pool_get_array(diag_physics,'precipfrac', precipfrac)
                 call mpas_pool_get_array(tend_physics,'rthblten',rthblten)
                 call mpas_pool_get_array(tend_physics,'rqvblten',rqvblten)
                 call mpas_pool_get_array(tend_physics,'rqcblten',rqcblten)
                 call mpas_pool_get_array(tend_physics,'rqiblten',rqiblten)
                 call mpas_pool_get_array(tend_physics,'rthratenlw',rthratenlw)
-                call mpas_pool_get_array(tend_physics,'rthratensw',rthratensw)                                
+                call mpas_pool_get_array(tend_physics,'rthratensw',rthratensw)
 
 !                call mpas_pool_get_array(diag_physics,'qc_bl',qc_bl)
 !                call mpas_pool_get_array(diag_physics,'cldfrac_bl',cldfrac_bl)
-                
-                qal_sgs => scalars(index_qal_sgs,:,:)
-                qai_sgs => scalars(index_qai_sgs,:,:)
+
+                qal => scalars(index_qal,:,:)
+                qai => scalars(index_qai,:,:)
 
                 do j = jts, jte
                 do k = kts, kte
                 do i = its, ite
-                   qalsgs_p(i,k,j) = qal_sgs(k,i)
-                   qaisgs_p(i,k,j) = qai_sgs(k,i)
+                   qal_p(i,k,j) = qal(k,i)
+                   qai_p(i,k,j) = qai(k,i)
 
+                   precipfrac_p(i,k,j) = precipfrac(k,i)
                    rthblten_p(i,k,j) = rthblten(k,i)
                    rqvblten_p(i,k,j) = rqvblten(k,i)
                    rqcblten_p(i,k,j) = rqcblten(k,i)
                    rqiblten_p(i,k,j) = rqiblten(k,i)
                    rthratenlw_p(i,k,j) = rthratenlw(k,i)
-                   rthratensw_p(i,k,j) = rthratensw(k,i)                                                         
+                   rthratensw_p(i,k,j) = rthratensw(k,i)
 !                   qcbl_p(i,k,j) = qc_bl(k,i)
-!                   cldfrac_p(i,k,j) = cldfrac_bl(k,i)                   
+!                   cldfrac_p(i,k,j) = cldfrac_bl(k,i)
                 enddo
                 enddo
                 enddo
@@ -1195,7 +1196,7 @@
  logical,pointer:: config_tempo_cldfra
  integer,pointer:: index_qv,index_qc,index_qr,index_qi,index_qs,index_qg
  integer,pointer:: index_nc,index_ni,index_nr,index_nifa,index_nwfa
- integer,pointer:: index_qal_sgs, index_qai_sgs
+ integer,pointer:: index_qal, index_qai
 !TEMPO/NSSL
  integer,pointer:: index_qh
  integer,pointer:: index_zrw,index_zgw,index_zhw
@@ -1212,7 +1213,7 @@
  real(kind=RKIND),dimension(:,:),pointer  :: qv,qc,qr,qi,qs,qg
  real(kind=RKIND),dimension(:,:),pointer  :: qh
  real(kind=RKIND),dimension(:,:),pointer  :: nc,ni,nr,nifa,nwfa
- real(kind=RKIND),dimension(:,:),pointer  :: qal_sgs, qai_sgs
+ real(kind=RKIND),dimension(:,:),pointer  :: qal, qai, precipfrac
  real(kind=RKIND),dimension(:,:),pointer  :: ns,ng,nh,nccn
  real(kind=RKIND),dimension(:,:),pointer  :: volg,volh,zrw,zgw,zhw
  real(kind=RKIND),dimension(:)  ,pointer  :: max_hail_diameter_sfc, max_hail_diameter_column
@@ -1495,17 +1496,19 @@
              endif
 
              if (config_tempo_cldfra) then
-                call mpas_pool_get_dimension(state,'index_qal_sgs' ,index_qal_sgs  )
-                call mpas_pool_get_dimension(state,'index_qai_sgs' ,index_qai_sgs  )
-                
-                qal_sgs => scalars(index_qal_sgs,:,:)
-                qai_sgs => scalars(index_qai_sgs,:,:)                
+                call mpas_pool_get_dimension(state,'index_qal' ,index_qal  )
+                call mpas_pool_get_dimension(state,'index_qai' ,index_qai  )
+                call mpas_pool_get_array(diag_physics,'precipfrac' ,precipfrac )
+
+                qal => scalars(index_qal,:,:)
+                qai => scalars(index_qai,:,:)
 
                 do j = jts, jte
                 do k = kts, kte
                 do i = its, ite
-                   qal_sgs(k,i) = qalsgs_p(i,k,j)
-                   qai_sgs(k,i) = qaisgs_p(i,k,j)
+                   qal(k,i) = qal_p(i,k,j)
+                   qai(k,i) = qai_p(i,k,j)
+                   precipfrac(k,i) = precipfrac_p(i,k,j)
                 enddo
                 enddo
                 enddo

--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -670,7 +670,7 @@
  integer,pointer:: index_zrw,index_zgw,index_zhw
  integer,pointer:: index_ns,index_ng,index_nh,index_nccn
  integer,pointer:: index_volg,index_volh
- integer,pointer:: index_qa_sgs, index_qc_sgs
+ integer,pointer:: index_qa_sgs, index_qc_sgs, index_qi_sgs
 
  real(kind=RKIND),dimension(:,:),pointer  :: zgrid,w
  real(kind=RKIND),dimension(:,:),pointer  :: zz,exner,pressure_b
@@ -678,7 +678,7 @@
  real(kind=RKIND),dimension(:,:),pointer  :: qv,qc,qr,qi,qs,qg
  real(kind=RKIND),dimension(:,:),pointer  :: qh
  real(kind=RKIND),dimension(:,:),pointer  :: nc,ni,nr,nifa,nwfa
- real(kind=RKIND),dimension(:,:),pointer  :: qa_sgs, qc_sgs
+ real(kind=RKIND),dimension(:,:),pointer  :: qa_sgs, qc_sgs, qi_sgs
  real(kind=RKIND),dimension(:,:),pointer  :: ns,ng,nh,nccn
  real(kind=RKIND),dimension(:,:),pointer  :: volg,volh,zrw,zgw,zhw
  real(kind=RKIND),dimension(:,:),pointer  :: rainprod,evapprod
@@ -950,15 +950,18 @@
              if (config_tempo_cldfra) then
                 call mpas_pool_get_dimension(state,'index_qa_sgs' ,index_qa_sgs  )
                 call mpas_pool_get_dimension(state,'index_qc_sgs' ,index_qc_sgs  )
+                call mpas_pool_get_dimension(state,'index_qi_sgs' ,index_qi_sgs  )
 
                 qa_sgs => scalars(index_qa_sgs,:,:)
                 qc_sgs => scalars(index_qc_sgs,:,:)
+                qi_sgs => scalars(index_qi_sgs,:,:)
 
                 do j = jts, jte
                 do k = kts, kte
                 do i = its, ite
                    qasgs_p(i,k,j) = qa_sgs(k,i)
                    qcsgs_p(i,k,j) = qc_sgs(k,i)
+                   qisgs_p(i,k,j) = qi_sgs(k,i)
                 enddo
                 enddo
                 enddo
@@ -1175,7 +1178,7 @@
  logical,pointer:: config_tempo_cldfra
  integer,pointer:: index_qv,index_qc,index_qr,index_qi,index_qs,index_qg
  integer,pointer:: index_nc,index_ni,index_nr,index_nifa,index_nwfa
- integer,pointer:: index_qa_sgs, index_qc_sgs
+ integer,pointer:: index_qa_sgs, index_qc_sgs, index_qi_sgs
 !TEMPO/NSSL
  integer,pointer:: index_qh
  integer,pointer:: index_zrw,index_zgw,index_zhw
@@ -1192,7 +1195,7 @@
  real(kind=RKIND),dimension(:,:),pointer  :: qv,qc,qr,qi,qs,qg
  real(kind=RKIND),dimension(:,:),pointer  :: qh
  real(kind=RKIND),dimension(:,:),pointer  :: nc,ni,nr,nifa,nwfa
- real(kind=RKIND),dimension(:,:),pointer  :: qa_sgs, qc_sgs
+ real(kind=RKIND),dimension(:,:),pointer  :: qa_sgs, qc_sgs, qi_sgs
  real(kind=RKIND),dimension(:,:),pointer  :: ns,ng,nh,nccn
  real(kind=RKIND),dimension(:,:),pointer  :: volg,volh,zrw,zgw,zhw
  real(kind=RKIND),dimension(:)  ,pointer  :: max_hail_diameter_sfc, max_hail_diameter_column
@@ -1477,15 +1480,18 @@
              if (config_tempo_cldfra) then
                 call mpas_pool_get_dimension(state,'index_qa_sgs' ,index_qa_sgs  )
                 call mpas_pool_get_dimension(state,'index_qc_sgs' ,index_qc_sgs  )
+                call mpas_pool_get_dimension(state,'index_qi_sgs' ,index_qi_sgs  )
 
                 qa_sgs => scalars(index_qa_sgs,:,:)
                 qc_sgs => scalars(index_qc_sgs,:,:)
+                qi_sgs => scalars(index_qi_sgs,:,:)
 
                 do j = jts, jte
                 do k = kts, kte
                 do i = its, ite
                    qa_sgs(k,i) = qasgs_p(i,k,j)
                    qc_sgs(k,i) = qcsgs_p(i,k,j)
+                   qi_sgs(k,i) = qisgs_p(i,k,j)
                 enddo
                 enddo
                 enddo

--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -670,7 +670,7 @@
  integer,pointer:: index_zrw,index_zgw,index_zhw
  integer,pointer:: index_ns,index_ng,index_nh,index_nccn
  integer,pointer:: index_volg,index_volh
- integer,pointer:: index_qa_sgs, index_qc_sgs, index_qi_sgs
+ integer,pointer:: index_qal_sgs, index_qai_sgs
 
  real(kind=RKIND),dimension(:,:),pointer  :: zgrid,w
  real(kind=RKIND),dimension(:,:),pointer  :: zz,exner,pressure_b
@@ -678,7 +678,7 @@
  real(kind=RKIND),dimension(:,:),pointer  :: qv,qc,qr,qi,qs,qg
  real(kind=RKIND),dimension(:,:),pointer  :: qh
  real(kind=RKIND),dimension(:,:),pointer  :: nc,ni,nr,nifa,nwfa
- real(kind=RKIND),dimension(:,:),pointer  :: qa_sgs, qc_sgs, qi_sgs
+ real(kind=RKIND),dimension(:,:),pointer  :: qal_sgs, qai_sgs
  real(kind=RKIND),dimension(:,:),pointer  :: ns,ng,nh,nccn
  real(kind=RKIND),dimension(:,:),pointer  :: volg,volh,zrw,zgw,zhw
  real(kind=RKIND),dimension(:,:),pointer  :: rainprod,evapprod
@@ -688,6 +688,7 @@
  real(kind=RKIND),dimension(:,:),pointer  :: qc_bl, cldfrac_bl
  real(kind=RKIND),dimension(:,:),pointer  :: rthmpten,rqvmpten,rqcmpten,rqrmpten,rqimpten,rqsmpten,rqgmpten
  real(kind=RKIND),dimension(:,:),pointer  :: rncmpten,rnimpten,rnrmpten,rnifampten,rnwfampten
+ real(kind=RKIND),dimension(:,:),pointer  :: rthblten, rqvblten, rqcblten, rqiblten, rthratenlw, rthratensw
  real(kind=RKIND),dimension(:,:,:),pointer:: scalars
 
 !local variables:
@@ -948,20 +949,36 @@
              endif
 
              if (config_tempo_cldfra) then
-                call mpas_pool_get_dimension(state,'index_qa_sgs' ,index_qa_sgs  )
-                call mpas_pool_get_dimension(state,'index_qc_sgs' ,index_qc_sgs  )
-                call mpas_pool_get_dimension(state,'index_qi_sgs' ,index_qi_sgs  )
+                call mpas_pool_get_dimension(state,'index_qal_sgs' ,index_qal_sgs  )
+                call mpas_pool_get_dimension(state,'index_qai_sgs' ,index_qai_sgs  )
 
-                qa_sgs => scalars(index_qa_sgs,:,:)
-                qc_sgs => scalars(index_qc_sgs,:,:)
-                qi_sgs => scalars(index_qi_sgs,:,:)
+                call mpas_pool_get_array(tend_physics,'rthblten',rthblten)
+                call mpas_pool_get_array(tend_physics,'rqvblten',rqvblten)
+                call mpas_pool_get_array(tend_physics,'rqcblten',rqcblten)
+                call mpas_pool_get_array(tend_physics,'rqiblten',rqiblten)
+                call mpas_pool_get_array(tend_physics,'rthratenlw',rthratenlw)
+                call mpas_pool_get_array(tend_physics,'rthratensw',rthratensw)                                
+
+!                call mpas_pool_get_array(diag_physics,'qc_bl',qc_bl)
+!                call mpas_pool_get_array(diag_physics,'cldfrac_bl',cldfrac_bl)
+                
+                qal_sgs => scalars(index_qal_sgs,:,:)
+                qai_sgs => scalars(index_qai_sgs,:,:)
 
                 do j = jts, jte
                 do k = kts, kte
                 do i = its, ite
-                   qasgs_p(i,k,j) = qa_sgs(k,i)
-                   qcsgs_p(i,k,j) = qc_sgs(k,i)
-                   qisgs_p(i,k,j) = qi_sgs(k,i)
+                   qalsgs_p(i,k,j) = qal_sgs(k,i)
+                   qaisgs_p(i,k,j) = qai_sgs(k,i)
+
+                   rthblten_p(i,k,j) = rthblten(k,i)
+                   rqvblten_p(i,k,j) = rqvblten(k,i)
+                   rqcblten_p(i,k,j) = rqcblten(k,i)
+                   rqiblten_p(i,k,j) = rqiblten(k,i)
+                   rthratenlw_p(i,k,j) = rthratenlw(k,i)
+                   rthratensw_p(i,k,j) = rthratensw(k,i)                                                         
+!                   qcbl_p(i,k,j) = qc_bl(k,i)
+!                   cldfrac_p(i,k,j) = cldfrac_bl(k,i)                   
                 enddo
                 enddo
                 enddo
@@ -1178,7 +1195,7 @@
  logical,pointer:: config_tempo_cldfra
  integer,pointer:: index_qv,index_qc,index_qr,index_qi,index_qs,index_qg
  integer,pointer:: index_nc,index_ni,index_nr,index_nifa,index_nwfa
- integer,pointer:: index_qa_sgs, index_qc_sgs, index_qi_sgs
+ integer,pointer:: index_qal_sgs, index_qai_sgs
 !TEMPO/NSSL
  integer,pointer:: index_qh
  integer,pointer:: index_zrw,index_zgw,index_zhw
@@ -1195,7 +1212,7 @@
  real(kind=RKIND),dimension(:,:),pointer  :: qv,qc,qr,qi,qs,qg
  real(kind=RKIND),dimension(:,:),pointer  :: qh
  real(kind=RKIND),dimension(:,:),pointer  :: nc,ni,nr,nifa,nwfa
- real(kind=RKIND),dimension(:,:),pointer  :: qa_sgs, qc_sgs, qi_sgs
+ real(kind=RKIND),dimension(:,:),pointer  :: qal_sgs, qai_sgs
  real(kind=RKIND),dimension(:,:),pointer  :: ns,ng,nh,nccn
  real(kind=RKIND),dimension(:,:),pointer  :: volg,volh,zrw,zgw,zhw
  real(kind=RKIND),dimension(:)  ,pointer  :: max_hail_diameter_sfc, max_hail_diameter_column
@@ -1478,20 +1495,17 @@
              endif
 
              if (config_tempo_cldfra) then
-                call mpas_pool_get_dimension(state,'index_qa_sgs' ,index_qa_sgs  )
-                call mpas_pool_get_dimension(state,'index_qc_sgs' ,index_qc_sgs  )
-                call mpas_pool_get_dimension(state,'index_qi_sgs' ,index_qi_sgs  )
-
-                qa_sgs => scalars(index_qa_sgs,:,:)
-                qc_sgs => scalars(index_qc_sgs,:,:)
-                qi_sgs => scalars(index_qi_sgs,:,:)
+                call mpas_pool_get_dimension(state,'index_qal_sgs' ,index_qal_sgs  )
+                call mpas_pool_get_dimension(state,'index_qai_sgs' ,index_qai_sgs  )
+                
+                qal_sgs => scalars(index_qal_sgs,:,:)
+                qai_sgs => scalars(index_qai_sgs,:,:)                
 
                 do j = jts, jte
                 do k = kts, kte
                 do i = its, ite
-                   qa_sgs(k,i) = qasgs_p(i,k,j)
-                   qc_sgs(k,i) = qcsgs_p(i,k,j)
-                   qi_sgs(k,i) = qisgs_p(i,k,j)
+                   qal_sgs(k,i) = qalsgs_p(i,k,j)
+                   qai_sgs(k,i) = qaisgs_p(i,k,j)
                 enddo
                 enddo
                 enddo

--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -665,17 +665,20 @@
  character(len=StrKIND),pointer:: nssl_moments
  logical,pointer:: config_tempo_hailaware, config_tempo_aerosolaware
  logical,pointer:: config_tempo_ml_nc_pbl
+ logical,pointer:: config_tempo_cldfra
  integer,pointer:: index_qh
  integer,pointer:: index_zrw,index_zgw,index_zhw
  integer,pointer:: index_ns,index_ng,index_nh,index_nccn
  integer,pointer:: index_volg,index_volh
- 
+ integer,pointer:: index_qasgs, index_qcsgs
+
  real(kind=RKIND),dimension(:,:),pointer  :: zgrid,w
  real(kind=RKIND),dimension(:,:),pointer  :: zz,exner,pressure_b
  real(kind=RKIND),dimension(:,:),pointer  :: rho_zz,theta_m,pressure_p
  real(kind=RKIND),dimension(:,:),pointer  :: qv,qc,qr,qi,qs,qg
  real(kind=RKIND),dimension(:,:),pointer  :: qh
  real(kind=RKIND),dimension(:,:),pointer  :: nc,ni,nr,nifa,nwfa
+ real(kind=RKIND),dimension(:,:),pointer  :: qa_sgs, qc_sgs
  real(kind=RKIND),dimension(:,:),pointer  :: ns,ng,nh,nccn
  real(kind=RKIND),dimension(:,:),pointer  :: volg,volh,zrw,zgw,zhw
  real(kind=RKIND),dimension(:,:),pointer  :: rainprod,evapprod
@@ -697,6 +700,7 @@
  call mpas_pool_get_config(configs,'config_tempo_hailaware',config_tempo_hailaware)
  call mpas_pool_get_config(configs,'config_tempo_aerosolaware',config_tempo_aerosolaware)
  call mpas_pool_get_config(configs,'config_tempo_ml_nc_pbl',config_tempo_ml_nc_pbl)
+ call mpas_pool_get_config(configs,'config_tempo_cldfra',config_tempo_cldfra)
 
  call mpas_pool_get_array(mesh,'zgrid',zgrid)
  call mpas_pool_get_array(mesh,'zz'   ,zz   )
@@ -943,6 +947,23 @@
                 enddo
              endif
 
+             if (config_tempo_cldfra) then
+                call mpas_pool_get_dimension(state,'index_qasgs' ,index_qasgs  )
+                call mpas_pool_get_dimension(state,'index_qcsgs' ,index_qcsgs  )
+
+                qa_sgs => scalars(index_qasgs,:,:)
+                qc_sgs => scalars(index_qcsgs,:,:)
+
+                do j = jts, jte
+                do k = kts, kte
+                do i = its, ite
+                   qasgs_p(i,k,j) = qa_sgs(k,i)
+                   qcsgs_p(i,k,j) = qc_sgs(k,i)
+                enddo
+                enddo
+                enddo
+             endif
+
           case("mp_nssl2m")
              call mpas_pool_get_dimension(state,'index_ni',index_ni)
              call mpas_pool_get_dimension(state,'index_nr',index_nr)
@@ -1151,8 +1172,10 @@
  character(len=StrKIND),pointer:: mp_scheme
  character(len=StrKIND),pointer:: nssl_moments
  logical,pointer:: config_tempo_hailaware, config_tempo_aerosolaware
+ logical,pointer:: config_tempo_cldfra
  integer,pointer:: index_qv,index_qc,index_qr,index_qi,index_qs,index_qg
  integer,pointer:: index_nc,index_ni,index_nr,index_nifa,index_nwfa
+ integer,pointer:: index_qasgs, index_qcsgs
 !TEMPO/NSSL
  integer,pointer:: index_qh
  integer,pointer:: index_zrw,index_zgw,index_zhw
@@ -1169,6 +1192,7 @@
  real(kind=RKIND),dimension(:,:),pointer  :: qv,qc,qr,qi,qs,qg
  real(kind=RKIND),dimension(:,:),pointer  :: qh
  real(kind=RKIND),dimension(:,:),pointer  :: nc,ni,nr,nifa,nwfa
+ real(kind=RKIND),dimension(:,:),pointer  :: qa_sgs, qc_sgs
  real(kind=RKIND),dimension(:,:),pointer  :: ns,ng,nh,nccn
  real(kind=RKIND),dimension(:,:),pointer  :: volg,volh,zrw,zgw,zhw
  real(kind=RKIND),dimension(:)  ,pointer  :: max_hail_diameter_sfc, max_hail_diameter_column
@@ -1189,6 +1213,7 @@
  call mpas_pool_get_config(configs,'config_nssl_moments',nssl_moments)
  call mpas_pool_get_config(configs,'config_tempo_hailaware',config_tempo_hailaware)
  call mpas_pool_get_config(configs,'config_tempo_aerosolaware',config_tempo_aerosolaware)
+ call mpas_pool_get_config(configs,'config_tempo_cldfra',config_tempo_cldfra)
 
  call mpas_pool_get_array(mesh,'zz'   ,zz   )
  call mpas_pool_get_array(mesh,'zgrid',zgrid)
@@ -1444,6 +1469,23 @@
                 do i = its, ite
                    ng(k,i) = ng_p(i,k,j)
                    volg(k,i) = volg_p(i,k,j)
+                enddo
+                enddo
+                enddo
+             endif
+
+             if (config_tempo_cldfra) then
+                call mpas_pool_get_dimension(state,'index_qasgs' ,index_qasgs  )
+                call mpas_pool_get_dimension(state,'index_qcsgs' ,index_qcsgs  )
+
+                qa_sgs => scalars(index_qasgs,:,:)
+                qc_sgs => scalars(index_qcsgs,:,:)
+
+                do j = jts, jte
+                do k = kts, kte
+                do i = its, ite
+                   qa_sgs(k,i) = qasgs_p(i,k,j)
+                   qc_sgs(k,i) = qcsgs_p(i,k,j)
                 enddo
                 enddo
                 enddo

--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -670,7 +670,7 @@
  integer,pointer:: index_zrw,index_zgw,index_zhw
  integer,pointer:: index_ns,index_ng,index_nh,index_nccn
  integer,pointer:: index_volg,index_volh
- integer,pointer:: index_qasgs, index_qcsgs
+ integer,pointer:: index_qa_sgs, index_qc_sgs
 
  real(kind=RKIND),dimension(:,:),pointer  :: zgrid,w
  real(kind=RKIND),dimension(:,:),pointer  :: zz,exner,pressure_b
@@ -948,11 +948,11 @@
              endif
 
              if (config_tempo_cldfra) then
-                call mpas_pool_get_dimension(state,'index_qasgs' ,index_qasgs  )
-                call mpas_pool_get_dimension(state,'index_qcsgs' ,index_qcsgs  )
+                call mpas_pool_get_dimension(state,'index_qa_sgs' ,index_qa_sgs  )
+                call mpas_pool_get_dimension(state,'index_qc_sgs' ,index_qc_sgs  )
 
-                qa_sgs => scalars(index_qasgs,:,:)
-                qc_sgs => scalars(index_qcsgs,:,:)
+                qa_sgs => scalars(index_qa_sgs,:,:)
+                qc_sgs => scalars(index_qc_sgs,:,:)
 
                 do j = jts, jte
                 do k = kts, kte
@@ -1175,7 +1175,7 @@
  logical,pointer:: config_tempo_cldfra
  integer,pointer:: index_qv,index_qc,index_qr,index_qi,index_qs,index_qg
  integer,pointer:: index_nc,index_ni,index_nr,index_nifa,index_nwfa
- integer,pointer:: index_qasgs, index_qcsgs
+ integer,pointer:: index_qa_sgs, index_qc_sgs
 !TEMPO/NSSL
  integer,pointer:: index_qh
  integer,pointer:: index_zrw,index_zgw,index_zhw
@@ -1475,11 +1475,11 @@
              endif
 
              if (config_tempo_cldfra) then
-                call mpas_pool_get_dimension(state,'index_qasgs' ,index_qasgs  )
-                call mpas_pool_get_dimension(state,'index_qcsgs' ,index_qcsgs  )
+                call mpas_pool_get_dimension(state,'index_qa_sgs' ,index_qa_sgs  )
+                call mpas_pool_get_dimension(state,'index_qc_sgs' ,index_qc_sgs  )
 
-                qa_sgs => scalars(index_qasgs,:,:)
-                qc_sgs => scalars(index_qcsgs,:,:)
+                qa_sgs => scalars(index_qa_sgs,:,:)
+                qc_sgs => scalars(index_qc_sgs,:,:)
 
                 do j = jts, jte
                 do k = kts, kte

--- a/src/core_atmosphere/physics/mpas_atmphys_packages.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_packages.F
@@ -39,9 +39,9 @@
  character(len=StrKIND),pointer:: config_convection_scheme
  character(len=StrKIND),pointer:: config_pbl_scheme
  character(len=StrKIND),pointer:: config_lsm_scheme
- logical,pointer:: config_tempo_hailaware, config_tempo_aerosolaware
+ logical,pointer:: config_tempo_hailaware, config_tempo_aerosolaware, config_tempo_cldfra
  logical,pointer:: mp_kessler_in,mp_thompson_in,mp_thompson_aers_in,mp_wsm6_in,mp_nssl2m_in,nssl3m_in
- logical,pointer:: mp_tempo_in, tempo_hailaware_in, tempo_aerosolaware_in
+ logical,pointer:: mp_tempo_in, tempo_hailaware_in, tempo_aerosolaware_in, tempo_cldfra_in
  logical,pointer:: cu_grell_freitas_in,cu_grell_freitas_li_in,cu_kain_fritsch_in,cu_ntiedtke_in
  logical,pointer:: bl_mynn_in,bl_mynnedmf_in,bl_ysu_in,bl_myj_in
  logical,pointer:: lsm_noah_in,lsm_ruc_in
@@ -65,6 +65,7 @@
  call mpas_pool_get_config(configs,'config_nssl_moments',config_nssl_moments)
  call mpas_pool_get_config(configs,'config_tempo_hailaware',config_tempo_hailaware)
  call mpas_pool_get_config(configs,'config_tempo_aerosolaware',config_tempo_aerosolaware)
+ call mpas_pool_get_config(configs,'config_tempo_cldfra',config_tempo_cldfra)
 
  nullify(mp_kessler_in)
  call mpas_pool_get_package(packages,'mp_kessler_inActive',mp_kessler_in)
@@ -83,6 +84,9 @@
  
  nullify(tempo_hailaware_in)
  call mpas_pool_get_package(packages,'tempo_hailaware_inActive',tempo_hailaware_in)
+
+ nullify(tempo_cldfra_in)
+ call mpas_pool_get_package(packages,'tempo_cldfra_inActive',tempo_cldfra_in)
  
  nullify(mp_wsm6_in)
  call mpas_pool_get_package(packages,'mp_wsm6_inActive',mp_wsm6_in)
@@ -112,6 +116,7 @@
  mp_tempo_in         = .false.
  tempo_aerosolaware_in  = .false.
  tempo_hailaware_in  = .false.
+ tempo_cldfra_in  = .false.
  mp_wsm6_in          = .false.
  mp_nssl2m_in            = .false.
  nssl3m_in               = .false.
@@ -132,6 +137,9 @@
     if (config_tempo_hailaware) then
        tempo_hailaware_in = .true.
     endif
+    if (config_tempo_cldfra) then
+       tempo_cldfra_in = .true.
+    endif
  elseif(config_microp_scheme == 'mp_nssl2m') then
     mp_nssl2m_in = .true.
     IF ( config_nssl_moments == 'nssl3m' ) THEN
@@ -145,6 +153,7 @@
  call mpas_log_write('    mp_tempo_in             = $l', logicArgs=(/mp_tempo_in/))
  call mpas_log_write('    tempo_aerosolaware_in   = $l', logicArgs=(/tempo_aerosolaware_in/))
  call mpas_log_write('    tempo_hailaware_in      = $l', logicArgs=(/tempo_hailaware_in/))
+ call mpas_log_write('    tempo_cldfra_in         = $l', logicArgs=(/tempo_cldfra_in/))
  call mpas_log_write('    mp_wsm6_in              = $l', logicArgs=(/mp_wsm6_in/))
  call mpas_log_write('    mp_nssl2m_in            = $l', logicArgs=(/mp_nssl2m_in/))
  call mpas_log_write('    nssl3m_in               = $l', logicArgs=(/nssl3m_in/))

--- a/src/core_atmosphere/physics/mpas_atmphys_vars.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_vars.F
@@ -219,7 +219,10 @@
     muc_p,            &!
     ntc_p,            &!
     nifa2d_p
-      
+
+ real(kind=RKIND),dimension(:,:,:),allocatable:: &
+      qasgs_p, qcsgs_p
+
 !... arrays located at w (vertical velocity) points, or at interface between layers:
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     w_p,              &!vertical velocity                                                     [m/s]

--- a/src/core_atmosphere/physics/mpas_atmphys_vars.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_vars.F
@@ -221,7 +221,7 @@
     nifa2d_p
 
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
-      qasgs_p, qcsgs_p
+      qasgs_p, qcsgs_p, qisgs_p
 
 !... arrays located at w (vertical velocity) points, or at interface between layers:
  real(kind=RKIND),dimension(:,:,:),allocatable:: &

--- a/src/core_atmosphere/physics/mpas_atmphys_vars.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_vars.F
@@ -221,7 +221,7 @@
     nifa2d_p
 
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
-      qalsgs_p, qaisgs_p
+      qal_p, qai_p, precipfrac_p
 
 !... arrays located at w (vertical velocity) points, or at interface between layers:
  real(kind=RKIND),dimension(:,:,:),allocatable:: &

--- a/src/core_atmosphere/physics/mpas_atmphys_vars.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_vars.F
@@ -221,7 +221,7 @@
     nifa2d_p
 
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
-      qasgs_p, qcsgs_p, qisgs_p
+      qalsgs_p, qaisgs_p
 
 !... arrays located at w (vertical velocity) points, or at interface between layers:
  real(kind=RKIND),dimension(:,:,:),allocatable:: &


### PR DESCRIPTION
This PR adds prognostic sub-grid scale (sgs) clouds to TEMPO microphysics and MPAS. This option is turned on by setting `config_tempo_cldfra=.true.` in an MPAS namelist. This option forces the radiation to use this prognostic cloud fraction along with sgs cloud water and cloud ice mixing ratios. 

setting `config_tempo_incld=.true.` should be used with the cloud fraction scheme to use in-cloud microphysical processes.

Two state variables (which are advected) have been added, qal and qai, which are the prognostic cloud fractions for cloud water and cloud ice. 

Testing and relations to other Pull Requests should be added as subsequent comments.

See the below examples for more information.
https://github.com/MPAS-Dev/MPAS/pull/930
https://github.com/MPAS-Dev/MPAS/pull/931

Information on running mandatory regression tests on Jet can be found [here](https://github.com/barlage/mpas_testcase) and the results pasted below.

<details>
  <summary>
    regression test case results
  </summary>
  
```
PASTE compare_run_testcases AND/OR compare_create_testcases TEXT HERE
```
</details>
