### PR TITLE
Fix incorrect array size in convective diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MPAS-v8.3.0-1.11
+MPAS-v8.3.0-1.12
 ====
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.3.0-1.11">
+<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.3.0-1.12">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->

--- a/src/core_atmosphere/diagnostics/mpas_convective_diagnostics.F
+++ b/src/core_atmosphere/diagnostics/mpas_convective_diagnostics.F
@@ -327,7 +327,7 @@ module mpas_convective_diagnostics
 
         real (kind=RKIND), allocatable, dimension(:,:) :: updraft_helicity, smooth_helicity
         real (kind=RKIND), allocatable, dimension(:,:) :: updraft_helicity_neg, smooth_helicity_neg
-        real (kind=RKIND), allocatable, dimension(:,:) :: wspd
+        real (kind=RKIND), allocatable, dimension(:)   :: wspd
         real (kind=RKIND), allocatable, dimension(:) :: z_agl, pres
         real (kind=RKIND), dimension(:,:), pointer :: kiteAreasOnVertex, vorticity, w, zgrid
         real (kind=RKIND), dimension(:), pointer :: areaCell, updraft_helicity_max, w_velocity_max
@@ -489,12 +489,12 @@ module mpas_convective_diagnostics
             endif
 
             if (is_needed_wind02_max) then
-                allocate(wspd(nVertLevels,nCells))
+                allocate(wspd(nVertLevels))
                 do iCell=1, nCellsSolve
                   z_agl(1:nVertLevels) = 0.5*(zgrid(1:nVertLevels,iCell)+zgrid(2:nVertlevelsP1,iCell)) - zgrid(1,iCell)
                   if (column_height_value(refl10cm(:,iCell),z_agl(1:nVertLevels),1000.0_RKIND,nVertLevels) > 20.0_RKIND) then
                     do k=1,nVertLevels
-                      wspd(k,iCell) = sqrt(uzonal(k,iCell)**2+umeridional(k,iCell)**2)
+                      wspd(k) = sqrt(uzonal(k,iCell)**2+umeridional(k,iCell)**2)
                     end do
                     wind02_max(iCell) = max(wind02_max(iCell), col_depth_max(wspd , z_agl, 0.0_RKIND, 2000.0_RKIND, nVertLevels ))
                   endif

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.3.0-1.11">
+<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.3.0-1.12">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->


### PR DESCRIPTION
Model crashes in debug mode at somewhat random times due to incorrect array size in convective diagnostics. 

Addresses #155 

<details>
  <summary>
    regression test case results
  </summary>
  
```


     version_to_compare = convdiag_bug
   gsl_version_baseline = v8.3.0-1.11
  ncar_version_baseline = v8.3.0
         test_directory = /scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/
 gsl_baseline_directory = /scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/
ncar_baseline_directory = /scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/
           compile_flag = -intdebug
         test_repo_name = gsl

######################################################################
# compare to previous GSL CONUS mesoscale_reference baselines A1GSL   
######################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-convdiag_bug-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.11-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-convdiag_bug-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.11-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-convdiag_bug-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.11-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

#############################################################################
# compare to previous GSL CONUS convection_permitting_none baselines F1GSL   
#############################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-convdiag_bug-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.11-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-convdiag_bug-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.11-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-convdiag_bug-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.11-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

#############################################################################
# compare to previous GSL CONUS mesoscale_reference_noahmp baselines E1GSL   
#############################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-convdiag_bug-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.11-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-convdiag_bug-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.11-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-convdiag_bug-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.11-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

######################################################################
# compare to previous GSL CONUS hrrrv5 GFS baselines C5GSL            
######################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-convdiag_bug-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.11-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-convdiag_bug-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.11-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-convdiag_bug-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.11-intdebug.hrrrv5.gsl.gsl.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

######################################################################
# compare to previous GSL CONUS hrrrv5 RAP winter baselines C7GSL     
######################################################################

  === history.2024-02-02_18.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-convdiag_bug-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.11-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.00.00.nc" are identical.

  === history.2024-02-02_18.12.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-convdiag_bug-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.12.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.11-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_18.12.00.nc" are identical.

  === history.2024-02-02_19.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-convdiag_bug-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_19.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.11-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024020218/history.2024-02-02_19.00.00.nc" are identical.

######################################################################
# compare to previous GSL CONUS hrrrv5 RAP summer baselines C8GSL     
######################################################################

  === history.2024-08-15_18.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-convdiag_bug-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.11-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.00.00.nc" are identical.

  === history.2024-08-15_18.12.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-convdiag_bug-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.12.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.11-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_18.12.00.nc" are identical.

  === history.2024-08-15_19.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-convdiag_bug-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_19.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/gsl-v8.3.0-1.11-intdebug.hrrrv5.gsl.gsl.conus.120km.rap.2024081518/history.2024-08-15_19.00.00.nc" are identical.

########################################################################
# compare to previous NCAR CONUS mesoscale_reference baselines A1NCAR   
########################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-convdiag_bug-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-convdiag_bug-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-convdiag_bug-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.mesoscale_reference.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

########################################################################
# compare to previous NCAR CONUS convection_permitting baselines B1NCAR   
########################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-convdiag_bug-intdebug.convection_permitting.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.convection_permitting.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-convdiag_bug-intdebug.convection_permitting.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.convection_permitting.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-convdiag_bug-intdebug.convection_permitting.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.convection_permitting.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

###############################################################################
# compare to previous NCAR CONUS convection_permitting_none baselines F1NCAR   
###############################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-convdiag_bug-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-convdiag_bug-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-convdiag_bug-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.convection_permitting_none.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.

###############################################################################
# compare to previous NCAR CONUS mesoscale_reference_noahmp baselines E1NCAR   
###############################################################################

  === history.2023-03-10_15.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-convdiag_bug-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.00.00.nc" are identical.

  === history.2023-03-10_15.12.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-convdiag_bug-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_15.12.00.nc" are identical.

  === history.2023-03-10_16.00.00.nc comparison
Files "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baseline_factory/mpas_testcase/run_case/gsl-convdiag_bug-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" and "/scratch4/BMC/wrfruc/Michael.Barlage/mpas/baselines_mpas/run_case/ncar-v8.3.0-intdebug.mesoscale_reference_noahmp.ncar.ncar.conus.120km.gfs.2023031015/history.2023-03-10_16.00.00.nc" are identical.


```
</details>
