### PR TITLE
Add GitHub actions for MPAS Standalone build.

### DIFF
--- a/.github/workflows/build_mpas.yml
+++ b/.github/workflows/build_mpas.yml
@@ -40,12 +40,12 @@ jobs:
         sudo apt-get update
         sudo apt-get install libnetcdff-dev
 
-    - name: Cache openmpi
-      id: cache-openmpi
-      uses: actions/cache@v4
-      with:
-        path: /home/runner/ompi-4.1.6
-        key: cache-openmpi-${{matrix.fortran-compiler}}-key
+#    - name: Cache openmpi
+#      id: cache-openmpi
+#      uses: actions/cache@v4
+#      with:
+#        path: /home/runner/ompi-4.1.6
+#        key: cache-openmpi-${{matrix.fortran-compiler}}-key
 
     - name: Install openmpi
       if: steps.cache-openmpi.outputs.cache-hit != 'true'
@@ -60,12 +60,12 @@ jobs:
         echo "LD_LIBRARY_PATH=${OMPI}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
         echo "PATH=${OMPI}/bin:$PATH" >> $GITHUB_ENV
 
-    - name: Cache GNU autotools
-      id: cache-AUTOTOOLS
-      uses: actions/cache@v4
-      with:
-        path: /home/runner/AUTOTOOLS
-        key: cache-AUTOTOOLS-${{matrix.fortran-compiler}}-key
+#    - name: Cache GNU autotools
+#      id: cache-AUTOTOOLS
+#      uses: actions/cache@v4
+#      with:
+#        path: /home/runner/AUTOTOOLS
+#        key: cache-AUTOTOOLS-${{matrix.fortran-compiler}}-key
 
     - name: Build GNU autotools
       if: steps.cache-AUTOTOOLS.outputs.cache-hit != 'true'

--- a/.github/workflows/build_mpas.yml
+++ b/.github/workflows/build_mpas.yml
@@ -23,12 +23,8 @@ jobs:
       PNETCDF: /home/runner/PnetCDF
       AUTOTOOLS: /home/runner/AUTOTOOLS
       OMPI: /home/runner/ompi-4.1.6
-      LD_LIBRARY_PATH: ${PNETCDF}:${LD_LIBRARY_PATH}
-      LD_LIBRARY_PATH: ${AUTOTOOLS}:${LD_LIBRARY_PATH}
-      LD_LIBRARY_PATH: ${OMPI}:${LD_LIBRARY_PATH}
-      PATH: ${PNETCDF}:${PATH}
-      PATH: ${AUTOTOOLS}:${PATH}
-      PATH: ${OMPI}:${PATH}
+      LD_LIBRARY_PATH: ${PNETCDF}:${AUTOTOOLS}:${OMPI}:${LD_LIBRARY_PATH}
+      PATH: ${PNETCDF}:${AUTOTOOLS}:${OMPI}${PATH}
 
     # Workflow steps
     steps:

--- a/.github/workflows/build_mpas.yml
+++ b/.github/workflows/build_mpas.yml
@@ -40,12 +40,12 @@ jobs:
         sudo apt-get update
         sudo apt-get install libnetcdff-dev
 
-#    - name: Cache openmpi
-#      id: cache-openmpi
-#      uses: actions/cache@v4
-#      with:
-#        path: /home/runner/ompi-4.1.6
-#        key: cache-openmpi-${{matrix.fortran-compiler}}-key
+    - name: Cache openmpi
+      id: cache-openmpi
+      uses: actions/cache@v4
+      with:
+        path: /home/runner/ompi-4.1.6
+        key: cache-openmpi-${{matrix.fortran-compiler}}-key
 
     - name: Install openmpi
       if: steps.cache-openmpi.outputs.cache-hit != 'true'
@@ -60,12 +60,12 @@ jobs:
         echo "LD_LIBRARY_PATH=${OMPI}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
         echo "PATH=${OMPI}/bin:$PATH" >> $GITHUB_ENV
 
-#    - name: Cache GNU autotools
-#      id: cache-AUTOTOOLS
-#      uses: actions/cache@v4
-#      with:
-#        path: /home/runner/AUTOTOOLS
-#        key: cache-AUTOTOOLS-${{matrix.fortran-compiler}}-key
+    - name: Cache GNU autotools
+      id: cache-AUTOTOOLS
+      uses: actions/cache@v4
+      with:
+        path: /home/runner/AUTOTOOLS
+        key: cache-AUTOTOOLS-${{matrix.fortran-compiler}}-key
 
     - name: Build GNU autotools
       if: steps.cache-AUTOTOOLS.outputs.cache-hit != 'true'
@@ -100,12 +100,12 @@ jobs:
         echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
         echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
 
-#    - name: Cache PnetCDF
-#      id: cache-pnetcdf
-#      uses: actions/cache@v4
-#      with:
-#        path: /home/runner/PnetCDF
-#        key: cache-PnetCDF-${{matrix.fortran-compiler}}-key
+    - name: Cache PnetCDF
+      id: cache-pnetcdf
+      uses: actions/cache@v4
+      with:
+        path: /home/runner/PnetCDF
+        key: cache-PnetCDF-${{matrix.fortran-compiler}}-key
 
     - name: Install PnetCDF
       if: steps.cache-PnetCDF.outputs.cache-hit != 'true'
@@ -142,7 +142,8 @@ jobs:
       if: matrix.build-system == 'make'
       run: |
         cd ${driver_ROOT}/MPAS-Model/MPAS-Model
-        make gfortran CORE=init_atmosphere;atmosphere
+        make gfortran CORE=init_atmosphere
+        make gfortran CORE=atmosphere
 
     - name: Build MPAS Standalone (cmake)
       if: matrix.build-system == 'cmake'

--- a/.github/workflows/build_mpas.yml
+++ b/.github/workflows/build_mpas.yml
@@ -1,4 +1,4 @@
-name: CI test to build MPAS Standalone
+name: CI (GNU) MPAS Standalone
 
 on: [pull_request,workflow_dispatch,push]
 
@@ -9,7 +9,8 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        fortran-compiler: [gfortran-10, gfortran-11, gfortran-12]
+        fortran-compiler: [gfortran-10]#, gfortran-11, gfortran-12]
+	build-system: [make,cmake]
 
     # Environmental variables
     env:
@@ -139,12 +140,17 @@ jobs:
         echo "LD_LIBRARY_PATH=${PNETCDF}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
         echo "PATH=${PNETCDF}/bin:$PATH" >> $GITHUB_ENV
 
-    # Build MPAS-A
-    - name: Build MPAS
+    - name: Build MPAS Standalone (make)
+      if: matrix.build-system == 'make'
       run: |
-        echo "ls lib/"
-        ls ${PNETCDF}/lib
-        echo "ls include/"
-        ls ${PNETCDF}/include
         cd ${driver_ROOT}/MPAS-Model/MPAS-Model
         make gfortran CORE=atmosphere
+
+    - name: Build MPAS Standalone (cmake)
+      if: matrix.build-system == 'cmake'
+      run: |
+        cd ${driver_ROOT}/MPAS-Model/MPAS-Model
+        mkdir build
+        cd build
+        cmake -DMPAS_DOUBLE_PRECISION=OFF -DMPAS_CORES="init_atmosphere;atmosphere" ..
+        make -j8

--- a/.github/workflows/build_mpas.yml
+++ b/.github/workflows/build_mpas.yml
@@ -29,6 +29,11 @@ jobs:
     - name: Checkout code (into ${driver_ROOT})
       uses: actions/checkout@v3
 
+    - name: Initialize submodules
+      run: |
+        git submodule update --init --recursive
+        echo "ls -l src/core_atmosphere/physics/physics_mmm"
+          
     - name: Install NetCDF library
       run: |
         sudo apt-get update

