### PR TITLE
Updates to the MYNN-EDMF

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MPAS-v8.3.0-1.10
+MPAS-v8.3.0-1.11
 ====
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -2958,6 +2958,11 @@
                      description="=0:activatevmixing of moisture species separately;= 1:activate mixing of total water in the mynn PBL scheme"
                      possible_values="0,1"/>
 
+		<nml_option name="config_mynn_ess" type="integer" default_value="1" in_defaults="false"
+                     units="-"
+                     description="=0:use buoyancy-flux functions;= 1:use O-Gorman (2011)"
+                     possible_values="0,1"/>
+
                 <nml_option name="config_icloud_bl" type="integer" default_value="1" in_defaults="false"
                      units="-"
                      description="configuration for MYNN subgrid cloud coupling to radiation"

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -2761,6 +2761,11 @@
                      description="Logical flag to turn on/off prognostic graupel number concentration and rime density"
                      possible_values=".true. or .false."/>
 
+		<nml_option name="config_tempo_cldfra" type="logical" default_value="false" in_defaults="false"
+		     units="-"
+                     description="Logical flag to turn on/off prognostic cloud fraction"
+                     possible_values=".true. or .false."/>
+
 		<nml_option name="config_tempo_ml_nc_pbl" type="logical" default_value="false" in_defaults="false"
 		     units="-"
                      description="Logical flag to turn on/off ML prediction of boundary layer cloud number concentrations"

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.3.0-1.10">
+<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.3.0-1.11">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->

--- a/src/core_atmosphere/physics/mpas_atmphys_control.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_control.F
@@ -106,7 +106,8 @@
                                   config_radt_lw_scheme,    &
                                   config_radt_sw_scheme,    &
                                   config_sfclayer_scheme
-
+ integer,pointer:: config_mynn_cloudpdf
+ logical,pointer:: config_tempo_cldfra
 !-----------------------------------------------------------------------------------------------------------------
 !call mpas_log_write('')
 !call mpas_log_write('--- enter subroutine physics_namelist_check:')
@@ -121,6 +122,8 @@
  call mpas_pool_get_config(configs,'config_radt_lw_scheme'   ,config_radt_lw_scheme   )
  call mpas_pool_get_config(configs,'config_radt_sw_scheme'   ,config_radt_sw_scheme   )
  call mpas_pool_get_config(configs,'config_sfclayer_scheme'  ,config_sfclayer_scheme  )
