### PR TITLE
remove fpe0 flag from LDFLAGS_DEBUG to work with icx compile in debug mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1493,7 +1493,7 @@ ifneq "$(PNETCDF)" ""
 			&    err = ncmpi_create(MPI_COMM_WORLD, \"foo.nc\", NC_NOCLOBBER, MPI_INFO_NULL, &ncid);\n\
 			&    return 0;\n\
 			&}\n" | sed 's/&/ /' > pnetcdf.c
-	@( $(CC) pnetcdf.c $(CPPINCLUDES) $(CFLAGS) $(LDFLAGS) -L$(PNETCDF)/$(PNETCDFLIBLOC) -lpnetcdf  -o pnetcdf.out > pnetcdf.log 2>&1; \
+	@( $(CC) pnetcdf.c $(CPPINCLUDES) $(CFLAGS) -L$(PNETCDF)/$(PNETCDFLIBLOC) -lpnetcdf  -o pnetcdf.out > pnetcdf.log 2>&1; \
 	   if [ $$? -eq 0 ] ; then \
 	       echo "$(CC) can compile test PnetCDF C program."; \
 	   else \

--- a/Makefile
+++ b/Makefile
@@ -472,7 +472,7 @@ intel-mpi-ursa:   # usra
 	"FFLAGS_DEBUG = -g -convert big_endian -free -CU -CB -check all -fpe0 -traceback" \
 	"CFLAGS_DEBUG = -g -traceback" \
 	"CXXFLAGS_DEBUG = -g -traceback" \
-	"LDFLAGS_DEBUG = -g -fpe0 -traceback" \
+	"LDFLAGS_DEBUG = -g -traceback" \
 	"FFLAGS_OMP = -qopenmp" \
 	"CFLAGS_OMP = -qopenmp" \
 	"PICFLAG = -fpic" \
@@ -1493,7 +1493,7 @@ ifneq "$(PNETCDF)" ""
 			&    err = ncmpi_create(MPI_COMM_WORLD, \"foo.nc\", NC_NOCLOBBER, MPI_INFO_NULL, &ncid);\n\
 			&    return 0;\n\
 			&}\n" | sed 's/&/ /' > pnetcdf.c
-	@( $(CC) pnetcdf.c $(CPPINCLUDES) $(CFLAGS) -L$(PNETCDF)/$(PNETCDFLIBLOC) -lpnetcdf  -o pnetcdf.out > pnetcdf.log 2>&1; \
+	@( $(CC) pnetcdf.c $(CPPINCLUDES) $(CFLAGS) $(LDFLAGS) -L$(PNETCDF)/$(PNETCDFLIBLOC) -lpnetcdf  -o pnetcdf.out > pnetcdf.log 2>&1; \
 	   if [ $$? -eq 0 ] ; then \
 	       echo "$(CC) can compile test PnetCDF C program."; \
 	   else \

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MPAS-v8.3.0-1.12
+MPAS-v8.3.0-1.13
 ====
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.3.0-1.12">
+<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.3.0-1.13">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.3.0-1.12">
+<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.3.0-1.13">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->


### PR DESCRIPTION
Compiling with make fails on ursa in debug mode with rrfs-workflow configuration because it seems the `icx` compiler doesn't like `-fpe0` as a compile time option. The `LDFLAGS` in this case provide mostly redundant flags (`-g -traceback` already included in `CFLAGS`) to the compile command. 

This is only changed in the intel-mpi-ursa target.

Edit: changed to follow the approach used in the `intel` make target

```
Checking for a working PnetCDF library...
*********************************************************
ERROR: Test PnetCDF C program could not be compiled by mpiicc.
Please ensure you have a working PnetCDF library installed.

The following compilation command failed with errors:
mpiicc pnetcdf.c -I/contrib/spack-stack/spack-stack-1.9.1/envs/ue-oneapi-2024.2.1/install/oneapi/2024.2.1/parallel-netcdf-1.12.3-czznkk2/include -g -traceback -DSINGLE_PRECISION -g -fpe0 -traceback -L/contrib/spack-stack/spack-stack-1.9.1/envs/ue-oneapi-2024.2.1/install/oneapi/2024.2.1/parallel-netcdf-1.12.3-czznkk2/lib -lpnetcdf -o pnetcdf.out

Test program pnetcdf.c and output pnetcdf.log have been left
in the top-level MPAS directory for further debugging
*********************************************************
make[1]: *** [Makefile:1489: pnetcdf_test] Error 1
make[1]: Leaving directory '/scratch4/BMC/wrfruc/Michael.Barlage/mpas/code/gsl/gsl-fork/MPAS-Model'
make: *** [Makefile:460: intel-mpi-ursa] Error 2
 
[Michael.Barlage@ufe02 MPAS-Model]$ more pnetcdf.log 
icx: error: unknown argument: '-fpe0'

```

<details>
  <summary>
    regression test case results
  </summary>
  
```


     version_to_compare = pnetcdf_test
   gsl_version_baseline = v8.3.0-1.12
  ncar_version_baseline = v8.3.0
         test_directory = /scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/
 gsl_baseline_directory = /scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/
ncar_baseline_directory = /scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/
           compile_flag = -intdebug
         test_repo_name = gsl

######################################################################
# compare to previous GSL CONUS mesoscale_reference baselines A1GSL   
######################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-pnetcdf_test-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.12-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-pnetcdf_test-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.12-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-pnetcdf_test-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.12-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

#############################################################################
# compare to previous GSL CONUS convection_permitting_none baselines F1GSL   
#############################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-pnetcdf_test-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.12-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-pnetcdf_test-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.12-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-pnetcdf_test-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.12-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

#############################################################################
# compare to previous GSL CONUS mesoscale_reference_noahmp baselines E1GSL   
#############################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-pnetcdf_test-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.12-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-pnetcdf_test-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.12-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-pnetcdf_test-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.12-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

######################################################################
# compare to previous GSL CONUS hrrrv5 GFS baselines C5GSL            
######################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-pnetcdf_test-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.12-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-pnetcdf_test-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.12-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-pnetcdf_test-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.12-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

######################################################################
# compare to previous GSL CONUS hrrrv5 RAP winter baselines C7GSL     
######################################################################

  === history.2024-02-02_18.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-pnetcdf_test-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.12-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.00.00.nc" are identical.

  === history.2024-02-02_18.12.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-pnetcdf_test-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.12.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.12-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.12.00.nc" are identical.

  === history.2024-02-02_19.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-pnetcdf_test-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_19.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.12-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_19.00.00.nc" are identical.

######################################################################
# compare to previous GSL CONUS hrrrv5 RAP summer baselines C8GSL     
######################################################################

  === history.2024-08-15_18.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-pnetcdf_test-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.12-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.00.00.nc" are identical.

  === history.2024-08-15_18.12.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-pnetcdf_test-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.12.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.12-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.12.00.nc" are identical.

  === history.2024-08-15_19.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-pnetcdf_test-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_19.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.12-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_19.00.00.nc" are identical.

########################################################################
# compare to previous NCAR CONUS mesoscale_reference baselines A1NCAR   
########################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-pnetcdf_test-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-pnetcdf_test-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-pnetcdf_test-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

########################################################################
# compare to previous NCAR CONUS convection_permitting baselines B1NCAR   
########################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-pnetcdf_test-intdebug.convection_permitting.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.convection_permitting.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-pnetcdf_test-intdebug.convection_permitting.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.convection_permitting.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-pnetcdf_test-intdebug.convection_permitting.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.convection_permitting.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

###############################################################################
# compare to previous NCAR CONUS convection_permitting_none baselines F1NCAR   
###############################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-pnetcdf_test-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-pnetcdf_test-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-pnetcdf_test-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

###############################################################################
# compare to previous NCAR CONUS mesoscale_reference_noahmp baselines E1NCAR   
###############################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-pnetcdf_test-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-pnetcdf_test-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-pnetcdf_test-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.



```
</details>