--- a/.github/workflows/build_mpas.yml
+++ b/.github/workflows/build_mpas.yml
@@ -52,8 +52,8 @@ jobs:
         ./configure --prefix=${OMPI}
         make -j4
         make install
-        #echo "LD_LIBRARY_PATH=${OMPI}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-        #echo "PATH=${OMPI}/bin:$PATH" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=${OMPI}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        echo "PATH=${OMPI}/bin:$PATH" >> $GITHUB_ENV
 
     # Cache GNU autotools
     - name: Cache GNU autotools
@@ -131,9 +131,9 @@ jobs:
       run: |
         echo "FC=mpif90" >> $GITHUB_ENV
         echo "CC=mpicc"  >> $GITHUB_ENV
+        echo "PNETCDF=${PNETCDF}" >> $GITHUB_ENV
         echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-        echo "PNETCDF=${PNETCDF}" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=${OMPI}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
         echo "PATH=${OMPI}/bin:$PATH" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=${PNETCDF}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV

--- a/.github/workflows/build_mpas.yml
+++ b/.github/workflows/build_mpas.yml
@@ -23,8 +23,6 @@ jobs:
       PNETCDF: /home/runner/PnetCDF
       AUTOTOOLS: /home/runner/AUTOTOOLS
       OMPI: /home/runner/ompi-4.1.6
-      LD_LIBRARY_PATH: ${PNETCDF}:${AUTOTOOLS}:${OMPI}:${LD_LIBRARY_PATH}
-      PATH: ${PNETCDF}:${AUTOTOOLS}:${OMPI}${PATH}
 
     # Workflow steps
     steps:

--- a/.github/workflows/build_mpas.yml
+++ b/.github/workflows/build_mpas.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         fortran-compiler: [gfortran-10]#, gfortran-11, gfortran-12]
-        build-system: [make,cmake]
+        build-system: [make]
 
     # Environmental variables
     env:

--- a/.github/workflows/build_mpas.yml
+++ b/.github/workflows/build_mpas.yml
@@ -135,8 +135,10 @@ jobs:
         echo "PATH=${OMPI}/bin:$PATH" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=${OMPI}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
         echo "PATH=${PNETCDF}/bin:$PATH" >> $GITHUB_ENV
+
+    - name: Display environment
         echo "LD_LIBRARY_PATH=${PNETCDF}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-	echo "FC:              " ${FC}
+        echo "FC:              " ${FC}
         echo "CC:              " ${CC}
         echo "PATH:            " ${PATH}
         echo "LD_LIBRARY_PATH: " ${LD_LIBRARY_PATH}

--- a/.github/workflows/build_mpas.yml
+++ b/.github/workflows/build_mpas.yml
@@ -124,8 +124,6 @@ jobs:
         autoreconf -i
         ./configure --prefix=${PNETCDF} --with-mpi=${OMPI}
         make -j 8 install
-        #make -s LIBTOOLFLAGS=--silent V=1 -j 8 install > qout 2>&1
-        #make -s distclean >> qout 2>&1
         echo "PATH=${PNETCDF}/bin:$PATH" >> $GITHUB_ENV
 
     - name: Setup environment for openmpi compiler

--- a/.github/workflows/build_mpas.yml
+++ b/.github/workflows/build_mpas.yml
@@ -135,9 +135,10 @@ jobs:
         echo "PATH=${OMPI}/bin:$PATH" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=${OMPI}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
         echo "PATH=${PNETCDF}/bin:$PATH" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=${PNETCDF}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
     - name: Display environment
-        echo "LD_LIBRARY_PATH=${PNETCDF}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+      run: |
         echo "FC:              " ${FC}
         echo "CC:              " ${CC}
         echo "PATH:            " ${PATH}

--- a/.github/workflows/build_mpas.yml
+++ b/.github/workflows/build_mpas.yml
@@ -56,6 +56,9 @@ jobs:
         ./configure --prefix=${OMPI}
         make -j4
         make install
+
+    - name: Add (OMPI) to Paths
+      run: |
         echo "LD_LIBRARY_PATH=${OMPI}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
         echo "PATH=${OMPI}/bin:$PATH" >> $GITHUB_ENV
 
@@ -99,6 +102,11 @@ jobs:
         echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
         echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
 
+    - name: Add (autotools) to Paths
+      run: |
+        echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
+
     - name: Cache PnetCDF
       id: cache-pnetcdf
       uses: actions/cache@v4
@@ -110,8 +118,8 @@ jobs:
       if: steps.cache-PnetCDF.outputs.cache-hit != 'true'
       run: |
         set -x
-        echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-        echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
+        #echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        #echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
         m4 --version
         autoconf --version
         automake --version
@@ -123,19 +131,24 @@ jobs:
         autoreconf -i
         ./configure --prefix=${PNETCDF} --with-mpi=${OMPI}
         make -j 8 install
+
+    - name: Add (PNETCDF) to paths.
+      run: |
+        echo "PNETCDF=${PNETCDF}" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=${PNETCDF}/bin:$LD_LIBRARY_PATH" >> $GITHUB_ENV
         echo "PATH=${PNETCDF}/bin:$PATH" >> $GITHUB_ENV
 
-    - name: Setup environment
-      run: |
-        echo "FC=mpif90" >> $GITHUB_ENV
-        echo "CC=mpicc"  >> $GITHUB_ENV
-        echo "PNETCDF=${PNETCDF}" >> $GITHUB_ENV
-        echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
-        echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-        echo "PATH=${OMPI}/bin:$PATH" >> $GITHUB_ENV
-        echo "LD_LIBRARY_PATH=${OMPI}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-        echo "PATH=${PNETCDF}/bin:$PATH" >> $GITHUB_ENV
-        echo "LD_LIBRARY_PATH=${PNETCDF}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+#    - name: Setup environment
+#      run: |
+#        echo "FC=mpif90" >> $GITHUB_ENV
+#        echo "CC=mpicc"  >> $GITHUB_ENV
+#        echo "PNETCDF=${PNETCDF}" >> $GITHUB_ENV
+#        echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
+#        echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+#        echo "PATH=${OMPI}/bin:$PATH" >> $GITHUB_ENV
+#        echo "LD_LIBRARY_PATH=${OMPI}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+#        echo "PATH=${PNETCDF}/bin:$PATH" >> $GITHUB_ENV
+#        echo "LD_LIBRARY_PATH=${PNETCDF}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
     - name: Display environment
       run: |

--- a/.github/workflows/build_mpas.yml
+++ b/.github/workflows/build_mpas.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        fortran-compiler: [gfortran-10]#, gfortran-11, gfortran-12]
-        build-system: [make]
+        fortran-compiler: [gfortran-10, gfortran-11, gfortran-12]
+        build-system: [make, cmake]
 
     # Environmental variables
     env:
@@ -63,7 +63,7 @@ jobs:
       id: cache-AUTOTOOLS
       uses: actions/cache@v4
       with:
-        path: ${AUTOTOOLS}/home/runner/AUTOTOOLS
+        path: /home/runner/AUTOTOOLS
         key: cache-AUTOTOOLS-${{matrix.fortran-compiler}}-key
 
     - name: Build GNU autotools
@@ -99,12 +99,12 @@ jobs:
         echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
         echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
 
-    - name: Cache PnetCDF
-      id: cache-pnetcdf
-      uses: actions/cache@v4
-      with:
-        path: /home/runner/PnetCDF
-        key: cache-PnetCDF-${{matrix.fortran-compiler}}-key
+#    - name: Cache PnetCDF
+#      id: cache-pnetcdf
+#      uses: actions/cache@v4
+#      with:
+#        path: /home/runner/PnetCDF
+#        key: cache-PnetCDF-${{matrix.fortran-compiler}}-key
 
     - name: Install PnetCDF
       if: steps.cache-PnetCDF.outputs.cache-hit != 'true'