+ call mpas_pool_get_config(configs,'config_tempo_cldfra'     ,config_tempo_cldfra     )
+ call mpas_pool_get_config(configs,'config_mynn_cloudpdf'    ,config_mynn_cloudpdf    )
 
  call mpas_log_write('')
  call mpas_log_write('----- Setting up physics suite '''//trim(config_physics_suite)//''' -----')
@@ -294,6 +297,19 @@
 
  endif
 
+ if ((config_microp_scheme .eq. 'mp_tempo') .and. (config_tempo_cldfra)) then
+    write(mpas_err_message,'(A,A20)') &
+      '     setting cloud fraction to config_radt_cld_scheme = cld_tempo'
+    call physics_message(mpas_err_message)
+    config_radt_cld_scheme = "cld_tempo"
+    if ((config_pbl_scheme == 'bl_mynn') .and. (config_mynn_cloudpdf .ge. 0)) then
+       write(mpas_err_message,'(A,A20)') &
+       '     setting config_mynn_cloudpdf to -2 when using tempo prognostic clouds'
+       call physics_message(mpas_err_message)
+       config_mynn_cloudpdf = -2
+    endif
+ endif
+      
 !surface-layer scheme:
  if(.not. (config_sfclayer_scheme .eq. 'off'     .or. &
            config_sfclayer_scheme .eq. 'sf_mynn' .or. &

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
@@ -1214,6 +1214,7 @@
                    bl_mynn_mixnumcon,   &
                    bl_mynn_cloudmix,    &
                    bl_mynn_mixqt,       &
+                   bl_mynn_ess,         &
                    bl_mynn_tkebudget,   &
                    icloud_bl,           &
                    spp_pbl
@@ -1406,6 +1407,7 @@
        call mpas_pool_get_config(configs,'config_mynn_mixnumcon'  ,bl_mynn_mixnumcon  )
        call mpas_pool_get_config(configs,'config_mynn_mixclouds'  ,bl_mynn_cloudmix   )
        call mpas_pool_get_config(configs,'config_mynn_mixqt'      ,bl_mynn_mixqt      )
+       call mpas_pool_get_config(configs,'config_mynn_ess'        ,bl_mynn_ess        )
        call mpas_pool_get_config(configs,'config_mynn_tkeadvect'  ,bl_mynn_tkeadvect  )
        call mpas_pool_get_config(configs,'config_mynn_tkebudget'  ,bl_mynn_tkebudget  )
        call mpas_pool_get_config(configs,'config_icloud_bl'       ,icloud_bl          )
@@ -1496,6 +1498,7 @@
                   bl_mynn_mixnumcon  = bl_mynn_mixnumcon   ,                                              &
                   bl_mynn_cloudmix   = bl_mynn_cloudmix    ,                                              &
                   bl_mynn_mixqt      = bl_mynn_mixqt       ,                                              &
+                  bl_mynn_ess        = bl_mynn_ess         ,                                              &
                   ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,                 &
                   ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,                 &
                   its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte ,                 &

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.3.0-1.10">
+<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.3.0-1.11">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->


### PR DESCRIPTION
This PR syncs the WRF and MPAS versions of the MYNN-EDMF submodule. Several back-n-forth tunings between the WRF-WFIP3 and MPAS-global were performed to make sure we can simultaneously have strong LLJs in the mid-latitudes, increased PBLHs in the Tropics, higher mass-flux cloud fractions in cold-air outbreaks, and smaller mass-flux cloud fractions in the Tropics. This was accomplished by adding a new effective static stability option (config_mynn_ess = 1) to help increase the PBLH in the Tropics while tuned to have a much smaller impact over land. This new option only reduces the estimate of static stability in partially condensed grid cells, so it has no impact at all in clear-sky conditions.

Many other smaller modifications were made:

- added config_tempo_cldfra to help facilitate testing of the new prognostic cloud scheme.
- changes how the mass-flux sgs clouds are blended with the stratus clouds in transition regimes.
- added some mesoscale scale-awareness (variation of parameters between dx=4km and 16km) to help improve the underdiffusive nature of the global 15km runs.

pdf showing some of the performance changes (updated):
[PR152 - effective static stability.pdf](https://github.com/user-attachments/files/21537875/PR152.-.effective.static.stability.pdf)


Testing in MPAS has been done in both global and CONUS frameworks. Working on regression tests now...

See the below examples for more information.
https://github.com/MPAS-Dev/MPAS/pull/930
https://github.com/MPAS-Dev/MPAS/pull/931

Information on running mandatory regression tests on Jet can be found [here](https://github.com/barlage/mpas_testcase) and the results pasted below.

<details>
  <summary>
    final regression test case results (only changes hrrrv5 suite, as expected):
  </summary>
  
```
     version_to_compare = v8.3.0-1.11
   gsl_version_baseline = v8.3.0-1.10
  ncar_version_baseline = v8.3.0
         test_directory = /mnt/lfs5/BMC/rtwbl/olson/mpas_testcase_20250721/run_case/
 gsl_baseline_directory = /lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/
ncar_baseline_directory = /lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/
           compile_flag = -intdebug
         test_repo_name = gsl

######################################################################
# compare to previous GSL CONUS mesoscale_reference baselines A1GSL   
######################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/mnt/lfs5/BMC/rtwbl/olson/mpas_testcase_20250721/run_case/gsl-v8.3.0-1.11-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/B
MC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.10-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/mnt/lfs5/BMC/rtwbl/olson/mpas_testcase_20250721/run_case/gsl-v8.3.0-1.11-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/B
MC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.10-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/mnt/lfs5/BMC/rtwbl/olson/mpas_testcase_20250721/run_case/gsl-v8.3.0-1.11-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/lfs5/B
MC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.10-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

#############################################################################
# compare to previous GSL CONUS convection_permitting_none baselines F1GSL   
#############################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/mnt/lfs5/BMC/rtwbl/olson/mpas_testcase_20250721/run_case/gsl-v8.3.0-1.11-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "
/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.10-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are iden
tical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/mnt/lfs5/BMC/rtwbl/olson/mpas_testcase_20250721/run_case/gsl-v8.3.0-1.11-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "
/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.10-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are iden
tical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/mnt/lfs5/BMC/rtwbl/olson/mpas_testcase_20250721/run_case/gsl-v8.3.0-1.11-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "
/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.10-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are iden
tical.

#############################################################################
# compare to previous GSL CONUS mesoscale_reference_noahmp baselines E1GSL   
#############################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/mnt/lfs5/BMC/rtwbl/olson/mpas_testcase_20250721/run_case/gsl-v8.3.0-1.11-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "
/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.10-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/mnt/lfs5/BMC/rtwbl/olson/mpas_testcase_20250721/run_case/gsl-v8.3.0-1.11-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "
/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.10-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/mnt/lfs5/BMC/rtwbl/olson/mpas_testcase_20250721/run_case/gsl-v8.3.0-1.11-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "
/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.10-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

######################################################################
# compare to previous GSL CONUS hrrrv5 GFS baselines C5GSL            
######################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/mnt/lfs5/BMC/rtwbl/olson/mpas_testcase_20250721/run_case/gsl-v8.3.0-1.11-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/BMC/wrfruc/Micha
el.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.10-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Variable               Group  Count          Sum      AbsSum          Min         Max       Range         Mean      StdDev
qv                     /      44179   0.00960698   0.0344359 -0.000158627 0.000262115 0.000420742  2.17456e-07 5.64532e-06
qc                     /        911  -0.00021465 0.000683029 -7.00719e-05 4.83973e-05 0.000118469 -2.35621e-07 4.36358e-06
qr                     /        256  -2.9435e-05 3.04983e-05 -2.53638e-06 7.18131e-08 2.60819e-06  -1.1498e-07 4.00848e-07
qi                     /         23  -4.3281e-11  1.0459e-10 -7.32143e-11 2.03499e-11 9.35643e-11 -1.88178e-12 1.61267e-11
qs                     /         21   1.4172e-13 3.50752e-13 -4.88498e-14 7.10543e-14 1.19904e-13  6.74856e-15 2.92408e-14
ni                     /         23    -0.217977    0.325314    -0.148438   0.0385742    0.187012  -0.00947725   0.0405526
nr                     /        256     -13809.5     14533.6     -849.743     46.5338     896.277     -53.9433     145.055
nc                     /        938 -8.00465e+08 3.19816e+09 -2.25465e+08 2.85922e+08 5.11388e+08      -853374 1.89273e+07
nifa                   /      37456 -5.93126e+06 1.22492e+07     -43160.4       60332      103492     -158.353     1555.67
nwfa                   /      40126  2.83037e+09 2.53291e+10  -2.8592e+08 2.11977e+08 4.97897e+08      70537.1 5.38339e+06
u                      /     172806      3.05102     940.077     -1.35695     1.50411     2.86106  1.76557e-05   0.0403168
w                      /      72404    -0.147663     1.03415  -0.00357051  0.00129786  0.00486837 -2.03943e-06 5.80893e-05
pressure               /      33925      829.191     2629.25     -43.7422     47.9766     91.7188    0.0244419    0.815093
surface_pressure       /        689      174.648     250.148     -4.39844     48.1562     52.5547     0.253481     2.93222
rho                    /      38854   -0.0974438    0.673933   -0.0034914  0.00136995  0.00486135 -2.50795e-06 0.000111525
theta                  /      32053      19.7477     151.731    -0.355072    0.766632      1.1217  0.000616095    0.027446
relhum                 /      47981      100.264     1040.45     -5.69779     5.62553     11.3233   0.00208967    0.147689
divergence             /      63256  6.85109e-07  0.00234645 -7.24886e-06 6.27207e-06 1.35209e-05  1.08307e-11 2.11141e-07
vorticity              /     112511  1.79633e-06  0.00984552 -2.61379e-05   2.593e-05 5.20679e-05  1.59658e-11 5.36882e-07
ke                     /      61655     -314.825     4034.55     -15.6874      8.1592     23.8466  -0.00510624    0.459021
uReconstructZonal      /      59929     -10.9688     327.585     -1.48571    0.973532     2.45924  -0.00018303   0.0407764
uReconstructMeridional /      62284      32.7235     296.671     -1.18699     1.49912     2.68611  0.000525392   0.0327025
ertel_pv               /      62197     -146.472     257.814     -1.58979    0.639853     2.22965  -0.00235497   0.0372885
u_pv                   /       1015  -0.00168794   0.0785025  -0.00146484 0.000993729  0.00245857   -1.663e-06 0.000162806
v_pv                   /       1080   0.00288373   0.0720103 -0.000779629 0.000905037  0.00168467  2.67012e-06 0.000135178
theta_pv               /        670 -0.000488281   0.0386963 -0.000579834 0.000549316  0.00112915 -7.28778e-07 8.14168e-05
vort_pv                /       1085 -1.07627e-08 2.26157e-07 -1.01136e-08 3.73802e-09 1.38516e-08 -9.91952e-12 5.35569e-10
depv_dt_lw             /      60293 -0.000231866  0.00105248 -7.62223e-06 9.29268e-06 1.69149e-05 -3.84566e-09 1.92251e-07
depv_dt_sw             /      60074  5.35374e-06 6.00014e-05 -2.85232e-07 2.70375e-07 5.55608e-07  8.91191e-11 7.80406e-09
depv_dt_bl             /      61582    -0.242321    0.411186  -0.00250233  0.00122795  0.00373028 -3.93494e-06  5.6909e-05
depv_dt_mix            /      67561 -9.33916e-05  0.00189472 -8.80209e-06 9.45263e-06 1.82547e-05 -1.38233e-09 2.23581e-07
dtheta_dt_mp           /       3933   0.00369805  0.00579283 -0.000154622 0.000207011 0.000361633  9.40263e-07 9.09528e-06
depv_dt_mp             /      22894  -0.00161788  0.00638126 -0.000453677 0.000138824 0.000592501 -7.06684e-08 5.24825e-06
depv_dt_diab           /      68023    -0.244259     0.41031  -0.00249442  0.00115989  0.00365431 -3.59083e-06 5.38635e-05
depv_dt_fric           /      70084     0.181859    0.515224  -0.00582405   0.0145089    0.020333  2.59487e-06 0.000146841
depv_dt_diab_pv        /       1135 -1.63686e-07 5.48594e-07 -3.08719e-08 1.30049e-08 4.38768e-08 -1.44217e-10 2.11674e-09
depv_dt_fric_pv        /       1186 -5.76563e-07 3.43266e-06 -3.90224e-07 3.85102e-07 7.75326e-07 -4.86141e-10 2.28896e-08
rainnc                 /         30   -0.0443688   0.0467116   -0.0140474   0.0011608   0.0152082  -0.00147896  0.00272773
precipw                /        785    0.0834582    0.116258  -0.00216866   0.0234118   0.0255804  0.000106316   0.0011413
kpbl                   /        321          239         321           -1           1           2     0.744548    0.668611
hpbl                   /       1233      21833.7     27457.9     -36.5417     57.2953     93.8369      17.7078     21.9902
cldfrac_bl             /       1627     -84.4821     88.7774    -0.409388    0.493415    0.902803   -0.0519251   0.0828624

  === history.2023-03-10_16.00.00.nc comparison
Variable               Group  Count          Sum      AbsSum          Min         Max       Range         Mean      StdDev
qv                     /      56158    0.0194796    0.134087 -0.000615808 0.000476687  0.00109249  3.46871e-07 1.41327e-05
qc                     /       2348  -0.00926292   0.0257347 -0.000324369 0.000306798 0.000631167 -3.94502e-06 3.14023e-05
qr                     /       3826  -0.00104733  0.00165553 -0.000109548 1.75389e-05 0.000127087 -2.73741e-07 5.08558e-06
qi                     /       3567  1.01979e-05 3.16838e-05 -9.28783e-07 4.18597e-06 5.11475e-06  2.85895e-09 9.41312e-08
qs                     /       4282   0.00026487 0.000479969 -1.39758e-05 7.18074e-05 8.57832e-05  6.18565e-08 1.98611e-06
qg                     /        572 -0.000822471  0.00214318 -0.000209714 0.000105577  0.00031529 -1.43789e-06 2.01937e-05
ni                     /       3567       159945      194645     -1129.81     32876.9     34006.8      44.8403     912.482
nr                     /       3826     -6306.72      127921     -5975.97     5836.03       11812     -1.64838     259.158
ng                     /        572     -17185.4     27339.8     -3232.24     938.493     4170.73     -30.0445     254.821
nc                     /       2348 -1.56473e+09 1.44838e+10  -2.2382e+08 2.25827e+08 4.49648e+08      -666411 1.98086e+07
nifa                   /      48046 -3.00031e+06 2.55662e+07      -190464      273051      463514     -62.4467     3459.34
nwfa                   /      54639 -7.18497e+10 9.15347e+11 -2.28897e+09 2.11606e+09 4.40503e+09 -1.31499e+06 9.66538e+07
volg                   /        571  9.28198e-08  3.5065e-06 -2.62142e-07 2.84422e-07 5.46564e-07  1.62557e-10 3.26288e-08
u                      /     179802     -12.6568      2656.4     -4.32965     4.54827     8.87792 -7.03932e-05   0.0799215
w                      /      72488    -0.245908     7.43752  -0.00718088  0.00755826   0.0147391  -3.3924e-06 0.000293569
pressure               /      56186     -3317.16     20777.1     -97.7266     105.102     202.828    -0.059039     1.93383
surface_pressure       /        958      75.8906     804.375     -29.3984     49.0078     78.4062    0.0792178     2.81402
rho                    /      56785      0.31858     1.51653  -0.00483274  0.00441611  0.00924885  5.61028e-06 0.000122587
theta                  /      54650     -85.9855      404.41      -1.3302     1.54764     2.87784  -0.00157339   0.0328396
relhum                 /      56916      873.802     3385.59     -19.3916     19.3118     38.7034    0.0153525    0.351025
divergence             /      64995 -2.13281e-06  0.00902197 -2.63657e-05 2.42499e-05 5.06157e-05 -3.28151e-11  6.7034e-07
vorticity              /     122058 -6.35555e-06   0.0317857 -9.03482e-05 8.75757e-05 0.000177924 -5.20699e-11 1.43088e-06
ke                     /      64972      2029.14     10306.8     -64.0872     33.7416     97.8288    0.0312309    0.851909
uReconstructZonal      /      64888     -9.46764     871.711     -2.33938     2.50486     4.84424 -0.000145907   0.0746675
uReconstructMeridional /      64991     -76.2093     740.374     -4.65649     2.94508     7.60157  -0.00117261   0.0606595
ertel_pv               /      67645     -11.0851     291.812    -0.709294    0.519994     1.22929 -0.000163871   0.0200321
u_pv                   /       1110   -0.0229463      1.5324   -0.0639381   0.0321159   0.0960541 -2.06724e-05   0.0033507
v_pv                   /       1117    -0.156855     1.51866    -0.180477   0.0177307    0.198208 -0.000140425  0.00584142
theta_pv               /       1058   -0.0380249     1.11102   -0.0529175   0.0814209    0.134338 -3.59404e-05  0.00423607
vort_pv                /       1127 -6.68127e-07 6.28801e-06 -4.93161e-07 2.83824e-07 7.76985e-07 -5.92837e-10 2.50918e-08
iLev_DT                /          1           -1           1           -1          -1           0           -1           0
depv_dt_lw             /      69791  0.000507675   0.0624693 -0.000342854 0.000392488 0.000735342  7.27422e-09 6.07132e-06
depv_dt_sw             /      69008  9.86989e-06    0.014288 -6.93701e-05 5.25637e-05 0.000121934  1.43025e-10 1.32179e-06
depv_dt_bl             /      58854    0.0363042    0.248695 -0.000594763   0.0039092  0.00450397  6.16852e-07 3.61237e-05
depv_dt_mix            /      70981 -2.02928e-05  0.00292843 -5.95701e-06 5.78481e-06 1.17418e-05 -2.85891e-10 1.94305e-07
dtheta_dt_mp           /      11684    0.0043702   0.0480244 -0.000372781 0.000482051 0.000854831  3.74033e-07 1.76761e-05
depv_dt_mp             /      31822  -0.00040272   0.0319921 -0.000248026 0.000353887 0.000601914 -1.26554e-08 7.43083e-06
depv_dt_diab           /      71651    0.0363988    0.279691 -0.000619224  0.00390966  0.00452888  5.08001e-07  3.3393e-05
depv_dt_fric           /      72484   0.00251348    0.210438  -0.00224242  0.00206018  0.00430261  3.46763e-08 2.80211e-05
depv_dt_diab_pv        /       1192  6.75153e-07 4.55991e-05 -1.53283e-06 3.36605e-06 4.89888e-06  5.66403e-10 1.60108e-07
depv_dt_fric_pv        /       1231  2.35202e-05 9.04691e-05 -6.82843e-06 1.16125e-05 1.84409e-05  1.91066e-08 6.07425e-07
rainnc                 /        303   -0.0191463    0.517257   -0.0724158   0.0427426    0.115158  -6.3189e-05  0.00630696
precipw                /        972       1.0474     2.42817   -0.0400171   0.0920935    0.132111   0.00107757  0.00812404
kpbl                   /        317          123         317           -1           1           2     0.388013    0.923111
hpbl                   /       1233      10103.6     25075.1     -137.432     104.112     241.544      8.19434     24.8439
hfx                    /       1223      199.032     2763.12     -54.0541     69.0211     123.075     0.162741     6.58082
qfx                    /       1196  -0.00010318 0.000332254 -1.11832e-05 9.22056e-06 2.04038e-05 -8.62711e-08 7.79971e-07
cd                     /       1214    0.0122684    0.118765  -0.00245125  0.00508236  0.00753361  1.01057e-05 0.000324946
cda                    /       1217   0.00729688    0.104127  -0.00260167  0.00296332  0.00556499  5.99579e-06 0.000258889
ck                     /       1218    0.0104476   0.0757135  -0.00134197  0.00320573   0.0045477  8.57765e-06 0.000171151
cka                    /       1217   0.00589746   0.0719273  -0.00160681  0.00184042  0.00344723   4.8459e-06  0.00015316
lh                     /       1196      -263.01     841.296     -27.9581     23.0514     51.0095    -0.219908     1.95592
u10                    /       1218     -4.88695     55.2082      -0.7914    0.703947     1.49535  -0.00401227    0.103474
v10                    /       1219     -16.6488     53.3361    -0.638065     1.02575     1.66381   -0.0136578   0.0922964
q2                     /       1198   0.00941519   0.0159617 -0.000149134 0.000426496  0.00057563  7.85909e-06 3.43994e-05
t2m                    /       1126      6.51468     36.7549    -0.331146    0.416351    0.747498   0.00578568   0.0627902
th2m                   /       1131      6.77393     37.5496    -0.331299    0.423798    0.755096   0.00598932   0.0635758
gsw                    /       1052      127.789     12267.3     -114.912     256.548      371.46     0.121472      25.457
glw                    /       1022      566.876     4073.54     -50.2282     46.1832     96.4115     0.554673      7.6422
skintemp               /        779      16.3333      91.242     -1.41519     2.27625     3.69144     0.020967    0.257884
snow                   /        338     -2.98421       5.798    -0.526216    0.132353    0.658569  -0.00882902   0.0490967
snowh                  /        344   -0.0166889   0.0460067  -0.00229341 0.000882685   0.0031761 -4.85143e-05  0.00027112
canwat                 /         81  -0.00145768  0.00463025  -0.00100099 0.000901831  0.00190282  -1.7996e-05 0.000182214
sh2o                   /       3455    0.0652804    0.267026   -0.0154606    0.022045   0.0375056  1.88945e-05 0.000626445
smois                  /       3648    0.0504032    0.120568  -0.00226085  0.00271231  0.00497316  1.38167e-05  0.00015414
tslb                   /       3485      33.8366     179.592     -1.41519     2.27625     3.69144   0.00970921    0.152517
soilt1                 /        248     0.759888     2.15515     -0.13266   0.0843506     0.21701   0.00306406   0.0192589
snowfallac             /          1  5.22293e-12 5.22293e-12  5.22293e-12 5.22293e-12           0  5.22293e-12           0
acrunoff               /        283  -0.00881452    0.104161   -0.0405307   0.0157142   0.0562449 -3.11467e-05  0.00264188
grdflx                 /        783     -211.059     2941.74      -98.333     42.6076     140.941    -0.269551     8.61172
sfc_albedo             /        340   -0.0247489   0.0438648   -0.0016222 0.000634968  0.00225717 -7.27909e-05 0.000269705
cldfrac_bl             /       6195      1.81807      218.78    -0.761504    0.787393      1.5489  0.000293474   0.0906531
snowc                  /        329   -0.0616365    0.126071   -0.0094921  0.00257146   0.0120636 -0.000187345  0.00104454
graupelnc              /         11  -0.00070437  0.00071396 -0.000512305 3.37163e-06 0.000515677 -6.40336e-05  0.00015929

######################################################################
# compare to previous GSL CONUS hrrrv5 RAP winter baselines C7GSL     
######################################################################

  === history.2024-02-02_18.00.00.nc comparison
Files "/mnt/lfs5/BMC/rtwbl/olson/mpas_testcase_20250721/run_case/gsl-v8.3.0-1.11-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.00.00.nc" and "/lfs5/BMC/wrfruc/Micha
el.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.10-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.00.00.nc" are identical.

  === history.2024-02-02_18.12.00.nc comparison
Variable               Group  Count          Sum      AbsSum          Min         Max       Range         Mean      StdDev
qv                     /      52770    0.0403587    0.165733 -0.000551399 0.000371589 0.000922988  7.64805e-07 1.56107e-05
qc                     /       1435   0.00121835    0.010523 -0.000207073 0.000245881 0.000452954  8.49022e-07 2.15597e-05
qr                     /       4328 -0.000333777 0.000935142 -1.10084e-05 8.58119e-06 1.95896e-05 -7.71205e-08 8.81953e-07
qi                     /       4201 -1.65923e-05  1.9414e-05  -5.2909e-06  1.7234e-07 5.46324e-06  -3.9496e-09 1.19595e-07
qs                     /       8373 -0.000351498  0.00122878 -0.000262912 1.58842e-05 0.000278796 -4.19799e-08 2.96874e-06
qg                     /       1766 -9.67243e-07 0.000151628 -1.91809e-05  8.6996e-06 2.78805e-05 -5.47703e-10 6.72837e-07
ni                     /       4181       -47331     52597.1     -17553.6     458.579     18012.2     -11.3205     397.206
nr                     /       4328     -56354.8      177172     -2255.98     1108.16     3364.14      -13.021     161.788
ng                     /       1763     -5812.89     15640.9      -717.24     579.747     1296.99     -3.29716     48.2757
nc                     /       1433  1.33708e+09  4.3895e+09 -1.00374e+08 1.12678e+08 2.13052e+08       933062 1.04351e+07
nifa                   /      39624  1.73335e+07  6.8379e+07      -309767      839065 1.14883e+06      437.449     12758.2
nwfa                   /      48300  4.37329e+09 7.93079e+10 -2.74742e+08 1.54388e+08  4.2913e+08      90544.3 8.19248e+06
volg                   /       1766 -4.13139e-08 3.37706e-07 -3.41763e-08 2.53379e-08 5.95142e-08  -2.3394e-11 1.32457e-09
u                      /     179304      24.8932     2204.39     -1.78445     1.77719     3.56164  0.000138832   0.0588515
w                      /      72412    -0.207601     3.74674   -0.0100097  0.00954963   0.0195594 -2.86694e-06 0.000212834
pressure               /      52449      2451.05     15430.6     -53.0547     240.227     293.281    0.0467321     2.26584
surface_pressure       /        925      347.094     1059.11     -36.3047     239.883     276.188     0.375236     8.79662
rho                    /      54136    -0.397916      1.8022   -0.0060643  0.00258183  0.00864613  -7.3503e-06  0.00017014
theta                  /      43430      88.8567      436.37    -0.873077     1.50159     2.37466   0.00204598   0.0486162
relhum                 /      56433      93.3687     2834.36     -13.9697     13.3543      27.324   0.00165451    0.299727
divergence             /      64881 -3.05447e-07  0.00582555 -7.35975e-06 7.36243e-06 1.47222e-05  -4.7078e-12 3.44746e-07
vorticity              /     120137  2.84338e-05   0.0230877 -2.13043e-05 1.57361e-05 3.70404e-05  2.36678e-10 7.95347e-07
ke                     /      64698     -1131.14     8275.12     -17.1978      15.837     33.0349   -0.0174833    0.624782
uReconstructZonal      /      64428      -133.59     693.474     -1.41954    0.830637     2.25017  -0.00207347   0.0534817
uReconstructMeridional /      64701     -53.3871     715.376     -1.02004     1.23985     2.25989 -0.000825136   0.0523085
ertel_pv               /      66510     -432.384     616.084     -2.76704     2.26885     5.03588  -0.00650104   0.0657933
u_pv                   /       1102   -0.0204709    0.193401  -0.00459671  0.00370407  0.00830078 -1.85761e-05 0.000404508
v_pv                   /       1102  -0.00129241    0.204335  -0.00491476  0.00371742  0.00863218 -1.17278e-06 0.000445676
theta_pv               /        782   0.00131226   0.0827332  -0.00170898  0.00411987  0.00582886  1.67808e-06 0.000252366
vort_pv                /       1098  1.63698e-07 5.76773e-07 -5.42059e-09 3.29783e-08 3.83989e-08  1.49087e-10 1.84306e-09
depv_dt_lw             /      64993 -0.000454603  0.00395037 -4.38101e-05 4.29548e-05 8.67648e-05 -6.99465e-09 7.22251e-07
depv_dt_sw             /      64989 -5.18244e-06 0.000158753 -8.32337e-07 4.95902e-07 1.32824e-06 -7.97433e-11 1.50772e-08
depv_dt_bl             /      65440    -0.719222    0.978639   -0.0041451  0.00391668  0.00806178 -1.09906e-05 0.000101786
depv_dt_mix            /      69774 -2.85782e-05  0.00394177  -2.4139e-05 1.70677e-05 4.12067e-05 -4.09582e-10 4.01161e-07
dtheta_dt_mp           /      11909    0.0112292    0.049728 -0.000229984  0.00103845  0.00126843   9.4292e-07 2.03661e-05
depv_dt_mp             /      35988  -0.00366721   0.0387206  -0.00125087 0.000272978  0.00152385 -1.01901e-07 1.23864e-05
depv_dt_diab           /      69886    -0.723377    0.981926  -0.00413014  0.00305892  0.00718906 -1.03508e-05  9.7748e-05
depv_dt_fric           /      71988     0.118302     1.45498   -0.0159494     0.03493   0.0508794  1.64335e-06 0.000347908
depv_dt_diab_pv        /       1146 -8.75832e-09 2.05254e-06 -9.95169e-08 5.79762e-08 1.57493e-07 -7.64251e-12 6.49823e-09
depv_dt_fric_pv        /       1221  9.56527e-07 7.32857e-06 -4.41472e-07 4.35092e-07 8.76565e-07  7.83396e-10 3.20089e-08
rainnc                 /        496   -0.0598182    0.409194   -0.0411827   0.0177041   0.0588867 -0.000120601  0.00321191
precipw                /        964    0.0862265    0.678326   -0.0249705    0.026824   0.0517945  8.94465e-05  0.00242658
kpbl                   /        201          173         201           -1           1           2     0.860697     0.51039
hpbl                   /       1233        16645     18157.3     -32.9224     57.2776        90.2      13.4996      17.589
cldfrac_bl             /       2336     -103.568      182.96    -0.438214    0.542253    0.980467   -0.0443356    0.115916
snownc                 /        127    0.0380365   0.0682546  -0.00298792   0.0287187   0.0317066    0.0002995  0.00276085
graupelnc              /        205  -0.00354715  0.00718544  -0.00409825 0.000641862  0.00474011 -1.73032e-05  0.00029416

  === history.2024-02-02_19.00.00.nc comparison
Variable               Group  Count          Sum      AbsSum          Min         Max       Range         Mean      StdDev
qv                     /      57061    0.0266368    0.400211 -0.000809212 0.000665422  0.00147463  4.66813e-07 2.97717e-05
qc                     /       1464    0.0203253   0.0739246   -0.0005249 0.000456116 0.000981016  1.38834e-05 8.44161e-05
qr                     /       5605   -0.0014292  0.00449238 -3.87924e-05 5.78427e-05  9.6635e-05 -2.54987e-07 3.04105e-06
qi                     /       5480  -7.7117e-06 0.000114843 -2.87291e-06 3.40318e-06 6.27609e-06 -1.40725e-09  1.3287e-07
qs                     /       9317  -0.00047523   0.0070041 -4.58465e-05 8.69622e-05 0.000132809 -5.10068e-08 3.33383e-06
qg                     /       3209  0.000176825  0.00132284 -2.16195e-05 0.000102454 0.000124074  5.51028e-08 3.66928e-06
ni                     /       5480       127883      398017     -7441.03     66505.2     73946.3      23.3364     1183.23
nr                     /       5605      -248960      553942     -4056.19     4022.33     8078.52     -44.4175      320.46
ng                     /       3209     -3498.41     49287.8     -1635.63     2599.35     4234.98     -1.09019     83.6712
nc                     /       1464  1.06446e+10 3.35461e+10 -2.26365e+08 1.46342e+08 3.72707e+08  7.27089e+06 3.68977e+07
nifa                   /      46658  1.11409e+07 1.18471e+08      -516400      308024      824425      238.778       12148
nwfa                   /      55812 -1.07786e+11  1.8337e+12  -2.5588e+09 2.27176e+09 4.83056e+09 -1.93123e+06   1.484e+08
volg                   /       3209 -1.10539e-07 2.43298e-06 -4.40248e-08 1.51176e-07 1.95201e-07 -3.44466e-11 4.81544e-09
u                      /     179873     -10.6612     4876.52     -6.87599     4.22694     11.1029 -5.92709e-05    0.102824
w                      /      72424     -1.32703     20.8357   -0.0112916   0.0246447   0.0359363 -1.83231e-05 0.000772082
pressure               /      56948      -5964.4     51000.7     -97.7656      144.07     241.836    -0.104734     4.31433
surface_pressure       /        974     -806.977     2146.87     -54.8594     40.4219     95.2812    -0.828518     5.35472
rho                    /      57238     0.842321     3.63718  -0.00837684  0.00602186   0.0143987  1.47161e-05 0.000303204
theta                  /      56333     -217.152     1078.97     -1.87552     2.45438      4.3299  -0.00385479    0.086345
relhum                 /      57454      2058.45     13054.8     -44.4182     37.2735     81.6917    0.0358279     1.20186
divergence             /      65007  4.18402e-06   0.0168497 -4.07691e-05 4.18308e-05 8.25999e-05  6.43626e-11  8.7764e-07
vorticity              /     122280 -1.62772e-05   0.0623944 -0.000108366 0.000120809 0.000229174 -1.33114e-10 1.98953e-06
ke                     /      65006      2627.83     18238.6     -52.2195     35.5435      87.763    0.0404244     1.09522
uReconstructZonal      /      64972       37.258     1478.86      -3.3519     6.63289     9.98479  0.000573447   0.0884595
uReconstructMeridional /      65010      25.8677        1439      -1.4533     1.97153     3.42483  0.000397904   0.0838622
ertel_pv               /      69137      55.4781     565.905     -1.03463     1.09668     2.13131  0.000802437   0.0395775
u_pv                   /       1126     0.114231     5.24309    -0.186054    0.415053    0.601107  0.000101448   0.0218007
v_pv                   /       1132     0.496792     4.76759    -0.359136    0.327168    0.686304  0.000438862   0.0209711
theta_pv               /       1093   -0.0732117     5.08047    -0.600586    0.587585     1.18817 -6.69823e-05   0.0329121
vort_pv                /       1127  1.01365e-06 2.24615e-05 -2.85137e-06 1.33894e-06  4.1903e-06  8.99421e-10 1.15391e-07
iLev_DT                /          2           -2           2           -1          -1           0           -1           0
depv_dt_lw             /      72124  -0.00386325    0.116344 -0.000295432 0.000320994 0.000616427  -5.3564e-08 1.05524e-05
depv_dt_sw             /      71835  0.000929787   0.0290526 -9.31159e-05 8.82179e-05 0.000181334  1.29434e-08 2.54149e-06
depv_dt_bl             /      61075    0.0620521    0.349783  -0.00051547  0.00251807  0.00303354    1.016e-06 2.81731e-05
depv_dt_mix            /      71550  2.12911e-05   0.0049751 -1.01674e-05 1.01498e-05 2.03172e-05   2.9757e-10 3.20188e-07
dtheta_dt_mp           /      15728    0.0235627    0.201699 -0.000510152 0.000721317  0.00123147  1.49813e-06 4.30553e-05
depv_dt_mp             /      36971   0.00843265    0.113119 -0.000480068  0.00106898  0.00154905  2.28088e-07 1.76613e-05
depv_dt_diab           /      72541    0.0675726    0.399127 -0.000756318   0.0023538  0.00311012  9.31509e-07 2.82534e-05
depv_dt_fric           /      72715   -0.0101098    0.408379  -0.00420988  0.00223218  0.00644206 -1.39033e-07 5.28878e-05
depv_dt_diab_pv        /       1225 -1.01526e-05 6.93029e-05 -5.64195e-06 2.49408e-06 8.13603e-06 -8.28784e-09 2.75545e-07
depv_dt_fric_pv        /       1230  0.000105577 0.000839427 -0.000148304 0.000121306  0.00026961  8.58351e-08 6.84058e-06
rainnc                 /        621     -1.69285     2.95572    -0.106439   0.0869558    0.193395    -0.002726   0.0123577
precipw                /        977     -1.24185     6.39408    -0.107224    0.146137    0.253361  -0.00127109    0.014241
kpbl                   /        205           -8         206           -2           1           3   -0.0390244       1.009
hpbl                   /       1233     -840.797     24082.7     -218.808     159.251      378.06    -0.681911     30.5462
hfx                    /       1229       381.11      4133.7     -73.8024     145.407     219.209     0.310097     8.28625
qfx                    /       1229 -0.000524189 0.000994216 -1.52665e-05 1.51439e-05 3.04104e-05 -4.26517e-07 1.57041e-06
cd                     /       1198    0.0483046    0.106724  -0.00172428   0.0035618  0.00528608  4.03211e-05   0.0002309
cda                    /       1202     0.045274   0.0963258  -0.00111217   0.0028804  0.00399256  3.76656e-05 0.000197438
ck                     /       1214    0.0549209    0.075654 -0.000843964  0.00115824  0.00200221  4.52397e-05 0.000119802
cka                    /       1214    0.0499766   0.0711386  -0.00086628  0.00114737  0.00201365  4.11669e-05  0.00011583
lh                     /       1228     -1313.68      2495.7     -38.1663     37.8598      76.026     -1.06977     3.93483
u10                    /       1210      5.84041     90.1458     -1.29782    0.535353     1.83318   0.00482679    0.135775
v10                    /       1215     -25.2601     91.2371     -1.09923    0.546604     1.64583   -0.0207902    0.131665
q2                     /       1216    0.0206858   0.0324069  -0.00024624 0.000617507 0.000863747  1.70114e-05 4.89237e-05
t2m                    /       1128     -20.2863     55.6816    -0.681366    0.339508     1.02087   -0.0179843   0.0924889
th2m                   /       1132     -19.8391     56.0506    -0.646698    0.338959    0.985657   -0.0175257   0.0925878
gsw                    /       1126     -1236.45     19954.4     -144.954     248.228     393.182     -1.09809     33.2059
glw                    /       1112      1742.12     5662.82     -43.5883     61.7055     105.294      1.56666     9.41958
skintemp               /        778      1.15607     123.328     -1.72226     2.69196     4.41422   0.00148595    0.273349
snow                   /        179     -2.62779     5.92381    -0.352878    0.157586    0.510464   -0.0146804   0.0598618
snowh                  /        181   -0.0167052   0.0406089  -0.00220829  0.00128448  0.00349277 -9.22937e-05 0.000387037
canwat                 /        321    0.0325715   0.0445093  -0.00108686  0.00187783  0.00296469  0.000101469 0.000254047
sh2o                   /       4363  -0.00431791     0.34288   -0.0199021  0.00964037   0.0295425 -9.89666e-07 0.000565061
smois                  /       4480  -0.00138598    0.261651   -0.0196793  0.00915824   0.0288376 -3.09372e-07  0.00038999
tslb                   /       3967      28.3349     262.798     -1.72226     2.69196     4.41422   0.00714264    0.158606
soilt1                 /         91     -15.2402     17.1726     -9.54996    0.206024     9.75598    -0.167475     1.12413
rhosnf                 /        119      2785.21     12905.7      -377.71        1500     1877.71      23.4051     278.702
snowfallac             /        223  0.000905634  0.00308287  -0.00026042 0.000434271 0.000694692  4.06114e-06  4.9489e-05
acrunoff               /        463    0.0103306    0.200743   -0.0199674   0.0232027   0.0431701  2.23122e-05   0.0020125
grdflx                 /        779      627.056     5033.01     -50.1129     59.8192     109.932     0.804949     10.9845
sfc_albedo             /        165   -0.0176306    0.244993   -0.0547512   0.0663494    0.121101 -0.000106852  0.00780582
cldfrac_bl             /       7818      57.3628     545.164           -1    0.994618     1.99462   0.00733728    0.167863
snowc                  /        271   -0.0824011     1.01803    -0.235682    0.288243    0.523925 -0.000304063   0.0255456
snownc                 /        182     0.150574    0.411984   -0.0274233   0.0611197    0.088543  0.000827331  0.00736743
graupelnc              /        256   -0.0296991    0.145404   -0.0184819   0.0105477   0.0290296 -0.000116012  0.00200463

######################################################################
# compare to previous GSL CONUS hrrrv5 RAP summer baselines C8GSL     
######################################################################

  === history.2024-08-15_18.00.00.nc comparison
Files "/mnt/lfs5/BMC/rtwbl/olson/mpas_testcase_20250721/run_case/gsl-v8.3.0-1.11-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.00.00.nc" and "/lfs5/BMC/wrfruc/Micha
el.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.10-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.00.00.nc" are identical.

  === history.2024-08-15_18.12.00.nc comparison
Variable               Group  Count          Sum      AbsSum          Min         Max       Range         Mean      StdDev
qv                     /      53587    0.0880254    0.439706 -0.000640689  0.00176657  0.00240726  1.64266e-06 3.56176e-05
qc                     /        987  0.000360548  0.00457066 -0.000771185  0.00017745 0.000948635  3.65297e-07 2.96539e-05
qr                     /       3589 -6.66746e-05  0.00066885 -2.39387e-05 6.38707e-06 3.03258e-05 -1.85775e-08 9.35291e-07
qi                     /       1382 -1.18814e-07 1.89734e-07 -6.97491e-08 1.29342e-09 7.10426e-08 -8.59723e-11 2.12536e-09
qs                     /       3170  4.01739e-06  6.6122e-05 -6.75929e-06 1.59235e-05 2.26828e-05  1.26731e-09 3.81388e-07
qg                     /        719   2.2641e-06 2.46412e-06 -2.90252e-08 5.59565e-07  5.8859e-07  3.14895e-09 3.57102e-08
ni                     /       1381     -57711.5     59767.2       -54696     984.208     55680.2     -41.7897      1475.5
nr                     /       3589     -22903.3     77213.6     -2534.62     1857.71     4392.33     -6.38152     111.346
ng                     /        720      102.365     189.218     -19.3865     49.2488     68.6353     0.142174     2.38911
nc                     /        984   9.6288e+08  3.8409e+09 -2.25048e+08 1.19247e+08 3.44295e+08       978537 1.68112e+07
nifa                   /      47674  4.79094e+06 3.26969e+07      -160431      173591      334022      100.494      4228.2
nwfa                   /      51016   3.3761e+10 2.71601e+11 -6.00055e+08 5.29704e+08 1.12976e+09       661772 2.38024e+07
volg                   /        721  4.76681e-09  5.5209e-09 -9.78462e-11 1.31529e-09 1.41313e-09  6.61139e-12 7.79154e-11
u                      /     179533       1.1535     1779.99      -1.4881     1.52155     3.00964    6.425e-06   0.0431237
w                      /      72422     0.607219     5.20164  -0.00449112  0.00285699  0.00734811  8.38446e-06 0.000189253
pressure               /      52865      1805.49     16030.2     -280.719      154.32     435.039    0.0341528     2.44718
surface_pressure       /        953     -218.977     579.477     -15.6797     15.0078     30.6875    -0.229776     1.94392
rho                    /      54099    -0.793433     2.58028  -0.00633132  0.00537908   0.0117104 -1.46663e-05  0.00023099
theta                  /      46546      191.784     721.226     -1.49463     2.14368     3.63831   0.00412032   0.0715556
relhum                 /      55986     -31.2662     3440.79     -11.8441     11.8605     23.7046 -0.000558464    0.307083
divergence             /      64939 -1.79978e-06  0.00497611 -6.49411e-06 7.76214e-06 1.42562e-05  -2.7715e-11 2.40498e-07
vorticity              /     120177  2.61672e-07   0.0205079 -1.35752e-05 2.33451e-05 3.69203e-05  2.17739e-12 5.97377e-07
ke                     /      64803     -612.674     4663.61     -12.9321     6.15039     19.0825   -0.0094544    0.378054
uReconstructZonal      /      64679     -64.7674     504.691    -0.822676    0.808107     1.63078  -0.00100137   0.0321799
uReconstructMeridional /      64789     -37.1667     615.792      -1.4787    0.968763     2.44746 -0.000573657   0.0444402
ertel_pv               /      67129     -769.783     974.115     -5.90307     5.45747     11.3605   -0.0114672    0.106835
u_pv                   /       1110  -0.00598481    0.350995  -0.00385237  0.00466776  0.00852013 -5.39172e-06 0.000595652
v_pv                   /       1116  -0.00857918      0.3476  -0.00422478  0.00387812  0.00810289 -7.68743e-06 0.000608619
theta_pv               /        837    0.0112305    0.130798  -0.00228882  0.00408936  0.00637817  1.34175e-05 0.000326416
vort_pv                /       1113 -8.70227e-08 8.56972e-07 -1.54469e-08  2.5113e-08 4.05598e-08 -7.81875e-11 1.91473e-09
depv_dt_lw             /      65419  -0.00213628  0.00823216 -5.43408e-05 3.70571e-05 9.13979e-05 -3.26554e-08 1.22844e-06
depv_dt_sw             /      65713  2.01885e-05 0.000169104 -7.78575e-07 1.14714e-06 1.92571e-06  3.07223e-10 1.91282e-08
depv_dt_bl             /      66036      -1.2239     1.55044  -0.00806069  0.00804768   0.0161084 -1.85338e-05 0.000166564
depv_dt_mix            /      69983 -2.09368e-05   0.0057664 -5.08107e-05 3.12483e-05  8.2059e-05  -2.9917e-10 6.33357e-07
dtheta_dt_mp           /      10714  -0.00247722    0.044333  -0.00143085 0.000759633  0.00219048 -2.31214e-07 2.76866e-05
depv_dt_mp             /      37928   0.00294904   0.0244368 -0.000345842 0.000370469 0.000716311  7.77538e-08 6.71501e-06
depv_dt_diab           /      70097     -1.22309      1.5569  -0.00803083  0.00800032   0.0160312 -1.74485e-05 0.000161388
depv_dt_fric           /      71621   -0.0909966       1.103   -0.0145288   0.0205831   0.0351119 -1.27053e-06 0.000238143
depv_dt_diab_pv        /       1154  8.34712e-08 1.44425e-06  -5.6375e-08 5.50604e-08 1.11435e-07  7.23321e-11 5.41867e-09
depv_dt_fric_pv        /       1215 -2.73981e-07 6.52363e-06 -1.05985e-06 4.78176e-07 1.53802e-06 -2.25499e-10 4.16284e-08
rainnc                 /        249   -0.0381375   0.0940033   -0.0124654  0.00433267   0.0167981 -0.000153163  0.00146456
precipw                /        964    0.0928721    0.877571   -0.0766373    0.233215    0.309853  9.63404e-05  0.00814745
kpbl                   /        136          120         136           -1           1           2     0.882353    0.472328
hpbl                   /       1157      11465.4       12223     -33.0063     57.2981     90.3044      9.90963      16.536
cldfrac_bl             /       2129     -179.943     222.767    -0.517506    0.418114     0.93562   -0.0845198    0.122594
graupelnc              /         18 -3.50909e-08 6.29422e-08 -4.81468e-08 7.25413e-09  5.5401e-08  -1.9495e-09  1.1715e-08

  === history.2024-08-15_19.00.00.nc comparison
Variable               Group  Count          Sum      AbsSum          Min         Max       Range         Mean      StdDev
qv                     /      57149   -0.0668297    0.678275   -0.0011607   0.0011684   0.0023291 -1.16939e-06 4.38042e-05
qc                     /        977   0.00338596   0.0204447  -0.00027259  0.00043439 0.000706981  3.46567e-06 4.23785e-05
qr                     /       4871 -0.000532748  0.00203747 -2.32481e-05 1.05765e-05 3.38246e-05 -1.09371e-07 1.50715e-06
qi                     /       1589  1.13843e-07 4.03661e-06 -1.53209e-07  6.4676e-08 2.17885e-07  7.16442e-11 8.72689e-09
qs                     /       3536  8.89925e-05 0.000320297 -9.99496e-06 2.61319e-05 3.61269e-05  2.51676e-08 7.97282e-07
qg                     /        639  6.21246e-05 7.70086e-05 -2.41545e-06 9.25627e-06 1.16717e-05  9.72216e-08 8.57618e-07
ni                     /       1589     -51878.6     57883.7     -25343.5     523.393     25866.9     -32.6486     710.848
nr                     /       4871     -67425.1      240512     -5177.59     2578.37     7755.97     -13.8422     235.962
ng                     /        639      579.627     2366.44     -310.743     158.225     468.968     0.907084     23.5287
nc                     /        977   2.7855e+09 9.42058e+09 -1.43692e+08 1.34698e+08  2.7839e+08  2.85108e+06 2.37762e+07
nifa                   /      51205      11987.2 3.22757e+07      -177326      102162      279488     0.234102     3064.94
nwfa                   /      55939 -1.54739e+11 1.00782e+12 -1.24955e+09 2.32291e+09 3.57245e+09  -2.7662e+06 6.05098e+07
volg                   /        639  7.33449e-08 1.27544e-07 -1.31419e-08 1.24466e-08 2.55885e-08  1.14781e-10 1.30175e-09
u                      /     179869     -12.5201     2870.48     -2.67183     1.82598     4.49782 -6.96066e-05   0.0493399
w                      /      72424     -4.78192     19.1072   -0.0108325   0.0133254   0.0241579 -6.60268e-05 0.000640564
pressure               /      56952      655.797       33710       -99.25      104.18      203.43    0.0115149     2.89784
surface_pressure       /        970     -54.9531     1230.03     -35.8281     31.7734     67.6016   -0.0566527     3.29094
rho                    /      57252     0.401873      2.2992  -0.00392103  0.00579607  0.00971711  7.01937e-06 0.000133604
theta                  /      56471     -81.1762     833.734     -1.76642     1.67575     3.44217  -0.00143748   0.0532319
relhum                 /      57210      329.057     7837.49     -18.3325     26.3595      44.692   0.00575174    0.620528
divergence             /      65014  1.17104e-06   0.0110735 -8.87777e-06 1.04114e-05 1.92891e-05  1.80121e-11 4.60661e-07
vorticity              /     122307 -6.77166e-06   0.0349135 -2.80492e-05 2.61138e-05  5.4163e-05 -5.53661e-11  9.4269e-07
ke                     /      65009      1266.79     7307.29     -40.2655     13.5591     53.8246    0.0194864    0.498689
uReconstructZonal      /      64980      111.472     810.576      -1.8792     1.20225     3.08144   0.00171549    0.038912
uReconstructMeridional /      65011      22.2184     844.057     -1.13444     1.09463     2.22906  0.000341764   0.0423328
ertel_pv               /      70117      29.1715     359.951     -1.14682     1.76991     2.91672   0.00041604    0.024143
u_pv                   /       1117     -11.7118      17.191     -9.70966    0.257504     9.96716   -0.0104851    0.301826
v_pv                   /       1131      2.35272     4.49838    -0.136125     1.56751     1.70363   0.00208021   0.0473029
theta_pv               /       1083      20.7376     26.1335    -0.442017     16.1278     16.5698    0.0191483    0.513071
vort_pv                /       1133 -3.86332e-05 5.50993e-05 -2.96813e-05 1.46591e-06 3.11473e-05 -3.40981e-08 9.41348e-07
iLev_DT                /          3            2           4           -1           2           3     0.666667     1.52753
depv_dt_lw             /      72265  -0.00966736    0.086436  -0.00112376 0.000783959  0.00190771 -1.33777e-07 8.80798e-06
depv_dt_sw             /      71841  -0.00178718   0.0285477 -0.000141488 0.000208115 0.000349602 -2.48769e-08 2.53221e-06
depv_dt_bl             /      61034    0.0281591    0.364848  -0.00179484  0.00479244  0.00658728  4.61368e-07 4.92747e-05
depv_dt_mix            /      71677 -1.25906e-05  0.00354888 -1.13401e-05 1.10674e-05 2.24075e-05 -1.75658e-10 2.14604e-07
dtheta_dt_mp           /      14533    0.0301136   0.0950148 -0.000452805 0.000638453  0.00109126  2.07208e-06 2.77209e-05
depv_dt_mp             /      40026   0.00257601   0.0463216 -0.000369486 0.000588078 0.000957564  6.43585e-08 8.36785e-06
depv_dt_diab           /      72575     0.019268    0.408595  -0.00183634  0.00510581  0.00694215  2.65491e-07 4.70774e-05
depv_dt_fric           /      72726  -0.00560831    0.228499  -0.00175057  0.00432151  0.00607208 -7.71156e-08 3.22753e-05
depv_dt_diab_pv        /       1226 -3.29816e-05 7.49791e-05 -5.91669e-06 1.72532e-06 7.64201e-06 -2.69018e-08 3.45502e-07
depv_dt_fric_pv        /       1232 -0.000264565 0.000967594 -0.000221334  8.0537e-05 0.000301871 -2.14745e-07 8.48495e-06
rainnc                 /        473    -0.139409    0.926425   -0.0430557   0.0349963   0.0780521 -0.000294734  0.00595732
precipw                /        976     -1.63466     5.39149    -0.123482   0.0641136    0.187595  -0.00167486  0.00995983
kpbl                   /        208           -8         224          -12           1          13   -0.0384615      1.3364
hpbl                   /       1227        -8991       31595     -1548.35     225.108     1773.45     -7.32763     62.9774
hfx                    /       1226      3044.62     6000.82      -77.264     76.0999     153.364      2.48338     10.6029
qfx                    /       1226  0.000334121  0.00141006 -3.10141e-05 2.82583e-05 5.92724e-05   2.7253e-07 2.93772e-06
cd                     /       1220    0.0373418   0.0914571  -0.00216498  0.00336423  0.00552921  3.06081e-05 0.000192254
cda                    /       1219    0.0339896   0.0818156  -0.00204116  0.00294646  0.00498762  2.78832e-05 0.000170996
ck                     /       1222    0.0442394   0.0644726  -0.00149341  0.00129439  0.00278781  3.62025e-05 0.000112173
cka                    /       1223    0.0397682   0.0602859  -0.00151853   0.0013295  0.00284803  3.25169e-05 0.000109241
lh                     /       1226      835.303     3525.16     -77.5353     70.6458     148.181     0.681324      7.3443
u10                    /       1218      11.2682     38.8526    -0.572452    0.684313     1.25677   0.00925136   0.0575039
v10                    /       1218       8.6112     48.2679    -0.873998    0.551199      1.4252   0.00706995   0.0786151
q2                     /       1209   0.00597243   0.0344655 -0.000365136 0.000440383 0.000805519  4.93998e-06  4.9616e-05
t2m                    /       1117     -10.2173      56.683    -0.786591     2.18237     2.96896  -0.00914705    0.110324
th2m                   /       1125     -10.5345     58.0424    -0.828979     2.26782      3.0968  -0.00936396    0.113451
gsw                    /       1096      10017.7     27845.2      -315.16     327.937     643.096      9.14024     48.5833
glw                    /       1095     -697.551     3889.78     -44.2644     36.3465     80.6109    -0.637033     6.69479
skintemp               /        771      67.4297     153.701     -2.43311     1.97098     4.40408    0.0874575    0.370348
canwat                 /         26    0.0353815   0.0482232  -0.00243697   0.0126866   0.0151236   0.00136083  0.00306029
sh2o                   /       4425    0.0156964   0.0658075  -0.00311568   0.0018044  0.00492008  3.54721e-06 8.03877e-05
smois                  /       4438   0.00976293     0.06807  -0.00350467  0.00187469  0.00537936  2.19985e-06 8.45471e-05
tslb                   /       3811      149.929     333.042     -2.43311     1.97098     4.40408    0.0393411     0.20747
snowfallac             /         17 -6.99905e-11  1.2569e-10 -9.62928e-11 1.45093e-11 1.10802e-10 -4.11709e-12 2.41321e-11
acrunoff               /        240 -0.000224731 0.000701802 -0.000155866 4.22373e-05 0.000198104 -9.36378e-07 1.43351e-05
grdflx                 /        768     -1679.07     6530.65     -97.2833     86.3098     183.593     -2.18629     16.3974
cldfrac_bl             /       5266     -262.287     337.804    -0.896203    0.588996      1.4852   -0.0498077   0.0975892
graupelnc              /         18 -3.50909e-08 6.29422e-08 -4.81468e-08 7.25413e-09  5.5401e-08  -1.9495e-09  1.1715e-08

########################################################################
# compare to previous NCAR CONUS mesoscale_reference baselines A1NCAR   
########################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/mnt/lfs5/BMC/rtwbl/olson/mpas_testcase_20250721/run_case/gsl-v8.3.0-1.11-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5/B
MC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/mnt/lfs5/BMC/rtwbl/olson/mpas_testcase_20250721/run_case/gsl-v8.3.0-1.11-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5/B
MC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/mnt/lfs5/BMC/rtwbl/olson/mpas_testcase_20250721/run_case/gsl-v8.3.0-1.11-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/lfs5/B
MC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

########################################################################
# compare to previous NCAR CONUS convection_permitting baselines B1NCAR   
########################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/mnt/lfs5/BMC/rtwbl/olson/mpas_testcase_20250721/run_case/gsl-v8.3.0-1.11-intdebug.convection_permitting.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/lfs5
/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.convection_permitting.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/mnt/lfs5/BMC/rtwbl/olson/mpas_testcase_20250721/run_case/gsl-v8.3.0-1.11-intdebug.convection_permitting.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/lfs5
/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.convection_permitting.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/mnt/lfs5/BMC/rtwbl/olson/mpas_testcase_20250721/run_case/gsl-v8.3.0-1.11-intdebug.convection_permitting.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/lfs5
/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.convection_permitting.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

###############################################################################
# compare to previous NCAR CONUS convection_permitting_none baselines F1NCAR   
###############################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/mnt/lfs5/BMC/rtwbl/olson/mpas_testcase_20250721/run_case/gsl-v8.3.0-1.11-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "
/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/mnt/lfs5/BMC/rtwbl/olson/mpas_testcase_20250721/run_case/gsl-v8.3.0-1.11-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "
/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/mnt/lfs5/BMC/rtwbl/olson/mpas_testcase_20250721/run_case/gsl-v8.3.0-1.11-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "
/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

###############################################################################
# compare to previous NCAR CONUS mesoscale_reference_noahmp baselines E1NCAR   
###############################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/mnt/lfs5/BMC/rtwbl/olson/mpas_testcase_20250721/run_case/gsl-v8.3.0-1.11-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "
/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/mnt/lfs5/BMC/rtwbl/olson/mpas_testcase_20250721/run_case/gsl-v8.3.0-1.11-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "
/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/mnt/lfs5/BMC/rtwbl/olson/mpas_testcase_20250721/run_case/gsl-v8.3.0-1.11-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "
/lfs5/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

```
</details>
