### PR TITLE
v8.3.1 merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MPAS-v8.3.0
+MPAS-v8.3.1
 ====
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MPAS-v8.3.0-2.0
+MPAS-v8.3.1-2.1
 ====
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for

--- a/src/core_atmosphere/Externals.cfg
+++ b/src/core_atmosphere/Externals.cfg
@@ -2,7 +2,7 @@
 local_path = ./physics_mmm
 protocol = git
 repo_url = https://github.com/NCAR/MMM-physics.git
-tag = 20240626-MPASv8.2
+tag = 20250616-MPASv8.3
 required = True
 
 [GSL_UGWP]

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.3.0">
+<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.3.1">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.3.0-2.0">
+<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.3.1-2.1">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.3.0">
+<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.3.1">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.3.0-2.0">
+<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.3.1-2.1">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -5459,7 +5459,6 @@ call mpas_log_write('Done with soil consistency check')
             target_z = 0.5 * (zgrid(k,iCell) + zgrid(k+1,iCell))
             relhum(k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                        sorted_arr(:,1:nfglevels_actual-1), order=1, extrap=0)
-            if (target_z < z_fg(1,iCell) .and. k < nVertLevels) relhum(k,iCell) = relhum(k+1,iCell)
          end do
 
 
@@ -5477,7 +5476,6 @@ call mpas_log_write('Done with soil consistency check')
             target_z = 0.5 * (zgrid(k,iCell) + zgrid(k+1,iCell))
             spechum(k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                         sorted_arr(:,1:nfglevels_actual-1), order=1, extrap=0)
-            if (target_z < z_fg(1,iCell) .and. k < nVertLevels) spechum(k,iCell) = spechum(k+1,iCell)
          end do
 
 

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="landice" core_abbrev="li" version="8.3.0">
+<registry model="mpas" core="landice" core_abbrev="li" version="8.3.1">
 
 
 <!-- ======================================================================= -->

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="ocean" core_abbrev="ocn" version="8.3.0">
+<registry model="mpas" core="ocean" core_abbrev="ocn" version="8.3.1">
 
 	<dims>
 		<dim name="nCells" units="unitless"

--- a/src/core_seaice/Registry.xml
+++ b/src/core_seaice/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="seaice" core_abbrev="seaice" version="8.3.0">
+<registry model="mpas" core="seaice" core_abbrev="seaice" version="8.3.1">
 
 	<dims>
 		<dim name="nCells"

--- a/src/core_sw/Registry.xml
+++ b/src/core_sw/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="sw" core_abbrev="sw" version="8.3.0">
+<registry model="mpas" core="sw" core_abbrev="sw" version="8.3.1">
 	<dims>
 		<dim name="nCells"/>
 		<dim name="nEdges"/>

--- a/src/core_test/Registry.xml
+++ b/src/core_test/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="test" core_abbrev="test" version="8.3.0">
+<registry model="mpas" core="test" core_abbrev="test" version="8.3.1">
 	<dims>
 		<dim name="nCells"/>
 		<dim name="nEdges"/>


### PR DESCRIPTION
This PR merges NCAR's upstream v8.3.1 code into gsl/develop. There are only two changes: 

1. Updated manage_externals tag for NCAR's physics_mmm repo, fixing a recompilation bug.
2. A fix for the vertical interpolation of relative and specific humidity for lateral boundary conditions when the input data are arranged from top-to-bottom rather than bottom-to-top.

Everything else is a version number change, and I have removed the conflicts from the upstream versions in README.md, core_atmosphere/Registry.xml, and core_init_atmosphere/Registry.xml.

Requested priority reviewers: no preference.