@@ -132,10 +132,10 @@ jobs:
         echo "PNETCDF=${PNETCDF}" >> $GITHUB_ENV
         echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-        echo "LD_LIBRARY_PATH=${OMPI}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
         echo "PATH=${OMPI}/bin:$PATH" >> $GITHUB_ENV
-        echo "LD_LIBRARY_PATH=${PNETCDF}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=${OMPI}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
         echo "PATH=${PNETCDF}/bin:$PATH" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=${PNETCDF}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
     - name: Build MPAS Standalone (make)
       if: matrix.build-system == 'make'

--- a/.github/workflows/build_mpas.yml
+++ b/.github/workflows/build_mpas.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false  # Disable fail-fast
       matrix:
-        fortran-compiler: [gfortran-10, gfortran-11, gfortran-12]
+        fortran-compiler: [gfortran-12]
         build-system: [make, cmake]
 
     # Environmental variables
@@ -142,7 +142,7 @@ jobs:
       if: matrix.build-system == 'make'
       run: |
         cd ${driver_ROOT}/MPAS-Model/MPAS-Model
-        make gfortran CORE=atmosphere
+        make gfortran CORE=init_atmosphere;atmosphere
 
     - name: Build MPAS Standalone (cmake)
       if: matrix.build-system == 'cmake'

--- a/.github/workflows/build_mpas.yml
+++ b/.github/workflows/build_mpas.yml
@@ -40,12 +40,12 @@ jobs:
         sudo apt-get update
         sudo apt-get install libnetcdff-dev
 
-    - name: Cache openmpi
-      id: cache-openmpi
-      uses: actions/cache@v4
-      with:
-        path: /home/runner/ompi-4.1.6
-        key: cache-openmpi-${{matrix.fortran-compiler}}-key
+#    - name: Cache openmpi
+#      id: cache-openmpi
+#      uses: actions/cache@v4
+#      with:
+#        path: /home/runner/ompi-4.1.6
+#        key: cache-openmpi-${{matrix.fortran-compiler}}-key
 
     - name: Install openmpi
       if: steps.cache-openmpi.outputs.cache-hit != 'true'
@@ -60,12 +60,12 @@ jobs:
         echo "LD_LIBRARY_PATH=${OMPI}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
         echo "PATH=${OMPI}/bin:$PATH" >> $GITHUB_ENV
 
-    - name: Cache GNU autotools
-      id: cache-AUTOTOOLS
-      uses: actions/cache@v4
-      with:
-        path: /home/runner/AUTOTOOLS
-        key: cache-AUTOTOOLS-${{matrix.fortran-compiler}}-key
+#    - name: Cache GNU autotools
+#      id: cache-AUTOTOOLS
+#      uses: actions/cache@v4
+#      with:
+#        path: /home/runner/AUTOTOOLS
+#        key: cache-AUTOTOOLS-${{matrix.fortran-compiler}}-key
 
     - name: Build GNU autotools
       if: steps.cache-AUTOTOOLS.outputs.cache-hit != 'true'
@@ -100,12 +100,12 @@ jobs:
         echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
         echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
 
-    - name: Cache PnetCDF
-      id: cache-pnetcdf
-      uses: actions/cache@v4
-      with:
-        path: /home/runner/PnetCDF
-        key: cache-PnetCDF-${{matrix.fortran-compiler}}-key
+#    - name: Cache PnetCDF
+#      id: cache-pnetcdf
+#      uses: actions/cache@v4
+#      with:
+#        path: /home/runner/PnetCDF
+#        key: cache-PnetCDF-${{matrix.fortran-compiler}}-key
 
     - name: Install PnetCDF
       if: steps.cache-PnetCDF.outputs.cache-hit != 'true'

--- a/.github/workflows/build_mpas.yml
+++ b/.github/workflows/build_mpas.yml
@@ -1,0 +1,144 @@
+name: CI test to build MPAS Standalone
+
+on: [pull_request,workflow_dispatch,push]
+
+jobs:
+  build_mpas:
+
+    # The type of runner that the job will run on
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        fortran-compiler: [gfortran-10, gfortran-11, gfortran-12]
+
+    # Environmental variables
+    env:
+      driver_ROOT: /home/runner/work
+      AUTOCONF_VERSION: 2.71
+      AUTOMAKE_VERSION: 1.17
+      M4_VERSION: 1.4.19
+      LIBTOOL_VERSION: 2.5.4
+      PNETCDF: /home/runner/PnetCDF
+
+    # Workflow steps
+    steps:
+
+    - name: Checkout code (into ${driver_ROOT})
+      uses: actions/checkout@v3
+
+    # NetCDF C and FORTRAN libraries
+    - name: Install NetCDF library
+      run: |
+        sudo apt-get update
+        sudo apt-get install libnetcdff-dev
+
+    # Cache openmpi
+    - name: Cache openmpi
+      id: cache-openmpi
+      uses: actions/cache@v4
+      with:
+        path: /home/runner/ompi-4.1.6
+        key: cache-openmpi-${{matrix.fortran-compiler}}-key
+
+    - name: Install openmpi
+      if: steps.cache-openmpi.outputs.cache-hit != 'true'
+      run: |
+        wget https://github.com/open-mpi/ompi/archive/refs/tags/v4.1.6.tar.gz
+        tar -xvf v4.1.6.tar.gz
+        cd ompi-4.1.6
+        ./autogen.pl
+        ./configure --prefix=/home/runner/ompi-4.1.6
+        make -j4
+        make install
+        echo "LD_LIBRARY_PATH=/home/runner/ompi-4.1.6/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        echo "PATH=/home/runner/ompi-4.1.6/bin:$PATH" >> $GITHUB_ENV
+
+    # Cache GNU autotools
+    - name: Cache GNU autotools
+      id: cache-AUTOTOOLS
+      uses: actions/cache@v4
+      with:
+        path: /home/runner/AUTOTOOLS
+        key: cache-AUTOTOOLS-${{matrix.fortran-compiler}}-key
+
+    # Buld GNU Autotools
+    - name: Build GNU autotools
+      if: steps.cache-AUTOTOOLS.outputs.cache-hit != 'true'
+      run: |
+        wget -q https://ftp.gnu.org/gnu/m4/m4-${M4_VERSION}.tar.gz
+        gzip -dc m4-${M4_VERSION}.tar.gz | tar -xf -
+        cd m4-${M4_VERSION}
+        ./configure --prefix=/home/runner/AUTOTOOLS --silent
+        make -s -j 8 install > qout 2>&1
+        make -s -j 8 distclean >> qout 2>&1
+
+        wget -q https://ftp.gnu.org/gnu/autoconf/autoconf-${AUTOCONF_VERSION}.tar.gz
+        gzip -dc autoconf-${AUTOCONF_VERSION}.tar.gz | tar -xf -
+        cd autoconf-${AUTOCONF_VERSION}
+        ./configure --prefix=/home/runner/AUTOTOOLS --silent
+        make -s -j 8 install > qout 2>&1
+        make -s -j 8 distclean >> qout 2>&1
+
+        wget -q https://ftp.gnu.org/gnu/automake/automake-${AUTOMAKE_VERSION}.tar.gz
+        gzip -dc automake-${AUTOMAKE_VERSION}.tar.gz | tar -xf -
+        cd automake-${AUTOMAKE_VERSION}
+        ./configure --prefix=/home/runner/AUTOTOOLS --silent
+        make -s -j 8 install > qout 2>&1
+        make -s -j 8 distclean >> qout 2>&1
+
+        wget -q https://ftp.gnu.org/gnu/libtool/libtool-${LIBTOOL_VERSION}.tar.gz
+        gzip -dc libtool-${LIBTOOL_VERSION}.tar.gz | tar -xf -
+        cd libtool-${LIBTOOL_VERSION}
+        ./configure --prefix=/home/runner/AUTOTOOLS --silent
+        make -s -j 8 install > qout 2>&1
+        make -s -j 8 distclean >> qout 2>&1
+        echo "LD_LIBRARY_PATH=/home/runner/AUTOTOOLS/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        echo "PATH=/home/runner/AUTOTOOLS/bin:$PATH" >> $GITHUB_ENV
+
+    # Cache PNetCDF
+    - name: Cache PnetCDF
+      id: cache-pnetcdf
+      uses: actions/cache@v4
+      with:
+        path: /home/runner/PnetCDF
+        key: cache-PnetCDF-${{matrix.fortran-compiler}}-key
+
+    # PNetCDF library
+    - name: Install PnetCDF
+      if: steps.cache-PnetCDF.outputs.cache-hit != 'true'
+      run: |
+        set -x
+        echo "LD_LIBRARY_PATH=/home/runner/AUTOTOOLS/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        echo "PATH=/home/runner/AUTOTOOLS/bin:$PATH" >> $GITHUB_ENV
+        m4 --version
+        autoconf --version
+        automake --version
+        libtool --version
+        echo "Install PnetCDF on /home/runner/PnetCDF"
+        rm -rf PnetCDF ; mkdir PnetCDF ; cd PnetCDF
+        git clone -q https://github.com/Parallel-NetCDF/PnetCDF.git
+        cd PnetCDF
+        autoreconf -i
+        ./configure --prefix=/home/runner/PnetCDF --with-mpi=/home/runner/ompi-4.1.6
+        make -j 8 install
+        #make -s LIBTOOLFLAGS=--silent V=1 -j 8 install > qout 2>&1
+        #make -s distclean >> qout 2>&1
+        echo "PATH=/home/runner/PnetCDF/bin:$PATH" >> $GITHUB_ENV
+
+
+    - name: Environment for openmpi compiler
+      run: |
+        echo "FC=mpif90" >> $GITHUB_ENV
+        echo "CC=mpicc"  >> $GITHUB_ENV
+        echo "PNETCDF=/home/runner/PnetCDF" >> $GITHUB_ENV
+        echo "PATH=/home/runner/PnetCDF/bin:$PATH" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=/home/runner/PnetCDF/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+
+
+    # Build MPAS-A
+    - name: Build MPAS
+      run: |
+        ls ${PNETCDF}/lib
+        ls ${PNETCDF}/include
+        cd ${driver_ROOT}/MPAS-Model/MPAS-Model
+        make gfortran CORE=atmosphere

--- a/.github/workflows/build_mpas.yml
+++ b/.github/workflows/build_mpas.yml
@@ -19,6 +19,8 @@ jobs:
       M4_VERSION: 1.4.19
       LIBTOOL_VERSION: 2.5.4
       PNETCDF: /home/runner/PnetCDF
+      AUTOTOOLS: /home/runner/AUTOTOOLS
+      OMPI: /home/runner/ompi-4.1.6
 
     # Workflow steps
     steps:
@@ -37,7 +39,7 @@ jobs:
       id: cache-openmpi
       uses: actions/cache@v4
       with:
-        path: /home/runner/ompi-4.1.6
+        path: ${OMPI}
         key: cache-openmpi-${{matrix.fortran-compiler}}-key
 
     - name: Install openmpi
@@ -47,18 +49,18 @@ jobs:
         tar -xvf v4.1.6.tar.gz
         cd ompi-4.1.6
         ./autogen.pl
-        ./configure --prefix=/home/runner/ompi-4.1.6
+        ./configure --prefix=${OMPI}
         make -j4
         make install
-        echo "LD_LIBRARY_PATH=/home/runner/ompi-4.1.6/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-        echo "PATH=/home/runner/ompi-4.1.6/bin:$PATH" >> $GITHUB_ENV
+        #echo "LD_LIBRARY_PATH=${OMPI}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        #echo "PATH=${OMPI}/bin:$PATH" >> $GITHUB_ENV
 
     # Cache GNU autotools
     - name: Cache GNU autotools
       id: cache-AUTOTOOLS
       uses: actions/cache@v4
       with:
-        path: /home/runner/AUTOTOOLS
+        path: ${AUTOTOOLS}
         key: cache-AUTOTOOLS-${{matrix.fortran-compiler}}-key
 
     # Buld GNU Autotools
@@ -68,39 +70,39 @@ jobs:
         wget -q https://ftp.gnu.org/gnu/m4/m4-${M4_VERSION}.tar.gz
         gzip -dc m4-${M4_VERSION}.tar.gz | tar -xf -
         cd m4-${M4_VERSION}
-        ./configure --prefix=/home/runner/AUTOTOOLS --silent
+        ./configure --prefix=${AUTOTOOLS} --silent
         make -s -j 8 install > qout 2>&1
         make -s -j 8 distclean >> qout 2>&1
 
         wget -q https://ftp.gnu.org/gnu/autoconf/autoconf-${AUTOCONF_VERSION}.tar.gz
         gzip -dc autoconf-${AUTOCONF_VERSION}.tar.gz | tar -xf -
         cd autoconf-${AUTOCONF_VERSION}
-        ./configure --prefix=/home/runner/AUTOTOOLS --silent
+        ./configure --prefix=${AUTOTOOLS} --silent
         make -s -j 8 install > qout 2>&1
         make -s -j 8 distclean >> qout 2>&1
 
         wget -q https://ftp.gnu.org/gnu/automake/automake-${AUTOMAKE_VERSION}.tar.gz
         gzip -dc automake-${AUTOMAKE_VERSION}.tar.gz | tar -xf -
         cd automake-${AUTOMAKE_VERSION}
-        ./configure --prefix=/home/runner/AUTOTOOLS --silent
+        ./configure --prefix=${AUTOTOOLS} --silent
         make -s -j 8 install > qout 2>&1
         make -s -j 8 distclean >> qout 2>&1
 
         wget -q https://ftp.gnu.org/gnu/libtool/libtool-${LIBTOOL_VERSION}.tar.gz
         gzip -dc libtool-${LIBTOOL_VERSION}.tar.gz | tar -xf -
         cd libtool-${LIBTOOL_VERSION}
-        ./configure --prefix=/home/runner/AUTOTOOLS --silent
+        ./configure --prefix=${AUTOTOOLS} --silent
         make -s -j 8 install > qout 2>&1
         make -s -j 8 distclean >> qout 2>&1
-        echo "LD_LIBRARY_PATH=/home/runner/AUTOTOOLS/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-        echo "PATH=/home/runner/AUTOTOOLS/bin:$PATH" >> $GITHUB_ENV
+        #echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        #echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
 
     # Cache PNetCDF
     - name: Cache PnetCDF
       id: cache-pnetcdf
       uses: actions/cache@v4
       with:
-        path: /home/runner/PnetCDF
+        path: ${PNETCDF}
         key: cache-PnetCDF-${{matrix.fortran-compiler}}-key
 
     # PNetCDF library
@@ -108,37 +110,41 @@ jobs:
       if: steps.cache-PnetCDF.outputs.cache-hit != 'true'
       run: |
         set -x
-        echo "LD_LIBRARY_PATH=/home/runner/AUTOTOOLS/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-        echo "PATH=/home/runner/AUTOTOOLS/bin:$PATH" >> $GITHUB_ENV
+        #echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        #echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
         m4 --version
         autoconf --version
         automake --version
         libtool --version
-        echo "Install PnetCDF on /home/runner/PnetCDF"
+        echo "Install PnetCDF on ${PNETCDF}"
         rm -rf PnetCDF ; mkdir PnetCDF ; cd PnetCDF
         git clone -q https://github.com/Parallel-NetCDF/PnetCDF.git
         cd PnetCDF
         autoreconf -i
-        ./configure --prefix=/home/runner/PnetCDF --with-mpi=/home/runner/ompi-4.1.6
+        ./configure --prefix=${PNETCDF} --with-mpi=${OMPI}
         make -j 8 install
         #make -s LIBTOOLFLAGS=--silent V=1 -j 8 install > qout 2>&1
         #make -s distclean >> qout 2>&1
-        echo "PATH=/home/runner/PnetCDF/bin:$PATH" >> $GITHUB_ENV
+        echo "PATH=${PNETCDF}/bin:$PATH" >> $GITHUB_ENV
 
-
-    - name: Environment for openmpi compiler
+    - name: Setup environment for openmpi compiler
       run: |
         echo "FC=mpif90" >> $GITHUB_ENV
         echo "CC=mpicc"  >> $GITHUB_ENV
-        echo "PNETCDF=/home/runner/PnetCDF" >> $GITHUB_ENV
-        echo "PATH=/home/runner/PnetCDF/bin:$PATH" >> $GITHUB_ENV
-        echo "LD_LIBRARY_PATH=/home/runner/PnetCDF/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-
+        echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        echo "PNETCDF=${PNETCDF}" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=${OMPI}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        echo "PATH=${OMPI}/bin:$PATH" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=${PNETCDF}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        echo "PATH=${PNETCDF}/bin:$PATH" >> $GITHUB_ENV
 
     # Build MPAS-A
     - name: Build MPAS
       run: |
+        echo "ls lib/"
         ls ${PNETCDF}/lib
+	echo "ls include/"
         ls ${PNETCDF}/include
         cd ${driver_ROOT}/MPAS-Model/MPAS-Model
         make gfortran CORE=atmosphere

--- a/.github/workflows/build_mpas.yml
+++ b/.github/workflows/build_mpas.yml
@@ -1,6 +1,6 @@
 name: Build (GNU) MPAS Standalone
 
-on: [pull_request,workflow_dispatch,push]
+on: [pull_request,workflow_dispatch]
 
 jobs:
   build_mpas_GNU:

--- a/.github/workflows/build_mpas.yml
+++ b/.github/workflows/build_mpas.yml
@@ -1,9 +1,9 @@
-name: CI (GNU) MPAS Standalone
+name: Build (GNU) MPAS Standalone
 
 on: [pull_request,workflow_dispatch,push]
 
 jobs:
-  build_mpas:
+  build_mpas_GNU:
 
     # The type of runner that the job will run on
     runs-on: ubuntu-22.04
@@ -29,13 +29,11 @@ jobs:
     - name: Checkout code (into ${driver_ROOT})
       uses: actions/checkout@v3
 
-    # NetCDF C and FORTRAN libraries
     - name: Install NetCDF library
       run: |
         sudo apt-get update
         sudo apt-get install libnetcdff-dev
 
-    # Cache openmpi
     - name: Cache openmpi
       id: cache-openmpi
       uses: actions/cache@v4
@@ -56,7 +54,6 @@ jobs:
         echo "LD_LIBRARY_PATH=${OMPI}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
         echo "PATH=${OMPI}/bin:$PATH" >> $GITHUB_ENV
 
-    # Cache GNU autotools
     - name: Cache GNU autotools
       id: cache-AUTOTOOLS
       uses: actions/cache@v4
@@ -64,7 +61,6 @@ jobs:
         path: ${AUTOTOOLS}
         key: cache-AUTOTOOLS-${{matrix.fortran-compiler}}-key
 
-    # Buld GNU Autotools
     - name: Build GNU autotools
       if: steps.cache-AUTOTOOLS.outputs.cache-hit != 'true'
       run: |
@@ -98,7 +94,6 @@ jobs:
         echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
         echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
 
-    # Cache PNetCDF
     - name: Cache PnetCDF
       id: cache-pnetcdf
       uses: actions/cache@v4
@@ -106,7 +101,6 @@ jobs:
         path: ${PNETCDF}
         key: cache-PnetCDF-${{matrix.fortran-compiler}}-key
 
-    # PNetCDF library
     - name: Install PnetCDF
       if: steps.cache-PnetCDF.outputs.cache-hit != 'true'
       run: |

--- a/.github/workflows/build_mpas.yml
+++ b/.github/workflows/build_mpas.yml
@@ -144,7 +144,7 @@ jobs:
       run: |
         echo "ls lib/"
         ls ${PNETCDF}/lib
-	echo "ls include/"
+        echo "ls include/"
         ls ${PNETCDF}/include
         cd ${driver_ROOT}/MPAS-Model/MPAS-Model
         make gfortran CORE=atmosphere

--- a/.github/workflows/build_mpas.yml
+++ b/.github/workflows/build_mpas.yml
@@ -43,7 +43,7 @@ jobs:
       id: cache-openmpi
       uses: actions/cache@v4
       with:
-        path: ${OMPI}
+        path: /home/runner/ompi-4.1.6
         key: cache-openmpi-${{matrix.fortran-compiler}}-key
 
     - name: Install openmpi
@@ -63,7 +63,7 @@ jobs:
       id: cache-AUTOTOOLS
       uses: actions/cache@v4
       with:
-        path: ${AUTOTOOLS}
+        path: ${AUTOTOOLS}/home/runner/AUTOTOOLS
         key: cache-AUTOTOOLS-${{matrix.fortran-compiler}}-key
 
     - name: Build GNU autotools
@@ -103,7 +103,7 @@ jobs:
       id: cache-pnetcdf
       uses: actions/cache@v4
       with:
-        path: ${PNETCDF}
+        path: /home/runner/PnetCDF
         key: cache-PnetCDF-${{matrix.fortran-compiler}}-key
 
     - name: Install PnetCDF

--- a/.github/workflows/build_mpas.yml
+++ b/.github/workflows/build_mpas.yml
@@ -23,6 +23,12 @@ jobs:
       PNETCDF: /home/runner/PnetCDF
       AUTOTOOLS: /home/runner/AUTOTOOLS
       OMPI: /home/runner/ompi-4.1.6
+      LD_LIBRARY_PATH: ${PNETCDF}:${LD_LIBRARY_PATH}
+      LD_LIBRARY_PATH: ${AUTOTOOLS}:${LD_LIBRARY_PATH}
+      LD_LIBRARY_PATH: ${OMPI}:${LD_LIBRARY_PATH}
+      PATH: ${PNETCDF}:${PATH}
+      PATH: ${AUTOTOOLS}:${PATH}
+      PATH: ${OMPI}:${PATH}
 
     # Workflow steps
     steps:

--- a/.github/workflows/build_mpas.yml
+++ b/.github/workflows/build_mpas.yml
@@ -33,7 +33,6 @@ jobs:
     - name: Initialize submodules
       run: |
         git submodule update --init --recursive
-        echo "ls -l src/core_atmosphere/physics/physics_mmm"
           
     - name: Install NetCDF library
       run: |
@@ -126,7 +125,7 @@ jobs:
         make -j 8 install
         echo "PATH=${PNETCDF}/bin:$PATH" >> $GITHUB_ENV
 
-    - name: Setup environment for openmpi compiler
+    - name: Setup environment
       run: |
         echo "FC=mpif90" >> $GITHUB_ENV
         echo "CC=mpicc"  >> $GITHUB_ENV
@@ -137,6 +136,11 @@ jobs:
         echo "LD_LIBRARY_PATH=${OMPI}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
         echo "PATH=${PNETCDF}/bin:$PATH" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=${PNETCDF}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+	echo "FC:              " ${FC}
+        echo "CC:              " ${CC}
+        echo "PATH:            " ${PATH}
+        echo "LD_LIBRARY_PATH: " ${LD_LIBRARY_PATH}
+        echo "PNETCDF:         " ${PNETCDF}
 
     - name: Build MPAS Standalone (make)
       if: matrix.build-system == 'make'

--- a/.github/workflows/build_mpas.yml
+++ b/.github/workflows/build_mpas.yml
@@ -94,8 +94,8 @@ jobs:
         ./configure --prefix=${AUTOTOOLS} --silent
         make -s -j 8 install > qout 2>&1
         make -s -j 8 distclean >> qout 2>&1
-        #echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-        #echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
 
     # Cache PNetCDF
     - name: Cache PnetCDF
@@ -110,8 +110,8 @@ jobs:
       if: steps.cache-PnetCDF.outputs.cache-hit != 'true'
       run: |
         set -x
-        #echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-        #echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
         m4 --version
         autoconf --version
         automake --version

--- a/.github/workflows/build_mpas.yml
+++ b/.github/workflows/build_mpas.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         fortran-compiler: [gfortran-10]#, gfortran-11, gfortran-12]
-	build-system: [make,cmake]
+        build-system: [make,cmake]
 
     # Environmental variables
     env:

--- a/.github/workflows/build_mpas.yml
+++ b/.github/workflows/build_mpas.yml
@@ -8,6 +8,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false  # Disable fail-fast
       matrix:
         fortran-compiler: [gfortran-10, gfortran-11, gfortran-12]
         build-system: [make, cmake]

--- a/.github/workflows/build_mpas.yml
+++ b/.github/workflows/build_mpas.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false  # Disable fail-fast
       matrix:
         fortran-compiler: [gfortran-12]
-        build-system: [make, cmake]
+        build-system: [make]###, cmake]
 
     # Environmental variables
     env:
@@ -39,12 +39,12 @@ jobs:
         sudo apt-get update
         sudo apt-get install libnetcdff-dev
 
-#    - name: Cache openmpi
-#      id: cache-openmpi
-#      uses: actions/cache@v4
-#      with:
-#        path: /home/runner/ompi-4.1.6
-#        key: cache-openmpi-${{matrix.fortran-compiler}}-key
+    - name: Cache openmpi
+      id: cache-openmpi
+      uses: actions/cache@v4
+      with:
+        path: /home/runner/ompi-4.1.6
+        key: cache-openmpi-${{matrix.fortran-compiler}}-key
 
     - name: Install openmpi
       if: steps.cache-openmpi.outputs.cache-hit != 'true'
@@ -59,12 +59,12 @@ jobs:
         echo "LD_LIBRARY_PATH=${OMPI}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
         echo "PATH=${OMPI}/bin:$PATH" >> $GITHUB_ENV
 
-#    - name: Cache GNU autotools
-#      id: cache-AUTOTOOLS
-#      uses: actions/cache@v4
-#      with:
-#        path: /home/runner/AUTOTOOLS
-#        key: cache-AUTOTOOLS-${{matrix.fortran-compiler}}-key
+    - name: Cache GNU autotools
+      id: cache-AUTOTOOLS
+      uses: actions/cache@v4
+      with:
+        path: /home/runner/AUTOTOOLS
+        key: cache-AUTOTOOLS-${{matrix.fortran-compiler}}-key
 
     - name: Build GNU autotools
       if: steps.cache-AUTOTOOLS.outputs.cache-hit != 'true'
@@ -99,12 +99,12 @@ jobs:
         echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
         echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
 
-#    - name: Cache PnetCDF
-#      id: cache-pnetcdf
-#      uses: actions/cache@v4
-#      with:
-#        path: /home/runner/PnetCDF
-#        key: cache-PnetCDF-${{matrix.fortran-compiler}}-key
+    - name: Cache PnetCDF
+      id: cache-pnetcdf
+      uses: actions/cache@v4
+      with:
+        path: /home/runner/PnetCDF
+        key: cache-PnetCDF-${{matrix.fortran-compiler}}-key
 
     - name: Install PnetCDF
       if: steps.cache-PnetCDF.outputs.cache-hit != 'true'

--- a/.github/workflows/build_mpas_intel.yml
+++ b/.github/workflows/build_mpas_intel.yml
@@ -37,7 +37,14 @@ jobs:
       uses: NOAA-EMC/ci-install-intel-toolkit@develop
       with:
         install-mpi: true
-  
+
+    - name: Cache Intel
+      id: cache-INTEL
+      uses: actions/cache@v4
+      with:
+        path: /opt/intel/oneapi/mpi/2021.10.0
+        key: cache-AUTOTOOLS-${{matrix.fortran-compiler}}-key
+
     - name: Install NetCDF library
       run: |
         sudo apt-get update

--- a/.github/workflows/build_mpas_intel.yml
+++ b/.github/workflows/build_mpas_intel.yml
@@ -132,7 +132,8 @@ jobs:
       if: matrix.build-system == 'make'
       run: |
         cd ${driver_ROOT}/MPAS-Model/MPAS-Model
-        make intel-mpi CORE=init_atmosphere;atmosphere
+        make intel-mpi CORE=init_atmosphere
+        make intel-mpi CORE=atmosphere
 
     - name: Build MPAS Standalone (cmake)
       if: matrix.build-system == 'cmake'

--- a/.github/workflows/build_mpas_intel.yml
+++ b/.github/workflows/build_mpas_intel.yml
@@ -132,7 +132,7 @@ jobs:
       if: matrix.build-system == 'make'
       run: |
         cd ${driver_ROOT}/MPAS-Model/MPAS-Model
-        make gfortran CORE=atmosphere
+        make intel-mpi CORE=init_atmosphere;atmosphere
 
     - name: Build MPAS Standalone (cmake)
       if: matrix.build-system == 'cmake'

--- a/.github/workflows/build_mpas_intel.yml
+++ b/.github/workflows/build_mpas_intel.yml
@@ -79,8 +79,8 @@ jobs:
         ./configure --prefix=${AUTOTOOLS} --silent
         make -s -j 8 install > qout 2>&1
         make -s -j 8 distclean >> qout 2>&1
-        #echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-        #echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
 
     # Cache PNetCDF
     - name: Cache PnetCDF
@@ -95,8 +95,8 @@ jobs:
       if: steps.cache-PnetCDF.outputs.cache-hit != 'true'
       run: |
         set -x
-        #echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-        #echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
         m4 --version
         autoconf --version
         automake --version

--- a/.github/workflows/build_mpas_intel.yml
+++ b/.github/workflows/build_mpas_intel.yml
@@ -138,6 +138,6 @@ jobs:
       run: |
         cd ${driver_ROOT}/MPAS-Model/MPAS-Model
         mkdir build
-	cd build
+        cd build
         cmake -DMPAS_DOUBLE_PRECISION=OFF -DMPAS_CORES="init_atmosphere;atmosphere" ..
         make -j8

--- a/.github/workflows/build_mpas_intel.yml
+++ b/.github/workflows/build_mpas_intel.yml
@@ -1,4 +1,4 @@
-name: CI test to build MPAS Standalone
+name: Build (Intel) MPAS Standalone
 
 on: [pull_request,workflow_dispatch,push]
 
@@ -20,7 +20,7 @@ jobs:
       LIBTOOL_VERSION: 2.5.4
       PNETCDF: /home/runner/PnetCDF
       AUTOTOOLS: /home/runner/AUTOTOOLS
-      OMPI: /home/runner/ompi-4.1.6
+      OMPI: /opt/intel/oneapi/mpi/2021.10.0
 
     # Workflow steps
     steps:
@@ -112,15 +112,15 @@ jobs:
         #make -s distclean >> qout 2>&1
         echo "PATH=${PNETCDF}/bin:$PATH" >> $GITHUB_ENV
 
-    - name: Setup environment for openmpi compiler
+    - name: Setup environment
       run: |
         echo "FC=mpif90" >> $GITHUB_ENV
         echo "CC=mpicc"  >> $GITHUB_ENV
+        echo "PNETCDF=${PNETCDF}" >> $GITHUB_ENV
         echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-        echo "PNETCDF=${PNETCDF}" >> $GITHUB_ENV
-        echo "LD_LIBRARY_PATH=${PNETCDF}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
         echo "PATH=${PNETCDF}/bin:$PATH" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=${PNETCDF}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
     # Build MPAS-A
     - name: Build MPAS

--- a/.github/workflows/build_mpas_intel.yml
+++ b/.github/workflows/build_mpas_intel.yml
@@ -120,8 +120,8 @@ jobs:
 
     - name: Setup environment
       run: |
-        echo "FC=mpiifort >> $GITHUB_ENV
-        echo "CC=mpiicc"  >> $GITHUB_ENV
+        echo "FC=mpiifort" >> $GITHUB_ENV
+        echo "CC=mpiicc"   >> $GITHUB_ENV
         echo "PNETCDF=${PNETCDF}" >> $GITHUB_ENV
         echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV

--- a/.github/workflows/build_mpas_intel.yml
+++ b/.github/workflows/build_mpas_intel.yml
@@ -3,7 +3,7 @@ name: Build (Intel) MPAS Standalone
 on: [pull_request,workflow_dispatch,push]
 
 jobs:
-  build_mpas:
+  build_mpas_intel:
 
     # The type of runner that the job will run on
     runs-on: ubuntu-22.04
@@ -125,9 +125,5 @@ jobs:
     # Build MPAS-A
     - name: Build MPAS
       run: |
-        echo "ls lib/"
-        ls ${PNETCDF}/lib
-        echo "ls include/"
-        ls ${PNETCDF}/include
         cd ${driver_ROOT}/MPAS-Model/MPAS-Model
         make gfortran CORE=atmosphere

--- a/.github/workflows/build_mpas_intel.yml
+++ b/.github/workflows/build_mpas_intel.yml
@@ -47,7 +47,7 @@ jobs:
       id: cache-AUTOTOOLS
       uses: actions/cache@v4
       with:
-        path: ${AUTOTOOLS}
+        path: /home/runner/AUTOTOOLS
         key: cache-AUTOTOOLS-${{matrix.fortran-compiler}}-key
 
     - name: Build GNU autotools
@@ -87,7 +87,7 @@ jobs:
       id: cache-pnetcdf
       uses: actions/cache@v4
       with:
-        path: ${PNETCDF}
+        path: /home/runner/PnetCDF
         key: cache-PnetCDF-${{matrix.fortran-compiler}}-key
 
     - name: Install PnetCDF

--- a/.github/workflows/build_mpas_intel.yml
+++ b/.github/workflows/build_mpas_intel.yml
@@ -8,6 +8,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false  # Disable fail-fast
       matrix:
         fortran-compiler: [intel]
         build-system: [make, cmake]

--- a/.github/workflows/build_mpas_intel.yml
+++ b/.github/workflows/build_mpas_intel.yml
@@ -28,19 +28,21 @@ jobs:
     - name: Checkout code (into ${driver_ROOT})
       uses: actions/checkout@v3
 
-    # Intel
+    - name: Initialize submodules
+      run: |
+        git submodule update --init --recursive
+        echo "ls -l src/core_atmosphere/physics/physics_mmm"
+
     - name: "Install Intel compilers & MPI"
       uses: NOAA-EMC/ci-install-intel-toolkit@develop
       with:
         install-mpi: true
   
-    # NetCDF C and FORTRAN libraries
     - name: Install NetCDF library
       run: |
         sudo apt-get update
         sudo apt-get install libnetcdff-dev
 
-    # Cache GNU autotools
     - name: Cache GNU autotools
       id: cache-AUTOTOOLS
       uses: actions/cache@v4
@@ -48,7 +50,6 @@ jobs:
         path: ${AUTOTOOLS}
         key: cache-AUTOTOOLS-${{matrix.fortran-compiler}}-key
 
-    # Build GNU Autotools
     - name: Build GNU autotools
       if: steps.cache-AUTOTOOLS.outputs.cache-hit != 'true'
       run: |
@@ -82,7 +83,6 @@ jobs:
         echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
         echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
 
-    # Cache PNetCDF
     - name: Cache PnetCDF
       id: cache-pnetcdf
       uses: actions/cache@v4
@@ -90,7 +90,6 @@ jobs:
         path: ${PNETCDF}
         key: cache-PnetCDF-${{matrix.fortran-compiler}}-key
 
-    # PNetCDF library
     - name: Install PnetCDF
       if: steps.cache-PnetCDF.outputs.cache-hit != 'true'
       run: |
@@ -108,8 +107,6 @@ jobs:
         autoreconf -i
         ./configure --prefix=${PNETCDF} --with-mpi=${OMPI}
         make -j 8 install
-        #make -s LIBTOOLFLAGS=--silent V=1 -j 8 install > qout 2>&1
-        #make -s distclean >> qout 2>&1
         echo "PATH=${PNETCDF}/bin:$PATH" >> $GITHUB_ENV
 
     - name: Setup environment
@@ -122,7 +119,6 @@ jobs:
         echo "PATH=${PNETCDF}/bin:$PATH" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=${PNETCDF}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
-    # Build MPAS-A
     - name: Build MPAS
       run: |
         cd ${driver_ROOT}/MPAS-Model/MPAS-Model

--- a/.github/workflows/build_mpas_intel.yml
+++ b/.github/workflows/build_mpas_intel.yml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       matrix:
         fortran-compiler: [intel]
+        build-system: [make, cmake]
 
     # Environmental variables
     env:
@@ -126,7 +127,17 @@ jobs:
         echo "PATH=${PNETCDF}/bin:$PATH" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=${PNETCDF}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
-    - name: Build MPAS
+    - name: Build MPAS Standalone (make)
+      if: matrix.build-system == 'make'
       run: |
         cd ${driver_ROOT}/MPAS-Model/MPAS-Model
         make gfortran CORE=atmosphere
+
+    - name: Build MPAS Standalone (cmake)
+      if: matrix.build-system == 'cmake'
+      run: |
+        cd ${driver_ROOT}/MPAS-Model/MPAS-Model
+        mkdir build
+	cd build
+        cmake -DMPAS_DOUBLE_PRECISION=OFF -DMPAS_CORES="init_atmosphere;atmosphere" ..
+        make -j8

--- a/.github/workflows/build_mpas_intel.yml
+++ b/.github/workflows/build_mpas_intel.yml
@@ -1,6 +1,6 @@
 name: Build (Intel) MPAS Standalone
 
-on: [pull_request,workflow_dispatch,push]
+on: [pull_request,workflow_dispatch]
 
 jobs:
   build_mpas_intel:

--- a/.github/workflows/build_mpas_intel.yml
+++ b/.github/workflows/build_mpas_intel.yml
@@ -120,8 +120,8 @@ jobs:
 
     - name: Setup environment
       run: |
-        echo "FC=mpif90" >> $GITHUB_ENV
-        echo "CC=mpicc"  >> $GITHUB_ENV
+        echo "FC=mpiifort >> $GITHUB_ENV
+        echo "CC=mpiicc"  >> $GITHUB_ENV
         echo "PNETCDF=${PNETCDF}" >> $GITHUB_ENV
         echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV

--- a/.github/workflows/build_mpas_intel.yml
+++ b/.github/workflows/build_mpas_intel.yml
@@ -1,0 +1,133 @@
+name: CI test to build MPAS Standalone
+
+on: [pull_request,workflow_dispatch,push]
+
+jobs:
+  build_mpas:
+
+    # The type of runner that the job will run on
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        fortran-compiler: [intel]
+
+    # Environmental variables
+    env:
+      driver_ROOT: /home/runner/work
+      AUTOCONF_VERSION: 2.71
+      AUTOMAKE_VERSION: 1.17
+      M4_VERSION: 1.4.19
+      LIBTOOL_VERSION: 2.5.4
+      PNETCDF: /home/runner/PnetCDF
+      AUTOTOOLS: /home/runner/AUTOTOOLS
+      OMPI: /home/runner/ompi-4.1.6
+
+    # Workflow steps
+    steps:
+
+    - name: Checkout code (into ${driver_ROOT})
+      uses: actions/checkout@v3
+
+    # Intel
+    - name: "Install Intel compilers & MPI"
+      uses: NOAA-EMC/ci-install-intel-toolkit@develop
+      with:
+        install-mpi: true
+  
+    # NetCDF C and FORTRAN libraries
+    - name: Install NetCDF library
+      run: |
+        sudo apt-get update
+        sudo apt-get install libnetcdff-dev
+
+    # Cache GNU autotools
+    - name: Cache GNU autotools
+      id: cache-AUTOTOOLS
+      uses: actions/cache@v4
+      with:
+        path: ${AUTOTOOLS}
+        key: cache-AUTOTOOLS-${{matrix.fortran-compiler}}-key
+
+    # Build GNU Autotools
+    - name: Build GNU autotools
+      if: steps.cache-AUTOTOOLS.outputs.cache-hit != 'true'
+      run: |
+        wget -q https://ftp.gnu.org/gnu/m4/m4-${M4_VERSION}.tar.gz
+        gzip -dc m4-${M4_VERSION}.tar.gz | tar -xf -
+        cd m4-${M4_VERSION}
+        ./configure --prefix=${AUTOTOOLS} --silent
+        make -s -j 8 install > qout 2>&1
+        make -s -j 8 distclean >> qout 2>&1
+
+        wget -q https://ftp.gnu.org/gnu/autoconf/autoconf-${AUTOCONF_VERSION}.tar.gz
+        gzip -dc autoconf-${AUTOCONF_VERSION}.tar.gz | tar -xf -
+        cd autoconf-${AUTOCONF_VERSION}
+        ./configure --prefix=${AUTOTOOLS} --silent
+        make -s -j 8 install > qout 2>&1
+        make -s -j 8 distclean >> qout 2>&1
+
+        wget -q https://ftp.gnu.org/gnu/automake/automake-${AUTOMAKE_VERSION}.tar.gz
+        gzip -dc automake-${AUTOMAKE_VERSION}.tar.gz | tar -xf -
+        cd automake-${AUTOMAKE_VERSION}
+        ./configure --prefix=${AUTOTOOLS} --silent
+        make -s -j 8 install > qout 2>&1
+        make -s -j 8 distclean >> qout 2>&1
+
+        wget -q https://ftp.gnu.org/gnu/libtool/libtool-${LIBTOOL_VERSION}.tar.gz
+        gzip -dc libtool-${LIBTOOL_VERSION}.tar.gz | tar -xf -
+        cd libtool-${LIBTOOL_VERSION}
+        ./configure --prefix=${AUTOTOOLS} --silent
+        make -s -j 8 install > qout 2>&1
+        make -s -j 8 distclean >> qout 2>&1
+        #echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        #echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
+
+    # Cache PNetCDF
+    - name: Cache PnetCDF
+      id: cache-pnetcdf
+      uses: actions/cache@v4
+      with:
+        path: ${PNETCDF}
+        key: cache-PnetCDF-${{matrix.fortran-compiler}}-key
+
+    # PNetCDF library
+    - name: Install PnetCDF
+      if: steps.cache-PnetCDF.outputs.cache-hit != 'true'
+      run: |
+        set -x
+        #echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        #echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
+        m4 --version
+        autoconf --version
+        automake --version
+        libtool --version
+        echo "Install PnetCDF on ${PNETCDF}"
+        rm -rf PnetCDF ; mkdir PnetCDF ; cd PnetCDF
+        git clone -q https://github.com/Parallel-NetCDF/PnetCDF.git
+        cd PnetCDF
+        autoreconf -i
+        ./configure --prefix=${PNETCDF} --with-mpi=${OMPI}
+        make -j 8 install
+        #make -s LIBTOOLFLAGS=--silent V=1 -j 8 install > qout 2>&1
+        #make -s distclean >> qout 2>&1
+        echo "PATH=${PNETCDF}/bin:$PATH" >> $GITHUB_ENV
+
+    - name: Setup environment for openmpi compiler
+      run: |
+        echo "FC=mpif90" >> $GITHUB_ENV
+        echo "CC=mpicc"  >> $GITHUB_ENV
+        echo "PATH=${AUTOTOOLS}/bin:$PATH" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=${AUTOTOOLS}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        echo "PNETCDF=${PNETCDF}" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=${PNETCDF}/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        echo "PATH=${PNETCDF}/bin:$PATH" >> $GITHUB_ENV
+
+    # Build MPAS-A
+    - name: Build MPAS
+      run: |
+        echo "ls lib/"
+        ls ${PNETCDF}/lib
+        echo "ls include/"
+        ls ${PNETCDF}/include
+        cd ${driver_ROOT}/MPAS-Model/MPAS-Model
+        make gfortran CORE=atmosphere

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MPAS-v8.3.0-1.13
+MPAS-v8.3.0-1.14
 ====
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for

--- a/src/core_atmosphere/Externals.cfg
+++ b/src/core_atmosphere/Externals.cfg
@@ -1,12 +1,12 @@
 [MMM-physics]
-local_path = ./physics_mmm
+local_path = /home/runner/work/MPAS-Model/MPAS-Model/src/core_atmosphere/physics/physics_mmm
 protocol = git
 repo_url = https://github.com/NCAR/MMM-physics.git
 tag = 20240626-MPASv8.2
 required = True
 
 [GSL_UGWP]
-local_path = ./physics_noaa/UGWP
+local_path = /home/runner/work/MPAS-Model/MPAS-Model/src/core_atmosphere/physics/physics_noaa/UGWP
 protocol = git
 repo_url = https://github.com/NOAA-GSL/UGWP.git
 tag = MPAS_20241223

--- a/src/core_atmosphere/Externals.cfg
+++ b/src/core_atmosphere/Externals.cfg
@@ -1,12 +1,12 @@
 [MMM-physics]
-local_path = /home/runner/work/MPAS-Model/MPAS-Model/src/core_atmosphere/physics/physics_mmm
+local_path = ./physics_mmm
 protocol = git
 repo_url = https://github.com/NCAR/MMM-physics.git
 tag = 20240626-MPASv8.2
 required = True
 
 [GSL_UGWP]
-local_path = /home/runner/work/MPAS-Model/MPAS-Model/src/core_atmosphere/physics/physics_noaa/UGWP
+local_path = ./physics_noaa/UGWP
 protocol = git
 repo_url = https://github.com/NOAA-GSL/UGWP.git
 tag = MPAS_20241223

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.3.0-1.13">
+<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.3.0-1.14">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.3.0-1.13">
+<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.3.0-1.14">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->


### PR DESCRIPTION
## Description
This PR adds GitHub actions to build the MPAS-A model. This work was pulled from the feature/mpas-in-ufs branch and since expanded to include Intel

*Updated 07/31/2025 to only have latest GNU test*
Three new CI tests are enabled here.
Makefile/CMake for GNU/Intel Fortran.
- Makefile / gfortran-12
- Makefile / Intel (2023.2.1)
- Cmake / Intel (2023.2.1)

This main yaml script creates the necessary environment (netCDF, MPI, PNetCDF) and builds the MPAS standalone model on the GitHub servers. For GNU, native software is used. For Intel, A containerized version of Intel is used.

*NOTE* The 2 CMAKE tests will fail until #[149](https://github.com/ufs-community/MPAS-Model/pull/149) is merged. @guoqing-noaa @clark-evans 

