### PR TITLE
To read smoke/dust intial and boundary conditions from RRFS-A

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MPAS-v8.3.1-2.5
+MPAS-v8.3.1-2.6
 ====
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.3.1-2.5">
+<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.3.1-2.6">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.3.1-2.6">
+<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.3.1-noaa">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.3.1-2.6">
+<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.3.1-noaa">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.3.1-2.5">
+<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.3.1-2.6">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -4108,7 +4108,6 @@ module init_atm_cases
       integer :: nfglevels_actual
       integer, pointer :: index_qv, index_qc, index_qr, index_qi, index_qs, index_qg, index_ni, index_nc, index_nr, index_ns, index_ng
       integer, pointer :: index_nwfa, index_nifa
-      integer, pointer :: index_massden
       integer, pointer :: index_smoke_fine, index_dust_fine, index_dust_coarse
 
       integer, dimension(5) :: interp_list
@@ -4126,7 +4125,7 @@ module init_atm_cases
       real (kind=RKIND), dimension(:,:), pointer :: sorted_arrQ1,sorted_arrQ2,sorted_arrQ3,sorted_arrQ4,sorted_arrQ5,sorted_arrQ6,sorted_arrQ7,sorted_arrQ8
       real (kind=RKIND), dimension(:,:), pointer :: sorted_arrQ9,sorted_arrQ10
 ! Chemistry
-      real (kind=RKIND), dimension(:,:), pointer :: sorted_arrQ11,sorted_arrQ12,sorted_arrQ14,sorted_arrQ15
+      real (kind=RKIND), dimension(:,:), pointer :: sorted_arrQ11,sorted_arrQ12,sorted_arrQ13
 
 
       integer, dimension(:), pointer :: bdyMaskCell
@@ -4194,6 +4193,7 @@ module init_atm_cases
       integer, pointer :: config_theta_adv_order
       real (kind=RKIND), pointer :: config_coef_3rd_order
       logical, pointer :: config_blend_bdy_terrain
+      character (len=StrKIND), pointer :: config_smoke_scheme, config_dust_scheme
 
       character (len=StrKIND), pointer :: config_extrap_airtemp
       integer :: extrap_airtemp
@@ -4257,7 +4257,6 @@ module init_atm_cases
       real (kind=RKIND), dimension(:,:), pointer :: sm_fg
       real (kind=RKIND), dimension(:), pointer :: soilz
 ! Chemistry
-      real (kind=RKIND), dimension(:,:), pointer :: massden_fg
       real (kind=RKIND), dimension(:,:), pointer :: smoke_fine_fg
       real (kind=RKIND), dimension(:,:), pointer :: dust_fine_fg
       real (kind=RKIND), dimension(:,:), pointer :: dust_coarse_fg
@@ -4297,6 +4296,8 @@ module init_atm_cases
       call mpas_pool_get_config(configs, 'config_coef_3rd_order', config_coef_3rd_order)
       call mpas_pool_get_config(configs, 'config_blend_bdy_terrain', config_blend_bdy_terrain)
       call mpas_pool_get_config(configs, 'config_interface_projection', config_interface_projection)
+      call mpas_pool_get_config(configs, 'config_smoke_scheme', config_smoke_scheme)
+      call mpas_pool_get_config(configs, 'config_dust_scheme', config_dust_scheme)
       
       call mpas_pool_get_config(configs, 'config_extrap_airtemp', config_extrap_airtemp)
       if (trim(config_extrap_airtemp) == 'constant') then
@@ -4418,10 +4419,13 @@ module init_atm_cases
       call mpas_pool_get_array(fg, 'gfs_z', gfs_z)
       call mpas_pool_get_array(fg, 'p', p_fg)
 ! Chemistry
-      call mpas_pool_get_array(fg, 'MASSDEN', massden_fg)
-      call mpas_pool_get_array(fg, 'smoke_fine', smoke_fine_fg)
-      call mpas_pool_get_array(fg, 'dust_fine', dust_fine_fg)
-      call mpas_pool_get_array(fg, 'dust_coarse', dust_coarse_fg)
+      if ( config_smoke_scheme .ne. 'off' ) then
+         call mpas_pool_get_array(fg, 'smoke_fine', smoke_fine_fg)
+      endif
+      if ( config_dust_scheme .ne. 'off' ) then
+         call mpas_pool_get_array(fg, 'dust_fine', dust_fine_fg)
+         call mpas_pool_get_array(fg, 'dust_coarse', dust_coarse_fg)
+      endif
 
       call mpas_pool_get_dimension(dims, 'nVertLevels', nz1)
       call mpas_pool_get_dimension(dims, 'nCellsSolve', nCellsSolve)
@@ -4442,10 +4446,13 @@ module init_atm_cases
       call mpas_pool_get_dimension(state, 'index_ns', index_ns)
       call mpas_pool_get_dimension(state, 'index_ng', index_ng)
 ! Chemistry
-      call mpas_pool_get_dimension(state, 'index_MASSDEN',index_massden)
-      call mpas_pool_get_dimension(state, 'index_smoke_fine',index_smoke_fine)
-      call mpas_pool_get_dimension(state, 'index_dust_fine',index_dust_fine)
-      call mpas_pool_get_dimension(state, 'index_dust_coarse',index_dust_coarse)
+      if ( config_smoke_scheme .ne. 'off' ) then
+         call mpas_pool_get_dimension(state, 'index_smoke_fine',index_smoke_fine)
+      endif
+      if ( config_dust_scheme .ne. 'off' ) then
+         call mpas_pool_get_dimension(state, 'index_dust_fine',index_dust_fine)
+         call mpas_pool_get_dimension(state, 'index_dust_coarse',index_dust_coarse)
+      endif
 
       xnutr = 0.
       zd = 12000.
@@ -5072,7 +5079,6 @@ module init_atm_cases
              trim(field % field) == 'SEAICE' .or. &
              trim(field % field) == 'SKINTEMP' .or. &
 ! Chemistry
-             trim(field % field) == 'MASSDEN' .or. &
              trim(field % field) == 'SMKF' .or. &
              trim(field % field) == 'DSTF' .or. &
              trim(field % field) == 'DSTC') then
@@ -5363,34 +5369,33 @@ module init_atm_cases
                 call mpas_pool_get_array(fg, 'qni', destField2d)
                 ndims = 2
 ! Chemistry
-            else if (trim(field % field) == 'MASSDEN' ) then
-                call mpas_log_write('Interpolating MASSDEN at $i $r', intArgs=(/k/), realArgs=(/vert_level(k)/))
-                nInterpPoints = nCells
-                latPoints => latCell
-                lonPoints => lonCell
-                call mpas_pool_get_array(fg, 'MASSDEN', destField2d)
-                ndims = 2
             else if (trim(field % field) == 'SMKF' ) then
+              if ( config_smoke_scheme .ne. 'off' ) then
                 call mpas_log_write('Interpolating SMKFN at $i $r', intArgs=(/k/), realArgs=(/vert_level(k)/))
                 nInterpPoints = nCells
                 latPoints => latCell
                 lonPoints => lonCell
                 call mpas_pool_get_array(fg, 'smoke_fine', destField2d)
                 ndims = 2
+              endif
             else if (trim(field % field) == 'DSTF' ) then
+              if ( config_dust_scheme .ne. 'off' ) then
                 call mpas_log_write('Interpolating DSTFN at $i $r', intArgs=(/k/), realArgs=(/vert_level(k)/))
                 nInterpPoints = nCells
                 latPoints => latCell
                 lonPoints => lonCell
                 call mpas_pool_get_array(fg, 'dust_fine', destField2d)
                 ndims = 2
+              endif
             else if (trim(field % field) == 'DSTC' ) then
+              if ( config_dust_scheme .ne. 'off' ) then
                 call mpas_log_write('Interpolating DUSTC at $i $r', intArgs=(/k/), realArgs=(/vert_level(k)/))
                 nInterpPoints = nCells
                 latPoints => latCell
                 lonPoints => lonCell
                 call mpas_pool_get_array(fg, 'dust_coarse', destField2d)
                 ndims = 2
+              endif
             else if (trim(field % field) == 'GHT') then
                call mpas_log_write('Interpolating GHT at $i $r', intArgs=(/k/), realArgs=(/vert_level(k)/))
                nInterpPoints = nCells
@@ -7172,10 +7177,9 @@ call mpas_log_write('Done with soil consistency check')
       allocate(sorted_arrQ9(2,nfglevels_actual))
       allocate(sorted_arrQ10(2,nfglevels_actual))
 ! Chemistry
-      if (associated(index_massden      )) allocate(sorted_arrQ11(2,nfglevels_actual))
-      if (associated(index_smoke_fine   )) allocate(sorted_arrQ12(2,nfglevels_actual))
-      if (associated(index_dust_fine    )) allocate(sorted_arrQ14(2,nfglevels_actual))
-      if (associated(index_dust_coarse  )) allocate(sorted_arrQ15(2,nfglevels_actual))
+      if (associated(index_smoke_fine   )) allocate(sorted_arrQ11(2,nfglevels_actual))
+      if (associated(index_dust_fine    )) allocate(sorted_arrQ12(2,nfglevels_actual))
+      if (associated(index_dust_coarse  )) allocate(sorted_arrQ13(2,nfglevels_actual))
 
       call mpas_log_write('min lon $r max lon $r min lat $r max lat $r',realArgs=(/minval(lonPoints),maxval(lonPoints),minval(latPoints),maxval(latPoints)/))
       do iCell=1,nCells
@@ -7253,10 +7257,9 @@ call mpas_log_write('Done with soil consistency check')
          sorted_arrQ9(:,:) = -999.0
          sorted_arrQ10(:,:) = -999.0
 ! Chemistry
-         if (associated(index_massden     ) ) sorted_arrQ11(:,:) = -999.0
-         if (associated(index_smoke_fine  ) ) sorted_arrQ12(:,:) = -999.0
-         if (associated(index_dust_fine   ) ) sorted_arrQ14(:,:) = -999.0
-         if (associated(index_dust_coarse ) ) sorted_arrQ15(:,:) = -999.0
+         if (associated(index_smoke_fine  ) ) sorted_arrQ11(:,:) = -999.0
+         if (associated(index_dust_fine   ) ) sorted_arrQ12(:,:) = -999.0
+         if (associated(index_dust_coarse ) ) sorted_arrQ13(:,:) = -999.0
          scalars(index_nwfa,:,iCell) = 0._RKIND
          scalars(index_nifa,:,iCell) = 0._RKIND
          scalars(index_qc,:,iCell) = 0._RKIND
@@ -7270,9 +7273,6 @@ call mpas_log_write('Done with soil consistency check')
          scalars(index_ns,:,iCell) = 0._RKIND
          scalars(index_ng,:,iCell) = 0._RKIND
 ! Chemistry
-         if (associated(index_massden        )) then
-            if  (index_massden > 0      ) scalars(index_massden,:,iCell) = 0._RKIND
-         endif
          if (associated(index_smoke_fine     )) then
             if (index_smoke_fine > 0    ) scalars(index_smoke_fine,:,iCell) = 0._RKIND
          endif
@@ -7294,10 +7294,9 @@ call mpas_log_write('Done with soil consistency check')
             sorted_arrQ9(1,k) = z_fg(k,iCell)
             sorted_arrQ10(1,k) = z_fg(k,iCell)
 ! Chemistry
-            if (associated(index_massden     ) ) sorted_arrQ11(1,k) = z_fg(k,iCell)
-            if (associated(index_smoke_fine  ) ) sorted_arrQ12(1,k) = z_fg(k,iCell)
-            if (associated(index_dust_fine   ) ) sorted_arrQ14(1,k) = z_fg(k,iCell)
-            if (associated(index_dust_coarse ) ) sorted_arrQ15(1,k) = z_fg(k,iCell)
+            if (associated(index_smoke_fine  ) ) sorted_arrQ11(1,k) = z_fg(k,iCell)
+            if (associated(index_dust_fine   ) ) sorted_arrQ12(1,k) = z_fg(k,iCell)
+            if (associated(index_dust_coarse ) ) sorted_arrQ13(1,k) = z_fg(k,iCell)
             if (vert_level(k) == 200100.0) then
                 sorted_arrQ1(1,k) = 99999.0
                 sorted_arrQ2(1,k) = 99999.0
@@ -7310,10 +7309,9 @@ call mpas_log_write('Done with soil consistency check')
                 sorted_arrQ9(1,k) = 99999.0
                 sorted_arrQ10(1,k) = 99999.0
 ! Chemistry
-                if (associated(index_massden     ) ) sorted_arrQ11(1,k) = 99999.0
-                if (associated(index_smoke_fine  ) ) sorted_arrQ12(1,k) = 99999.0
-                if (associated(index_dust_fine   ) ) sorted_arrQ14(1,k) = 99999.0
-                if (associated(index_dust_coarse ) ) sorted_arrQ15(1,k) = 99999.0
+                if (associated(index_smoke_fine  ) ) sorted_arrQ11(1,k) = 99999.0
+                if (associated(index_dust_fine   ) ) sorted_arrQ12(1,k) = 99999.0
+                if (associated(index_dust_coarse ) ) sorted_arrQ13(1,k) = 99999.0
             endif
             sorted_arrQ1(2,k) = max(0._RKIND,qc_fg(k,iCell))
             sorted_arrQ2(2,k) = max(0._RKIND,qr_fg(k,iCell))
@@ -7326,10 +7324,9 @@ call mpas_log_write('Done with soil consistency check')
             sorted_arrQ9(2,k) = max(0._RKIND,qnwfa_fg(k,iCell))
             sorted_arrQ10(2,k) = max(0._RKIND,qnifa_fg(k,iCell))
 ! Chemistry
-            if (associated(massden_fg     ) ) sorted_arrQ11(2,k) = max(0._RKIND,massden_fg(k,iCell))
-            if (associated(smoke_fine_fg  ) ) sorted_arrQ12(2,k) = max(0._RKIND,smoke_fine_fg(k,iCell))
-            if (associated(dust_fine_fg   ) ) sorted_arrQ14(2,k) = max(0._RKIND,dust_fine_fg(k,iCell))
-            if (associated(dust_coarse_fg ) ) sorted_arrQ15(2,k) = max(0._RKIND,dust_coarse_fg(k,iCell))
+            if (associated(smoke_fine_fg  ) ) sorted_arrQ11(2,k) = max(0._RKIND,smoke_fine_fg(k,iCell))
+            if (associated(dust_fine_fg   ) ) sorted_arrQ12(2,k) = max(0._RKIND,dust_fine_fg(k,iCell))
+            if (associated(dust_coarse_fg ) ) sorted_arrQ13(2,k) = max(0._RKIND,dust_coarse_fg(k,iCell))
          end do
 
          call mpas_quicksort(nfglevels_actual, sorted_arrQ1)
@@ -7343,10 +7340,9 @@ call mpas_log_write('Done with soil consistency check')
          call mpas_quicksort(nfglevels_actual, sorted_arrQ9)
          call mpas_quicksort(nfglevels_actual, sorted_arrQ10)
 ! Chemistry
-         if (associated(index_massden      ) )   call mpas_quicksort(nfglevels_actual, sorted_arrQ11)
-         if (associated(index_smoke_fine   ) )   call mpas_quicksort(nfglevels_actual, sorted_arrQ12)
-         if (associated(index_dust_fine    ) )  call mpas_quicksort(nfglevels_actual, sorted_arrQ14)
-         if (associated(index_dust_coarse  ) )  call mpas_quicksort(nfglevels_actual, sorted_arrQ15)
+         if (associated(index_smoke_fine   ) )  call mpas_quicksort(nfglevels_actual, sorted_arrQ11)
+         if (associated(index_dust_fine    ) )  call mpas_quicksort(nfglevels_actual, sorted_arrQ12)
+         if (associated(index_dust_coarse  ) )  call mpas_quicksort(nfglevels_actual, sorted_arrQ13)
 
          do k = nVertLevels, 1, -1
             target_z = 0.5 * (zgrid(k,iCell) + zgrid(k+1,iCell))
@@ -7371,21 +7367,17 @@ call mpas_log_write('Done with soil consistency check')
             scalars(index_nr,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                         sorted_arrQ8(:,1:nfglevels_actual-1), order=1, extrap=0)
 ! Chemistry
-            if ( associated(index_massden)) then
-               if (  index_massden > 0      ) scalars(index_massden,k,iCell) = conv_aer_kg2ug * vertical_interp(target_z, nfglevels_actual-1, &
-                                        sorted_arrQ11(:,1:nfglevels_actual-1), order=1, extrap=0)
-            endif
             if ( associated(index_smoke_fine)) then
                 if ( index_smoke_fine > 0 ) scalars(index_smoke_fine,k,iCell) = conv_aer_kg2ug * vertical_interp(target_z, nfglevels_actual-1, &
-                                        sorted_arrQ12(:,1:nfglevels_actual-1), order=1, extrap=0)
+                                        sorted_arrQ11(:,1:nfglevels_actual-1), order=1, extrap=0)
             endif
             if ( associated(index_dust_fine )) then
                if ( index_dust_fine > 0  ) scalars(index_dust_fine,k,iCell) = conv_aer_kg2ug * vertical_interp(target_z, nfglevels_actual-1, &
-                                        sorted_arrQ14(:,1:nfglevels_actual-1), order=1, extrap=0)
+                                        sorted_arrQ12(:,1:nfglevels_actual-1), order=1, extrap=0)
             endif
             if ( associated(index_dust_coarse )) then
                if ( index_dust_coarse > 0 ) scalars(index_dust_coarse,k,iCell) = conv_aer_kg2ug * vertical_interp(target_z, nfglevels_actual-1, &
-                                        sorted_arrQ15(:,1:nfglevels_actual-1), order=1, extrap=0)
+                                        sorted_arrQ13(:,1:nfglevels_actual-1), order=1, extrap=0)
             endif
          end do
 
@@ -7489,10 +7481,9 @@ call mpas_log_write('Done with soil consistency check')
       deallocate(sorted_arr)
       deallocate(sorted_arrQ1,sorted_arrQ2,sorted_arrQ3,sorted_arrQ4,sorted_arrQ5,sorted_arrQ6,sorted_arrQ7,sorted_arrQ8,sorted_arrQ9,sorted_arrQ10)
 ! Chemistry
-      if (associated(index_massden     )) deallocate(sorted_arrQ11)
-      if (associated(index_smoke_fine  )) deallocate(sorted_arrQ12)
-      if (associated(index_dust_fine   )) deallocate(sorted_arrQ14)
-      if (associated(index_dust_coarse )) deallocate(sorted_arrQ15)
+      if (associated(index_smoke_fine  )) deallocate(sorted_arrQ11)
+      if (associated(index_dust_fine   )) deallocate(sorted_arrQ12)
+      if (associated(index_dust_coarse )) deallocate(sorted_arrQ13)
 
       ! Diagnose the water vapor mixing ratios:
       global_sh_min = 0._RKIND
@@ -7819,7 +7810,6 @@ call mpas_log_write('Done with soil consistency check')
       integer, pointer :: index_qv, index_qc, index_qr, index_qi, index_qs, index_qg,index_ni, index_nc, index_nr, index_ns, index_ng
       integer, pointer :: index_nwfa, index_nifa
 ! Chemistry
-      integer, pointer :: index_massden
       integer, pointer :: index_smoke_fine, index_dust_fine, index_dust_coarse
 
 
@@ -7833,7 +7823,7 @@ call mpas_log_write('Done with soil consistency check')
       real (kind=RKIND), dimension(:,:), pointer :: sorted_arrQ1,sorted_arrQ2,sorted_arrQ3,sorted_arrQ4,sorted_arrQ5,sorted_arrQ6,sorted_arrQ7,sorted_arrQ8
       real (kind=RKIND), dimension(:,:), pointer :: sorted_arrQ9,sorted_arrQ10
 ! Chemistry
-      real (kind=RKIND), dimension(:,:), pointer :: sorted_arrQ11,sorted_arrQ12,sorted_arrQ14,sorted_arrQ15
+      real (kind=RKIND), dimension(:,:), pointer :: sorted_arrQ11,sorted_arrQ12,sorted_arrQ13
 
       integer :: sfc_k
 
@@ -7863,6 +7853,7 @@ call mpas_log_write('Done with soil consistency check')
       real (kind=RKIND), pointer :: config_coef_3rd_order
 
       character (len=StrKIND), pointer :: config_extrap_airtemp
+      character (len=StrKIND), pointer :: config_smoke_scheme, config_dust_scheme
       integer :: extrap_airtemp
 
       real (kind=RKIND), dimension(:), pointer :: latCell, lonCell
@@ -7895,7 +7886,6 @@ call mpas_log_write('Done with soil consistency check')
       real (kind=RKIND), dimension(:,:), pointer :: qni_fg
       real (kind=RKIND), dimension(:,:), pointer :: qnr_fg
 ! Chemistry
-      real (kind=RKIND), dimension(:,:), pointer :: massden_fg
       real (kind=RKIND), dimension(:,:), pointer :: smoke_fine_fg, dust_fine_fg, dust_coarse_fg
 
       real (kind=RKIND), dimension(:,:), pointer :: p_fg
@@ -7994,10 +7984,15 @@ call mpas_log_write('Done with soil consistency check')
       call mpas_pool_get_array(fg, 'qni', qni_fg)
       call mpas_pool_get_array(fg, 'qnr', qnr_fg)
 ! Chemistry
-      call mpas_pool_get_array(fg, 'MASSDEN', massden_fg)
-      call mpas_pool_get_array(fg, 'smoke_fine', smoke_fine_fg)
-      call mpas_pool_get_array(fg, 'dust_fine', dust_fine_fg)
-      call mpas_pool_get_array(fg, 'dust_coarse', dust_coarse_fg)
+      call mpas_pool_get_config(configs, 'config_smoke_scheme', config_smoke_scheme)
+      call mpas_pool_get_config(configs, 'config_dust_scheme', config_dust_scheme)
+      if ( config_smoke_scheme .ne. 'off' ) then
+         call mpas_pool_get_array(fg, 'smoke_fine', smoke_fine_fg)
+      endif
+      if ( config_dust_scheme .ne. 'off' ) then
+         call mpas_pool_get_array(fg, 'dust_fine', dust_fine_fg)
+         call mpas_pool_get_array(fg, 'dust_coarse', dust_coarse_fg)
+      endif
 
       call mpas_pool_get_array(fg, 'p', p_fg)
 
@@ -8019,10 +8014,13 @@ call mpas_log_write('Done with soil consistency check')
       call mpas_pool_get_dimension(lbc_state, 'index_lbc_ns', index_ns)
       call mpas_pool_get_dimension(lbc_state, 'index_lbc_ng', index_ng)
 ! Chemistry
-      call mpas_pool_get_dimension(lbc_state, 'index_lbc_MASSDEN', index_massden)
-      call mpas_pool_get_dimension(lbc_state, 'index_lbc_smoke_fine', index_smoke_fine)
-      call mpas_pool_get_dimension(lbc_state, 'index_lbc_dust_fine', index_dust_fine)
-      call mpas_pool_get_dimension(lbc_state, 'index_lbc_dust_coarse', index_dust_coarse)
+      if ( config_smoke_scheme .ne. 'off' ) then
+         call mpas_pool_get_dimension(lbc_state, 'index_lbc_smoke_fine', index_smoke_fine)
+      endif
+      if ( config_dust_scheme .ne. 'off' ) then
+         call mpas_pool_get_dimension(lbc_state, 'index_lbc_dust_fine', index_dust_fine)
+         call mpas_pool_get_dimension(lbc_state, 'index_lbc_dust_coarse', index_dust_coarse)
+      endif
 
       etavs = (1.0_RKIND - 0.252_RKIND) * pii / 2.0_RKIND
       rcv = rgas / (cp - rgas)
@@ -8101,7 +8099,6 @@ call mpas_log_write('Done with soil consistency check')
              trim(field % field) == 'PRES' .or. &
              trim(field % field) == 'PRESSURE'.or. &
 ! Chemistry
-             trim(field % field) == 'MASSDEN' .or. &
              trim(field % field) == 'SMKF' .or. &
              trim(field % field) == 'DSTF' .or. &
              trim(field % field) == 'DSTC') then
@@ -8325,34 +8322,33 @@ call mpas_log_write('Done with soil consistency check')
                call mpas_pool_get_array(fg, 'soilz', destField1d)
                ndims = 1
 ! Chemistry
-            else if (trim(field % field) == 'MASSDEN' ) then
-                call mpas_log_write('Interpolating MASSDEN at $i $r', intArgs=(/k/), realArgs=(/vert_level(k)/))
-                nInterpPoints = nCells
-                latPoints => latCell
-                lonPoints => lonCell
-                call mpas_pool_get_array(fg, 'MASSDEN', destField2d)
-                ndims = 2
             else if (trim(field % field) == 'SMKF' ) then
+              if (config_smoke_scheme .ne. 'off' ) then
                 call mpas_log_write('Interpolating SMKF at $i $r', intArgs=(/k/), realArgs=(/vert_level(k)/))
                 nInterpPoints = nCells
                 latPoints => latCell
                 lonPoints => lonCell
                 call mpas_pool_get_array(fg, 'smoke_fine', destField2d)
                 ndims = 2
+              endif
             else if (trim(field % field) == 'DSTF' ) then
+              if (config_dust_scheme .ne. 'off' ) then
                 call mpas_log_write('Interpolating DSTF at $i $r', intArgs=(/k/), realArgs=(/vert_level(k)/))
                 nInterpPoints = nCells
                 latPoints => latCell
                 lonPoints => lonCell
                 call mpas_pool_get_array(fg, 'dust_fine', destField2d)
                 ndims = 2
+              endif
             else if (trim(field % field) == 'DSTC' ) then
+              if (config_dust_scheme .ne. 'off' ) then
                 call mpas_log_write('Interpolating DSTC at $i $r', intArgs=(/k/), realArgs=(/vert_level(k)/))
                 nInterpPoints = nCells
                 latPoints => latCell
                 lonPoints => lonCell
                 call mpas_pool_get_array(fg, 'dust_coarse', destField2d)
                 ndims = 2
+              endif
             end if
 
             allocate(rslab(-2:field % nx+3, field % ny))
@@ -8500,10 +8496,9 @@ call mpas_log_write('Done with soil consistency check')
       allocate(sorted_arrQ9(2,nfglevels_actual))
       allocate(sorted_arrQ10(2,nfglevels_actual))
 ! Chemistry
-      if (associated(index_massden     )) allocate(sorted_arrQ11(2,nfglevels_actual))
-      if (associated(index_smoke_fine  )) allocate(sorted_arrQ12(2,nfglevels_actual))
-      if (associated(index_dust_fine   )) allocate(sorted_arrQ14(2,nfglevels_actual))
-      if (associated(index_dust_coarse )) allocate(sorted_arrQ15(2,nfglevels_actual))
+      if (associated(index_smoke_fine  )) allocate(sorted_arrQ11(2,nfglevels_actual))
+      if (associated(index_dust_fine   )) allocate(sorted_arrQ12(2,nfglevels_actual))
+      if (associated(index_dust_coarse )) allocate(sorted_arrQ13(2,nfglevels_actual))
 
       do iCell=1,nCells
 
@@ -8573,10 +8568,9 @@ call mpas_log_write('Done with soil consistency check')
          sorted_arrQ9(:,:) = -999.0
          sorted_arrQ10(:,:) = -999.0
 ! Chemistry
-         if (associated(index_massden     )) sorted_arrQ11(:,:) = -999.0
-         if (associated(index_smoke_fine  )) sorted_arrQ12(:,:) = -999.0
-         if (associated(index_dust_fine   )) sorted_arrQ14(:,:) = -999.0
-         if (associated(index_dust_coarse )) sorted_arrQ15(:,:) = -999.0
+         if (associated(index_smoke_fine  )) sorted_arrQ11(:,:) = -999.0
+         if (associated(index_dust_fine   )) sorted_arrQ12(:,:) = -999.0
+         if (associated(index_dust_coarse )) sorted_arrQ13(:,:) = -999.0
          scalars(index_nwfa,:,iCell) = 0._RKIND
          scalars(index_nifa,:,iCell) = 0._RKIND
          scalars(index_qc,:,iCell) = 0._RKIND
@@ -8590,9 +8584,6 @@ call mpas_log_write('Done with soil consistency check')
          scalars(index_ns,:,iCell) = 0._RKIND
          scalars(index_ng,:,iCell) = 0._RKIND
 ! Chemistry
-         if (associated(index_massden      )) then
-            if (index_massden > 0      )  scalars(index_massden,:,iCell) = 0._RKIND
-         endif
          if (associated(index_smoke_fine   )) then
             if (index_smoke_fine > 0   )  scalars(index_smoke_fine,:,iCell) = 0._RKIND
          endif
@@ -8615,10 +8606,9 @@ call mpas_log_write('Done with soil consistency check')
             sorted_arrQ9(1,k) = z_fg(k,iCell)
             sorted_arrQ10(1,k) = z_fg(k,iCell)
 ! Chemistry
-           if (associated(index_massden     )) sorted_arrQ11(1,k) = z_fg(k,iCell)
-           if (associated(index_smoke_fine  )) sorted_arrQ12(1,k) = z_fg(k,iCell)
-           if (associated(index_dust_fine   )) sorted_arrQ14(1,k) = z_fg(k,iCell)
-           if (associated(index_dust_coarse )) sorted_arrQ15(1,k) = z_fg(k,iCell)
+           if (associated(index_smoke_fine  )) sorted_arrQ11(1,k) = z_fg(k,iCell)
+           if (associated(index_dust_fine   )) sorted_arrQ12(1,k) = z_fg(k,iCell)
+           if (associated(index_dust_coarse )) sorted_arrQ13(1,k) = z_fg(k,iCell)
             if (vert_level(k) == 200100.0) then
                 sorted_arrQ1(1,k) = 99999.0
                 sorted_arrQ2(1,k) = 99999.0
@@ -8631,10 +8621,9 @@ call mpas_log_write('Done with soil consistency check')
                 sorted_arrQ9(1,k) = 99999.0
                 sorted_arrQ10(1,k) = 99999.0
 ! Chemistry
-                if (associated(index_massden     )) sorted_arrQ11(1,k) = 99999.0
-                if (associated(index_smoke_fine  )) sorted_arrQ12(1,k) = 99999.0
-                if (associated(index_dust_fine   )) sorted_arrQ14(1,k) = 99999.0
-                if (associated(index_dust_coarse )) sorted_arrQ15(1,k) = 99999.0
+                if (associated(index_smoke_fine  )) sorted_arrQ11(1,k) = 99999.0
+                if (associated(index_dust_fine   )) sorted_arrQ12(1,k) = 99999.0
+                if (associated(index_dust_coarse )) sorted_arrQ13(1,k) = 99999.0
              endif
             sorted_arrQ1(2,k) = max(0._RKIND,qc_fg(k,iCell))
             sorted_arrQ2(2,k) = max(0._RKIND,qr_fg(k,iCell))
@@ -8647,10 +8636,9 @@ call mpas_log_write('Done with soil consistency check')
             sorted_arrQ9(2,k) = max(0._RKIND,qnwfa_fg(k,iCell))
             sorted_arrQ10(2,k) = max(0._RKIND,qnifa_fg(k,iCell))
 ! Chemistry
-            if (associated(massden_fg     ))sorted_arrQ11(2,k) = max(0._RKIND,massden_fg(k,iCell))
-            if (associated(smoke_fine_fg  ))sorted_arrq12(2,k) = max(0._rkind,smoke_fine_fg(k,icell))
-            if (associated(dust_fine_fg   ))sorted_arrq14(2,k) = max(0._rkind,dust_fine_fg(k,icell))
-            if (associated(dust_coarse_fg ))sorted_arrq15(2,k) = max(0._rkind,dust_coarse_fg(k,icell))
+            if (associated(smoke_fine_fg  ))sorted_arrq11(2,k) = max(0._rkind,smoke_fine_fg(k,icell))
+            if (associated(dust_fine_fg   ))sorted_arrq12(2,k) = max(0._rkind,dust_fine_fg(k,icell))
+            if (associated(dust_coarse_fg ))sorted_arrq13(2,k) = max(0._rkind,dust_coarse_fg(k,icell))
          end do
 
          call mpas_quicksort(nfglevels_actual, sorted_arrQ1)
@@ -8664,10 +8652,9 @@ call mpas_log_write('Done with soil consistency check')
          call mpas_quicksort(nfglevels_actual, sorted_arrQ9)
          call mpas_quicksort(nfglevels_actual, sorted_arrQ10)
 ! Chemistry
-         if (associated(index_massden     ))        call mpas_quicksort(nfglevels_actual, sorted_arrQ11)
-         if (associated(index_smoke_fine  ))        call mpas_quicksort(nfglevels_actual, sorted_arrQ12)
-         if (associated(index_dust_fine   ))        call mpas_quicksort(nfglevels_actual, sorted_arrQ14)
-         if (associated(index_dust_coarse ))        call mpas_quicksort(nfglevels_actual, sorted_arrQ15)
+         if (associated(index_smoke_fine  ))        call mpas_quicksort(nfglevels_actual, sorted_arrQ11)
+         if (associated(index_dust_fine   ))        call mpas_quicksort(nfglevels_actual, sorted_arrQ12)
+         if (associated(index_dust_coarse ))        call mpas_quicksort(nfglevels_actual, sorted_arrQ13)
          do k = nVertLevels, 1, -1
             target_z = 0.5 * (zgrid(k,iCell) + zgrid(k+1,iCell))
             scalars(index_nwfa,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
@@ -8691,21 +8678,17 @@ call mpas_log_write('Done with soil consistency check')
             scalars(index_nr,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                         sorted_arrQ8(:,1:nfglevels_actual-1), order=1, extrap=0)
 ! JLS
-            if ( associated(index_massden )) then
-               if (  index_massden > 0    ) scalars(index_massden,k,iCell) = conv_aer_kg2ug * vertical_interp(target_z, nfglevels_actual-1, &
-                                        sorted_arrQ11(:,1:nfglevels_actual-1), order=1, extrap=0)
-            endif
             if ( associated(index_smoke_fine )) then
                 if ( index_smoke_fine > 0  ) scalars(index_smoke_fine,k,iCell) = conv_aer_kg2ug * vertical_interp(target_z, nfglevels_actual-1, &
-                                        sorted_arrQ12(:,1:nfglevels_actual-1), order=1, extrap=0)
+                                        sorted_arrQ11(:,1:nfglevels_actual-1), order=1, extrap=0)
             endif
             if ( associated(index_dust_fine )) then
                if ( index_dust_fine > 0) scalars(index_dust_fine,k,iCell) = conv_aer_kg2ug * vertical_interp(target_z, nfglevels_actual-1, &
-                                        sorted_arrQ14(:,1:nfglevels_actual-1), order=1, extrap=0)
+                                        sorted_arrQ12(:,1:nfglevels_actual-1), order=1, extrap=0)
             endif
             if ( associated(index_dust_coarse )) then
                if ( index_dust_coarse > 0) scalars(index_dust_coarse,k,iCell) = conv_aer_kg2ug * vertical_interp(target_z, nfglevels_actual-1, &
-                                        sorted_arrQ15(:,1:nfglevels_actual-1), order=1, extrap=0)
+                                        sorted_arrQ13(:,1:nfglevels_actual-1), order=1, extrap=0)
             endif
             if (target_z < z_fg(1,iCell) .and. k < nVertLevels) then
                 scalars(index_nwfa,k,iCell) = scalars(index_nwfa,k+1,iCell)
@@ -8721,9 +8704,6 @@ call mpas_log_write('Done with soil consistency check')
                 scalars(index_ns,k,iCell) = scalars(index_ns,k+1,iCell)
                 scalars(index_ng,k,iCell) = scalars(index_ng,k+1,iCell)
 ! Chemistry
-                if ( associated(index_massden     )) then
-                   if (index_massden > 0      ) scalars(index_massden,k,iCell) = scalars(index_massden,k+1,iCell)
-                endif
                 if ( associated(index_smoke_fine  )) then
                    if (index_smoke_fine > 0   ) scalars(index_smoke_fine,k,iCell) = scalars(index_smoke_fine,k+1,iCell)
                 endif
@@ -8778,10 +8758,9 @@ call mpas_log_write('Done with soil consistency check')
       deallocate(sorted_arr)
       deallocate(sorted_arrQ1,sorted_arrQ2,sorted_arrQ3,sorted_arrQ4,sorted_arrQ5,sorted_arrQ6,sorted_arrQ7,sorted_arrQ8,sorted_arrQ9,sorted_arrQ10)
 ! Chemistry
-      if (associated(index_massden     )) deallocate(sorted_arrQ11)
-      if (associated(index_smoke_fine  )) deallocate(sorted_arrQ12)
-      if (associated(index_dust_fine   )) deallocate(sorted_arrQ14)
-      if (associated(index_dust_coarse )) deallocate(sorted_arrQ15)
+      if (associated(index_smoke_fine  )) deallocate(sorted_arrQ11)
+      if (associated(index_dust_fine   )) deallocate(sorted_arrQ12)
+      if (associated(index_dust_coarse )) deallocate(sorted_arrQ13)
 
       ! Diagnose the water vapor mixing ratios:
       global_sh_min = 0._RKIND

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -4108,7 +4108,7 @@ module init_atm_cases
       integer :: nfglevels_actual
       integer, pointer :: index_qv, index_qc, index_qr, index_qi, index_qs, index_qg, index_ni, index_nc, index_nr, index_ns, index_ng
       integer, pointer :: index_nwfa, index_nifa
-      integer, pointer :: index_smoke_fine, index_dust_fine, index_dust_coarse
+      integer, pointer :: index_smoke_fine => null(), index_dust_fine => null(), index_dust_coarse => null()
 
       integer, dimension(5) :: interp_list
       real (kind=RKIND) :: maskval
@@ -7810,7 +7810,7 @@ call mpas_log_write('Done with soil consistency check')
       integer, pointer :: index_qv, index_qc, index_qr, index_qi, index_qs, index_qg,index_ni, index_nc, index_nr, index_ns, index_ng
       integer, pointer :: index_nwfa, index_nifa
 ! Chemistry
-      integer, pointer :: index_smoke_fine, index_dust_fine, index_dust_coarse
+      integer, pointer :: index_smoke_fine => null(), index_dust_fine => null(), index_dust_coarse => null()
 
 
 

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -4108,7 +4108,7 @@ module init_atm_cases
       integer :: nfglevels_actual
       integer, pointer :: index_qv, index_qc, index_qr, index_qi, index_qs, index_qg, index_ni, index_nc, index_nr, index_ns, index_ng
       integer, pointer :: index_nwfa, index_nifa
-      integer, pointer :: index_MASSDEN
+      integer, pointer :: index_massden
       integer, pointer :: index_smoke_fine, index_dust_fine, index_dust_coarse
 
       integer, dimension(5) :: interp_list
@@ -4126,7 +4126,7 @@ module init_atm_cases
       real (kind=RKIND), dimension(:,:), pointer :: sorted_arrQ1,sorted_arrQ2,sorted_arrQ3,sorted_arrQ4,sorted_arrQ5,sorted_arrQ6,sorted_arrQ7,sorted_arrQ8
       real (kind=RKIND), dimension(:,:), pointer :: sorted_arrQ9,sorted_arrQ10
 ! Chemistry
-      real (kind=RKIND), dimension(:,:), pointer :: sorted_arrQ11,sorted_arrQ12,sorted_arrQ13,sorted_arrQ14,sorted_arrQ15
+      real (kind=RKIND), dimension(:,:), pointer :: sorted_arrQ11,sorted_arrQ12,sorted_arrQ14,sorted_arrQ15
 
 
       integer, dimension(:), pointer :: bdyMaskCell
@@ -4257,7 +4257,7 @@ module init_atm_cases
       real (kind=RKIND), dimension(:,:), pointer :: sm_fg
       real (kind=RKIND), dimension(:), pointer :: soilz
 ! Chemistry
-      real (kind=RKIND), dimension(:,:), pointer :: MASSDEN_fg
+      real (kind=RKIND), dimension(:,:), pointer :: massden_fg
       real (kind=RKIND), dimension(:,:), pointer :: smoke_fine_fg
       real (kind=RKIND), dimension(:,:), pointer :: dust_fine_fg
       real (kind=RKIND), dimension(:,:), pointer :: dust_coarse_fg
@@ -4418,7 +4418,7 @@ module init_atm_cases
       call mpas_pool_get_array(fg, 'gfs_z', gfs_z)
       call mpas_pool_get_array(fg, 'p', p_fg)
 ! Chemistry
-      call mpas_pool_get_array(fg, 'MASSDEN', MASSDEN_fg)
+      call mpas_pool_get_array(fg, 'MASSDEN', massden_fg)
       call mpas_pool_get_array(fg, 'smoke_fine', smoke_fine_fg)
       call mpas_pool_get_array(fg, 'dust_fine', dust_fine_fg)
       call mpas_pool_get_array(fg, 'dust_coarse', dust_coarse_fg)
@@ -4442,7 +4442,7 @@ module init_atm_cases
       call mpas_pool_get_dimension(state, 'index_ns', index_ns)
       call mpas_pool_get_dimension(state, 'index_ng', index_ng)
 ! Chemistry
-      call mpas_pool_get_dimension(state, 'index_MASSDEN',index_MASSDEN)
+      call mpas_pool_get_dimension(state, 'index_MASSDEN',index_massden)
       call mpas_pool_get_dimension(state, 'index_smoke_fine',index_smoke_fine)
       call mpas_pool_get_dimension(state, 'index_dust_fine',index_dust_fine)
       call mpas_pool_get_dimension(state, 'index_dust_coarse',index_dust_coarse)
@@ -7172,7 +7172,7 @@ call mpas_log_write('Done with soil consistency check')
       allocate(sorted_arrQ9(2,nfglevels_actual))
       allocate(sorted_arrQ10(2,nfglevels_actual))
 ! Chemistry
-      if (associated(index_MASSDEN      )) allocate(sorted_arrQ11(2,nfglevels_actual))
+      if (associated(index_massden      )) allocate(sorted_arrQ11(2,nfglevels_actual))
       if (associated(index_smoke_fine   )) allocate(sorted_arrQ12(2,nfglevels_actual))
       if (associated(index_dust_fine    )) allocate(sorted_arrQ14(2,nfglevels_actual))
       if (associated(index_dust_coarse  )) allocate(sorted_arrQ15(2,nfglevels_actual))
@@ -7253,7 +7253,7 @@ call mpas_log_write('Done with soil consistency check')
          sorted_arrQ9(:,:) = -999.0
          sorted_arrQ10(:,:) = -999.0
 ! Chemistry
-         if (associated(index_MASSDEN     ) ) sorted_arrQ11(:,:) = -999.0
+         if (associated(index_massden     ) ) sorted_arrQ11(:,:) = -999.0
          if (associated(index_smoke_fine  ) ) sorted_arrQ12(:,:) = -999.0
          if (associated(index_dust_fine   ) ) sorted_arrQ14(:,:) = -999.0
          if (associated(index_dust_coarse ) ) sorted_arrQ15(:,:) = -999.0
@@ -7270,8 +7270,8 @@ call mpas_log_write('Done with soil consistency check')
          scalars(index_ns,:,iCell) = 0._RKIND
          scalars(index_ng,:,iCell) = 0._RKIND
 ! Chemistry
-         if (associated(index_MASSDEN        )) then
-            if  (index_MASSDEN > 0      ) scalars(index_MASSDEN,:,iCell) = 0._RKIND
+         if (associated(index_massden        )) then
+            if  (index_massden > 0      ) scalars(index_massden,:,iCell) = 0._RKIND
          endif
          if (associated(index_smoke_fine     )) then
             if (index_smoke_fine > 0    ) scalars(index_smoke_fine,:,iCell) = 0._RKIND
@@ -7294,7 +7294,7 @@ call mpas_log_write('Done with soil consistency check')
             sorted_arrQ9(1,k) = z_fg(k,iCell)
             sorted_arrQ10(1,k) = z_fg(k,iCell)
 ! Chemistry
-            if (associated(index_MASSDEN     ) ) sorted_arrQ11(1,k) = z_fg(k,iCell)
+            if (associated(index_massden     ) ) sorted_arrQ11(1,k) = z_fg(k,iCell)
             if (associated(index_smoke_fine  ) ) sorted_arrQ12(1,k) = z_fg(k,iCell)
             if (associated(index_dust_fine   ) ) sorted_arrQ14(1,k) = z_fg(k,iCell)
             if (associated(index_dust_coarse ) ) sorted_arrQ15(1,k) = z_fg(k,iCell)
@@ -7310,7 +7310,7 @@ call mpas_log_write('Done with soil consistency check')
                 sorted_arrQ9(1,k) = 99999.0
                 sorted_arrQ10(1,k) = 99999.0
 ! Chemistry
-                if (associated(index_MASSDEN     ) ) sorted_arrQ11(1,k) = 99999.0
+                if (associated(index_massden     ) ) sorted_arrQ11(1,k) = 99999.0
                 if (associated(index_smoke_fine  ) ) sorted_arrQ12(1,k) = 99999.0
                 if (associated(index_dust_fine   ) ) sorted_arrQ14(1,k) = 99999.0
                 if (associated(index_dust_coarse ) ) sorted_arrQ15(1,k) = 99999.0
@@ -7326,7 +7326,7 @@ call mpas_log_write('Done with soil consistency check')
             sorted_arrQ9(2,k) = max(0._RKIND,qnwfa_fg(k,iCell))
             sorted_arrQ10(2,k) = max(0._RKIND,qnifa_fg(k,iCell))
 ! Chemistry
-            if (associated(MASSDEN_fg     ) ) sorted_arrQ11(2,k) = max(0._RKIND,MASSDEN_fg(k,iCell))
+            if (associated(massden_fg     ) ) sorted_arrQ11(2,k) = max(0._RKIND,massden_fg(k,iCell))
             if (associated(smoke_fine_fg  ) ) sorted_arrQ12(2,k) = max(0._RKIND,smoke_fine_fg(k,iCell))
             if (associated(dust_fine_fg   ) ) sorted_arrQ14(2,k) = max(0._RKIND,dust_fine_fg(k,iCell))
             if (associated(dust_coarse_fg ) ) sorted_arrQ15(2,k) = max(0._RKIND,dust_coarse_fg(k,iCell))
@@ -7343,7 +7343,7 @@ call mpas_log_write('Done with soil consistency check')
          call mpas_quicksort(nfglevels_actual, sorted_arrQ9)
          call mpas_quicksort(nfglevels_actual, sorted_arrQ10)
 ! Chemistry
-         if (associated(index_MASSDEN      ) )   call mpas_quicksort(nfglevels_actual, sorted_arrQ11)
+         if (associated(index_massden      ) )   call mpas_quicksort(nfglevels_actual, sorted_arrQ11)
          if (associated(index_smoke_fine   ) )   call mpas_quicksort(nfglevels_actual, sorted_arrQ12)
          if (associated(index_dust_fine    ) )  call mpas_quicksort(nfglevels_actual, sorted_arrQ14)
          if (associated(index_dust_coarse  ) )  call mpas_quicksort(nfglevels_actual, sorted_arrQ15)
@@ -7371,8 +7371,8 @@ call mpas_log_write('Done with soil consistency check')
             scalars(index_nr,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                         sorted_arrQ8(:,1:nfglevels_actual-1), order=1, extrap=0)
 ! Chemistry
-            if ( associated(index_MASSDEN)) then
-               if (  index_MASSDEN > 0      ) scalars(index_MASSDEN,k,iCell) = conv_aer_kg2ug * vertical_interp(target_z, nfglevels_actual-1, &
+            if ( associated(index_massden)) then
+               if (  index_massden > 0      ) scalars(index_massden,k,iCell) = conv_aer_kg2ug * vertical_interp(target_z, nfglevels_actual-1, &
                                         sorted_arrQ11(:,1:nfglevels_actual-1), order=1, extrap=0)
             endif
             if ( associated(index_smoke_fine)) then
@@ -7489,7 +7489,7 @@ call mpas_log_write('Done with soil consistency check')
       deallocate(sorted_arr)
       deallocate(sorted_arrQ1,sorted_arrQ2,sorted_arrQ3,sorted_arrQ4,sorted_arrQ5,sorted_arrQ6,sorted_arrQ7,sorted_arrQ8,sorted_arrQ9,sorted_arrQ10)
 ! Chemistry
-      if (associated(index_MASSDEN     )) deallocate(sorted_arrQ11)
+      if (associated(index_massden     )) deallocate(sorted_arrQ11)
       if (associated(index_smoke_fine  )) deallocate(sorted_arrQ12)
       if (associated(index_dust_fine   )) deallocate(sorted_arrQ14)
       if (associated(index_dust_coarse )) deallocate(sorted_arrQ15)
@@ -7819,7 +7819,7 @@ call mpas_log_write('Done with soil consistency check')
       integer, pointer :: index_qv, index_qc, index_qr, index_qi, index_qs, index_qg,index_ni, index_nc, index_nr, index_ns, index_ng
       integer, pointer :: index_nwfa, index_nifa
 ! Chemistry
-      integer, pointer :: index_MASSDEN
+      integer, pointer :: index_massden
       integer, pointer :: index_smoke_fine, index_dust_fine, index_dust_coarse
 
 
@@ -7833,7 +7833,7 @@ call mpas_log_write('Done with soil consistency check')
       real (kind=RKIND), dimension(:,:), pointer :: sorted_arrQ1,sorted_arrQ2,sorted_arrQ3,sorted_arrQ4,sorted_arrQ5,sorted_arrQ6,sorted_arrQ7,sorted_arrQ8
       real (kind=RKIND), dimension(:,:), pointer :: sorted_arrQ9,sorted_arrQ10
 ! Chemistry
-      real (kind=RKIND), dimension(:,:), pointer :: sorted_arrQ11,sorted_arrQ12,sorted_arrQ13,sorted_arrQ14,sorted_arrQ15
+      real (kind=RKIND), dimension(:,:), pointer :: sorted_arrQ11,sorted_arrQ12,sorted_arrQ14,sorted_arrQ15
 
       integer :: sfc_k
 
@@ -7895,7 +7895,7 @@ call mpas_log_write('Done with soil consistency check')
       real (kind=RKIND), dimension(:,:), pointer :: qni_fg
       real (kind=RKIND), dimension(:,:), pointer :: qnr_fg
 ! Chemistry
-      real (kind=RKIND), dimension(:,:), pointer :: MASSDEN_fg
+      real (kind=RKIND), dimension(:,:), pointer :: massden_fg
       real (kind=RKIND), dimension(:,:), pointer :: smoke_fine_fg, dust_fine_fg, dust_coarse_fg
 
       real (kind=RKIND), dimension(:,:), pointer :: p_fg
@@ -7994,7 +7994,7 @@ call mpas_log_write('Done with soil consistency check')
       call mpas_pool_get_array(fg, 'qni', qni_fg)
       call mpas_pool_get_array(fg, 'qnr', qnr_fg)
 ! Chemistry
-      call mpas_pool_get_array(fg, 'MASSDEN', MASSDEN_fg)
+      call mpas_pool_get_array(fg, 'MASSDEN', massden_fg)
       call mpas_pool_get_array(fg, 'smoke_fine', smoke_fine_fg)
       call mpas_pool_get_array(fg, 'dust_fine', dust_fine_fg)
       call mpas_pool_get_array(fg, 'dust_coarse', dust_coarse_fg)
@@ -8019,7 +8019,7 @@ call mpas_log_write('Done with soil consistency check')
       call mpas_pool_get_dimension(lbc_state, 'index_lbc_ns', index_ns)
       call mpas_pool_get_dimension(lbc_state, 'index_lbc_ng', index_ng)
 ! Chemistry
-      call mpas_pool_get_dimension(lbc_state, 'index_lbc_MASSDEN', index_MASSDEN)
+      call mpas_pool_get_dimension(lbc_state, 'index_lbc_MASSDEN', index_massden)
       call mpas_pool_get_dimension(lbc_state, 'index_lbc_smoke_fine', index_smoke_fine)
       call mpas_pool_get_dimension(lbc_state, 'index_lbc_dust_fine', index_dust_fine)
       call mpas_pool_get_dimension(lbc_state, 'index_lbc_dust_coarse', index_dust_coarse)
@@ -8500,7 +8500,7 @@ call mpas_log_write('Done with soil consistency check')
       allocate(sorted_arrQ9(2,nfglevels_actual))
       allocate(sorted_arrQ10(2,nfglevels_actual))
 ! Chemistry
-      if (associated(index_MASSDEN     )) allocate(sorted_arrQ11(2,nfglevels_actual))
+      if (associated(index_massden     )) allocate(sorted_arrQ11(2,nfglevels_actual))
       if (associated(index_smoke_fine  )) allocate(sorted_arrQ12(2,nfglevels_actual))
       if (associated(index_dust_fine   )) allocate(sorted_arrQ14(2,nfglevels_actual))
       if (associated(index_dust_coarse )) allocate(sorted_arrQ15(2,nfglevels_actual))
@@ -8573,7 +8573,7 @@ call mpas_log_write('Done with soil consistency check')
          sorted_arrQ9(:,:) = -999.0
          sorted_arrQ10(:,:) = -999.0
 ! Chemistry
-         if (associated(index_MASSDEN     )) sorted_arrQ11(:,:) = -999.0
+         if (associated(index_massden     )) sorted_arrQ11(:,:) = -999.0
          if (associated(index_smoke_fine  )) sorted_arrQ12(:,:) = -999.0
          if (associated(index_dust_fine   )) sorted_arrQ14(:,:) = -999.0
          if (associated(index_dust_coarse )) sorted_arrQ15(:,:) = -999.0
@@ -8590,8 +8590,8 @@ call mpas_log_write('Done with soil consistency check')
          scalars(index_ns,:,iCell) = 0._RKIND
          scalars(index_ng,:,iCell) = 0._RKIND
 ! Chemistry
-         if (associated(index_MASSDEN      )) then
-            if (index_MASSDEN > 0      )  scalars(index_MASSDEN,:,iCell) = 0._RKIND
+         if (associated(index_massden      )) then
+            if (index_massden > 0      )  scalars(index_massden,:,iCell) = 0._RKIND
          endif
          if (associated(index_smoke_fine   )) then
             if (index_smoke_fine > 0   )  scalars(index_smoke_fine,:,iCell) = 0._RKIND
@@ -8615,7 +8615,7 @@ call mpas_log_write('Done with soil consistency check')
             sorted_arrQ9(1,k) = z_fg(k,iCell)
             sorted_arrQ10(1,k) = z_fg(k,iCell)
 ! Chemistry
-           if (associated(index_MASSDEN     )) sorted_arrQ11(1,k) = z_fg(k,iCell)
+           if (associated(index_massden     )) sorted_arrQ11(1,k) = z_fg(k,iCell)
            if (associated(index_smoke_fine  )) sorted_arrQ12(1,k) = z_fg(k,iCell)
            if (associated(index_dust_fine   )) sorted_arrQ14(1,k) = z_fg(k,iCell)
            if (associated(index_dust_coarse )) sorted_arrQ15(1,k) = z_fg(k,iCell)
@@ -8631,7 +8631,7 @@ call mpas_log_write('Done with soil consistency check')
                 sorted_arrQ9(1,k) = 99999.0
                 sorted_arrQ10(1,k) = 99999.0
 ! Chemistry
-                if (associated(index_MASSDEN     )) sorted_arrQ11(1,k) = 99999.0
+                if (associated(index_massden     )) sorted_arrQ11(1,k) = 99999.0
                 if (associated(index_smoke_fine  )) sorted_arrQ12(1,k) = 99999.0
                 if (associated(index_dust_fine   )) sorted_arrQ14(1,k) = 99999.0
                 if (associated(index_dust_coarse )) sorted_arrQ15(1,k) = 99999.0
@@ -8647,7 +8647,7 @@ call mpas_log_write('Done with soil consistency check')
             sorted_arrQ9(2,k) = max(0._RKIND,qnwfa_fg(k,iCell))
             sorted_arrQ10(2,k) = max(0._RKIND,qnifa_fg(k,iCell))
 ! Chemistry
-            if (associated(MASSDEN_fg     ))sorted_arrQ11(2,k) = max(0._RKIND,MASSDEN_fg(k,iCell))
+            if (associated(massden_fg     ))sorted_arrQ11(2,k) = max(0._RKIND,massden_fg(k,iCell))
             if (associated(smoke_fine_fg  ))sorted_arrq12(2,k) = max(0._rkind,smoke_fine_fg(k,icell))
             if (associated(dust_fine_fg   ))sorted_arrq14(2,k) = max(0._rkind,dust_fine_fg(k,icell))
             if (associated(dust_coarse_fg ))sorted_arrq15(2,k) = max(0._rkind,dust_coarse_fg(k,icell))
@@ -8664,7 +8664,7 @@ call mpas_log_write('Done with soil consistency check')
          call mpas_quicksort(nfglevels_actual, sorted_arrQ9)
          call mpas_quicksort(nfglevels_actual, sorted_arrQ10)
 ! Chemistry
-         if (associated(index_MASSDEN     ))        call mpas_quicksort(nfglevels_actual, sorted_arrQ11)
+         if (associated(index_massden     ))        call mpas_quicksort(nfglevels_actual, sorted_arrQ11)
          if (associated(index_smoke_fine  ))        call mpas_quicksort(nfglevels_actual, sorted_arrQ12)
          if (associated(index_dust_fine   ))        call mpas_quicksort(nfglevels_actual, sorted_arrQ14)
          if (associated(index_dust_coarse ))        call mpas_quicksort(nfglevels_actual, sorted_arrQ15)
@@ -8691,8 +8691,8 @@ call mpas_log_write('Done with soil consistency check')
             scalars(index_nr,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                         sorted_arrQ8(:,1:nfglevels_actual-1), order=1, extrap=0)
 ! JLS
-            if ( associated(index_MASSDEN )) then
-               if (  index_MASSDEN > 0    ) scalars(index_MASSDEN,k,iCell) = conv_aer_kg2ug * vertical_interp(target_z, nfglevels_actual-1, &
+            if ( associated(index_massden )) then
+               if (  index_massden > 0    ) scalars(index_massden,k,iCell) = conv_aer_kg2ug * vertical_interp(target_z, nfglevels_actual-1, &
                                         sorted_arrQ11(:,1:nfglevels_actual-1), order=1, extrap=0)
             endif
             if ( associated(index_smoke_fine )) then
@@ -8721,8 +8721,8 @@ call mpas_log_write('Done with soil consistency check')
                 scalars(index_ns,k,iCell) = scalars(index_ns,k+1,iCell)
                 scalars(index_ng,k,iCell) = scalars(index_ng,k+1,iCell)
 ! Chemistry
-                if ( associated(index_MASSDEN     )) then
-                   if (index_MASSDEN > 0      ) scalars(index_MASSDEN,k,iCell) = scalars(index_MASSDEN,k+1,iCell)
+                if ( associated(index_massden     )) then
+                   if (index_massden > 0      ) scalars(index_massden,k,iCell) = scalars(index_massden,k+1,iCell)
                 endif
                 if ( associated(index_smoke_fine  )) then
                    if (index_smoke_fine > 0   ) scalars(index_smoke_fine,k,iCell) = scalars(index_smoke_fine,k+1,iCell)
@@ -8778,7 +8778,7 @@ call mpas_log_write('Done with soil consistency check')
       deallocate(sorted_arr)
       deallocate(sorted_arrQ1,sorted_arrQ2,sorted_arrQ3,sorted_arrQ4,sorted_arrQ5,sorted_arrQ6,sorted_arrQ7,sorted_arrQ8,sorted_arrQ9,sorted_arrQ10)
 ! Chemistry
-      if (associated(index_MASSDEN     )) deallocate(sorted_arrQ11)
+      if (associated(index_massden     )) deallocate(sorted_arrQ11)
       if (associated(index_smoke_fine  )) deallocate(sorted_arrQ12)
       if (associated(index_dust_fine   )) deallocate(sorted_arrQ14)
       if (associated(index_dust_coarse )) deallocate(sorted_arrQ15)

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -4108,6 +4108,8 @@ module init_atm_cases
       integer :: nfglevels_actual
       integer, pointer :: index_qv, index_qc, index_qr, index_qi, index_qs, index_qg, index_ni, index_nc, index_nr, index_ns, index_ng
       integer, pointer :: index_nwfa, index_nifa
+      integer, pointer :: index_MASSDEN
+      integer, pointer :: index_smoke_fine, index_dust_fine, index_dust_coarse
 
       integer, dimension(5) :: interp_list
       real (kind=RKIND) :: maskval
@@ -4123,6 +4125,9 @@ module init_atm_cases
       real (kind=RKIND), dimension(:,:), pointer :: sorted_arr
       real (kind=RKIND), dimension(:,:), pointer :: sorted_arrQ1,sorted_arrQ2,sorted_arrQ3,sorted_arrQ4,sorted_arrQ5,sorted_arrQ6,sorted_arrQ7,sorted_arrQ8
       real (kind=RKIND), dimension(:,:), pointer :: sorted_arrQ9,sorted_arrQ10
+! Chemistry
+      real (kind=RKIND), dimension(:,:), pointer :: sorted_arrQ11,sorted_arrQ12,sorted_arrQ13,sorted_arrQ14,sorted_arrQ15
+
 
       integer, dimension(:), pointer :: bdyMaskCell
 
@@ -4251,6 +4256,12 @@ module init_atm_cases
       real (kind=RKIND), dimension(:,:), pointer :: st_fg
       real (kind=RKIND), dimension(:,:), pointer :: sm_fg
       real (kind=RKIND), dimension(:), pointer :: soilz
+! Chemistry
+      real (kind=RKIND), dimension(:,:), pointer :: MASSDEN_fg
+      real (kind=RKIND), dimension(:,:), pointer :: smoke_fine_fg
+      real (kind=RKIND), dimension(:,:), pointer :: dust_fine_fg
+      real (kind=RKIND), dimension(:,:), pointer :: dust_coarse_fg
+      real (kind=RKIND), parameter :: conv_aer_kg2ug = 1.e9
 
       type (hashtable), allocatable :: level_hash
       logical :: too_many_fg_levs
@@ -4406,6 +4417,11 @@ module init_atm_cases
       call mpas_pool_get_array(fg, 'qnr', qnr_fg)
       call mpas_pool_get_array(fg, 'gfs_z', gfs_z)
       call mpas_pool_get_array(fg, 'p', p_fg)
+! Chemistry
+      call mpas_pool_get_array(fg, 'MASSDEN', MASSDEN_fg)
+      call mpas_pool_get_array(fg, 'smoke_fine', smoke_fine_fg)
+      call mpas_pool_get_array(fg, 'dust_fine', dust_fine_fg)
+      call mpas_pool_get_array(fg, 'dust_coarse', dust_coarse_fg)
 
       call mpas_pool_get_dimension(dims, 'nVertLevels', nz1)
       call mpas_pool_get_dimension(dims, 'nCellsSolve', nCellsSolve)
@@ -4425,6 +4441,11 @@ module init_atm_cases
       call mpas_pool_get_dimension(state, 'index_nr', index_nr)
       call mpas_pool_get_dimension(state, 'index_ns', index_ns)
       call mpas_pool_get_dimension(state, 'index_ng', index_ng)
+! Chemistry
+      call mpas_pool_get_dimension(state, 'index_MASSDEN',index_MASSDEN)
+      call mpas_pool_get_dimension(state, 'index_smoke_fine',index_smoke_fine)
+      call mpas_pool_get_dimension(state, 'index_dust_fine',index_dust_fine)
+      call mpas_pool_get_dimension(state, 'index_dust_coarse',index_dust_coarse)
 
       xnutr = 0.
       zd = 12000.
@@ -5049,7 +5070,12 @@ module init_atm_cases
              trim(field % field) == 'SHDMIN' .or. &
              trim(field % field) == 'SHDMAX' .or. &
              trim(field % field) == 'SEAICE' .or. &
-             trim(field % field) == 'SKINTEMP') then
+             trim(field % field) == 'SKINTEMP' .or. &
+! Chemistry
+             trim(field % field) == 'MASSDEN' .or. &
+             trim(field % field) == 'SMKF' .or. &
+             trim(field % field) == 'DSTF' .or. &
+             trim(field % field) == 'DSTC') then
 
             if (trim(field % field) == 'SM000010' .or. &
                 trim(field % field) == 'SM010040' .or. &
@@ -5336,7 +5362,35 @@ module init_atm_cases
                 lonPoints => lonCell
                 call mpas_pool_get_array(fg, 'qni', destField2d)
                 ndims = 2
-
+! Chemistry
+            else if (trim(field % field) == 'MASSDEN' ) then
+                call mpas_log_write('Interpolating MASSDEN at $i $r', intArgs=(/k/), realArgs=(/vert_level(k)/))
+                nInterpPoints = nCells
+                latPoints => latCell
+                lonPoints => lonCell
+                call mpas_pool_get_array(fg, 'MASSDEN', destField2d)
+                ndims = 2
+            else if (trim(field % field) == 'SMKF' ) then
+                call mpas_log_write('Interpolating SMKFN at $i $r', intArgs=(/k/), realArgs=(/vert_level(k)/))
+                nInterpPoints = nCells
+                latPoints => latCell
+                lonPoints => lonCell
+                call mpas_pool_get_array(fg, 'smoke_fine', destField2d)
+                ndims = 2
+            else if (trim(field % field) == 'DSTF' ) then
+                call mpas_log_write('Interpolating DSTFN at $i $r', intArgs=(/k/), realArgs=(/vert_level(k)/))
+                nInterpPoints = nCells
+                latPoints => latCell
+                lonPoints => lonCell
+                call mpas_pool_get_array(fg, 'dust_fine', destField2d)
+                ndims = 2
+            else if (trim(field % field) == 'DSTC' ) then
+                call mpas_log_write('Interpolating DUSTC at $i $r', intArgs=(/k/), realArgs=(/vert_level(k)/))
+                nInterpPoints = nCells
+                latPoints => latCell
+                lonPoints => lonCell
+                call mpas_pool_get_array(fg, 'dust_coarse', destField2d)
+                ndims = 2
             else if (trim(field % field) == 'GHT') then
                call mpas_log_write('Interpolating GHT at $i $r', intArgs=(/k/), realArgs=(/vert_level(k)/))
                nInterpPoints = nCells
@@ -7117,6 +7171,11 @@ call mpas_log_write('Done with soil consistency check')
       allocate(sorted_arrQ8(2,nfglevels_actual))
       allocate(sorted_arrQ9(2,nfglevels_actual))
       allocate(sorted_arrQ10(2,nfglevels_actual))
+! Chemistry
+      if (associated(index_MASSDEN      )) allocate(sorted_arrQ11(2,nfglevels_actual))
+      if (associated(index_smoke_fine   )) allocate(sorted_arrQ12(2,nfglevels_actual))
+      if (associated(index_dust_fine    )) allocate(sorted_arrQ14(2,nfglevels_actual))
+      if (associated(index_dust_coarse  )) allocate(sorted_arrQ15(2,nfglevels_actual))
 
       call mpas_log_write('min lon $r max lon $r min lat $r max lat $r',realArgs=(/minval(lonPoints),maxval(lonPoints),minval(latPoints),maxval(latPoints)/))
       do iCell=1,nCells
@@ -7193,6 +7252,11 @@ call mpas_log_write('Done with soil consistency check')
          sorted_arrQ8(:,:) = -999.0
          sorted_arrQ9(:,:) = -999.0
          sorted_arrQ10(:,:) = -999.0
+! Chemistry
+         if (associated(index_MASSDEN     ) ) sorted_arrQ11(:,:) = -999.0
+         if (associated(index_smoke_fine  ) ) sorted_arrQ12(:,:) = -999.0
+         if (associated(index_dust_fine   ) ) sorted_arrQ14(:,:) = -999.0
+         if (associated(index_dust_coarse ) ) sorted_arrQ15(:,:) = -999.0
          scalars(index_nwfa,:,iCell) = 0._RKIND
          scalars(index_nifa,:,iCell) = 0._RKIND
          scalars(index_qc,:,iCell) = 0._RKIND
@@ -7205,6 +7269,19 @@ call mpas_log_write('Done with soil consistency check')
          scalars(index_nr,:,iCell) = 0._RKIND
          scalars(index_ns,:,iCell) = 0._RKIND
          scalars(index_ng,:,iCell) = 0._RKIND
+! Chemistry
+         if (associated(index_MASSDEN        )) then
+            if  (index_MASSDEN > 0      ) scalars(index_MASSDEN,:,iCell) = 0._RKIND
+         endif
+         if (associated(index_smoke_fine     )) then
+            if (index_smoke_fine > 0    ) scalars(index_smoke_fine,:,iCell) = 0._RKIND
+         endif
+         if (associated(index_dust_fine      )) then
+             if (index_dust_fine > 0    ) scalars(index_dust_fine,:,iCell) = 0._RKIND
+         endif
+         if (associated(index_dust_coarse    )) then
+             if (index_dust_coarse > 0  ) scalars(index_dust_coarse,:,iCell) = 0._RKIND
+         endif
          do k = 1, nfglevels_actual
             sorted_arrQ1(1,k) = z_fg(k,iCell)
             sorted_arrQ2(1,k) = z_fg(k,iCell)
@@ -7216,6 +7293,11 @@ call mpas_log_write('Done with soil consistency check')
             sorted_arrQ8(1,k) = z_fg(k,iCell)
             sorted_arrQ9(1,k) = z_fg(k,iCell)
             sorted_arrQ10(1,k) = z_fg(k,iCell)
+! Chemistry
+            if (associated(index_MASSDEN     ) ) sorted_arrQ11(1,k) = z_fg(k,iCell)
+            if (associated(index_smoke_fine  ) ) sorted_arrQ12(1,k) = z_fg(k,iCell)
+            if (associated(index_dust_fine   ) ) sorted_arrQ14(1,k) = z_fg(k,iCell)
+            if (associated(index_dust_coarse ) ) sorted_arrQ15(1,k) = z_fg(k,iCell)
             if (vert_level(k) == 200100.0) then
                 sorted_arrQ1(1,k) = 99999.0
                 sorted_arrQ2(1,k) = 99999.0
@@ -7227,6 +7309,11 @@ call mpas_log_write('Done with soil consistency check')
                 sorted_arrQ8(1,k) = 99999.0
                 sorted_arrQ9(1,k) = 99999.0
                 sorted_arrQ10(1,k) = 99999.0
+! Chemistry
+                if (associated(index_MASSDEN     ) ) sorted_arrQ11(1,k) = 99999.0
+                if (associated(index_smoke_fine  ) ) sorted_arrQ12(1,k) = 99999.0
+                if (associated(index_dust_fine   ) ) sorted_arrQ14(1,k) = 99999.0
+                if (associated(index_dust_coarse ) ) sorted_arrQ15(1,k) = 99999.0
             endif
             sorted_arrQ1(2,k) = max(0._RKIND,qc_fg(k,iCell))
             sorted_arrQ2(2,k) = max(0._RKIND,qr_fg(k,iCell))
@@ -7238,6 +7325,11 @@ call mpas_log_write('Done with soil consistency check')
             sorted_arrQ8(2,k) = max(0._RKIND,qnr_fg(k,iCell))
             sorted_arrQ9(2,k) = max(0._RKIND,qnwfa_fg(k,iCell))
             sorted_arrQ10(2,k) = max(0._RKIND,qnifa_fg(k,iCell))
+! Chemistry
+            if (associated(MASSDEN_fg     ) ) sorted_arrQ11(2,k) = max(0._RKIND,MASSDEN_fg(k,iCell))
+            if (associated(smoke_fine_fg  ) ) sorted_arrQ12(2,k) = max(0._RKIND,smoke_fine_fg(k,iCell))
+            if (associated(dust_fine_fg   ) ) sorted_arrQ14(2,k) = max(0._RKIND,dust_fine_fg(k,iCell))
+            if (associated(dust_coarse_fg ) ) sorted_arrQ15(2,k) = max(0._RKIND,dust_coarse_fg(k,iCell))
          end do
 
          call mpas_quicksort(nfglevels_actual, sorted_arrQ1)
@@ -7250,6 +7342,12 @@ call mpas_log_write('Done with soil consistency check')
          call mpas_quicksort(nfglevels_actual, sorted_arrQ8)
          call mpas_quicksort(nfglevels_actual, sorted_arrQ9)
          call mpas_quicksort(nfglevels_actual, sorted_arrQ10)
+! Chemistry
+         if (associated(index_MASSDEN      ) )   call mpas_quicksort(nfglevels_actual, sorted_arrQ11)
+         if (associated(index_smoke_fine   ) )   call mpas_quicksort(nfglevels_actual, sorted_arrQ12)
+         if (associated(index_dust_fine    ) )  call mpas_quicksort(nfglevels_actual, sorted_arrQ14)
+         if (associated(index_dust_coarse  ) )  call mpas_quicksort(nfglevels_actual, sorted_arrQ15)
+
          do k = nVertLevels, 1, -1
             target_z = 0.5 * (zgrid(k,iCell) + zgrid(k+1,iCell))
             scalars(index_nwfa,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
@@ -7272,6 +7370,23 @@ call mpas_log_write('Done with soil consistency check')
                                         sorted_arrQ7(:,1:nfglevels_actual-1), order=1, extrap=0)
             scalars(index_nr,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                         sorted_arrQ8(:,1:nfglevels_actual-1), order=1, extrap=0)
+! Chemistry
+            if ( associated(index_MASSDEN)) then
+               if (  index_MASSDEN > 0      ) scalars(index_MASSDEN,k,iCell) = conv_aer_kg2ug * vertical_interp(target_z, nfglevels_actual-1, &
+                                        sorted_arrQ11(:,1:nfglevels_actual-1), order=1, extrap=0)
+            endif
+            if ( associated(index_smoke_fine)) then
+                if ( index_smoke_fine > 0 ) scalars(index_smoke_fine,k,iCell) = conv_aer_kg2ug * vertical_interp(target_z, nfglevels_actual-1, &
+                                        sorted_arrQ12(:,1:nfglevels_actual-1), order=1, extrap=0)
+            endif
+            if ( associated(index_dust_fine )) then
+               if ( index_dust_fine > 0  ) scalars(index_dust_fine,k,iCell) = conv_aer_kg2ug * vertical_interp(target_z, nfglevels_actual-1, &
+                                        sorted_arrQ14(:,1:nfglevels_actual-1), order=1, extrap=0)
+            endif
+            if ( associated(index_dust_coarse )) then
+               if ( index_dust_coarse > 0 ) scalars(index_dust_coarse,k,iCell) = conv_aer_kg2ug * vertical_interp(target_z, nfglevels_actual-1, &
+                                        sorted_arrQ15(:,1:nfglevels_actual-1), order=1, extrap=0)
+            endif
          end do
 
          ! GHT
@@ -7373,6 +7488,11 @@ call mpas_log_write('Done with soil consistency check')
 
       deallocate(sorted_arr)
       deallocate(sorted_arrQ1,sorted_arrQ2,sorted_arrQ3,sorted_arrQ4,sorted_arrQ5,sorted_arrQ6,sorted_arrQ7,sorted_arrQ8,sorted_arrQ9,sorted_arrQ10)
+! Chemistry
+      if (associated(index_MASSDEN     )) deallocate(sorted_arrQ11)
+      if (associated(index_smoke_fine  )) deallocate(sorted_arrQ12)
+      if (associated(index_dust_fine   )) deallocate(sorted_arrQ14)
+      if (associated(index_dust_coarse )) deallocate(sorted_arrQ15)
 
       ! Diagnose the water vapor mixing ratios:
       global_sh_min = 0._RKIND
@@ -7675,6 +7795,8 @@ call mpas_log_write('Done with soil consistency check')
       type (dm_info), pointer :: dminfo
 
       real (kind=RKIND), parameter :: t0b = 250.0
+! Chemistry
+      real (kind=RKIND), parameter :: conv_aer_kg2ug = 1.e9
 
       type (met_data) :: field
       type (proj_info) :: proj
@@ -7696,6 +7818,11 @@ call mpas_log_write('Done with soil consistency check')
       integer :: nfglevels_actual
       integer, pointer :: index_qv, index_qc, index_qr, index_qi, index_qs, index_qg,index_ni, index_nc, index_nr, index_ns, index_ng
       integer, pointer :: index_nwfa, index_nifa
+! Chemistry
+      integer, pointer :: index_MASSDEN
+      integer, pointer :: index_smoke_fine, index_dust_fine, index_dust_coarse
+
+
 
       integer, dimension(5) :: interp_list
       real (kind=RKIND) :: msgval
@@ -7705,6 +7832,8 @@ call mpas_log_write('Done with soil consistency check')
       real (kind=RKIND), dimension(:,:), pointer :: sorted_arr
       real (kind=RKIND), dimension(:,:), pointer :: sorted_arrQ1,sorted_arrQ2,sorted_arrQ3,sorted_arrQ4,sorted_arrQ5,sorted_arrQ6,sorted_arrQ7,sorted_arrQ8
       real (kind=RKIND), dimension(:,:), pointer :: sorted_arrQ9,sorted_arrQ10
+! Chemistry
+      real (kind=RKIND), dimension(:,:), pointer :: sorted_arrQ11,sorted_arrQ12,sorted_arrQ13,sorted_arrQ14,sorted_arrQ15
 
       integer :: sfc_k
 
@@ -7765,6 +7894,9 @@ call mpas_log_write('Done with soil consistency check')
       real (kind=RKIND), dimension(:,:), pointer :: qnc_fg
       real (kind=RKIND), dimension(:,:), pointer :: qni_fg
       real (kind=RKIND), dimension(:,:), pointer :: qnr_fg
+! Chemistry
+      real (kind=RKIND), dimension(:,:), pointer :: MASSDEN_fg
+      real (kind=RKIND), dimension(:,:), pointer :: smoke_fine_fg, dust_fine_fg, dust_coarse_fg
 
       real (kind=RKIND), dimension(:,:), pointer :: p_fg
       real (kind=RKIND), dimension(:), pointer :: soilz
@@ -7861,6 +7993,11 @@ call mpas_log_write('Done with soil consistency check')
       call mpas_pool_get_array(fg, 'qnc', qnc_fg)
       call mpas_pool_get_array(fg, 'qni', qni_fg)
       call mpas_pool_get_array(fg, 'qnr', qnr_fg)
+! Chemistry
+      call mpas_pool_get_array(fg, 'MASSDEN', MASSDEN_fg)
+      call mpas_pool_get_array(fg, 'smoke_fine', smoke_fine_fg)
+      call mpas_pool_get_array(fg, 'dust_fine', dust_fine_fg)
+      call mpas_pool_get_array(fg, 'dust_coarse', dust_coarse_fg)
 
       call mpas_pool_get_array(fg, 'p', p_fg)
 
@@ -7881,6 +8018,11 @@ call mpas_log_write('Done with soil consistency check')
       call mpas_pool_get_dimension(lbc_state, 'index_lbc_nr', index_nr)
       call mpas_pool_get_dimension(lbc_state, 'index_lbc_ns', index_ns)
       call mpas_pool_get_dimension(lbc_state, 'index_lbc_ng', index_ng)
+! Chemistry
+      call mpas_pool_get_dimension(lbc_state, 'index_lbc_MASSDEN', index_MASSDEN)
+      call mpas_pool_get_dimension(lbc_state, 'index_lbc_smoke_fine', index_smoke_fine)
+      call mpas_pool_get_dimension(lbc_state, 'index_lbc_dust_fine', index_dust_fine)
+      call mpas_pool_get_dimension(lbc_state, 'index_lbc_dust_coarse', index_dust_coarse)
 
       etavs = (1.0_RKIND - 0.252_RKIND) * pii / 2.0_RKIND
       rcv = rgas / (cp - rgas)
@@ -7957,7 +8099,12 @@ call mpas_log_write('Done with soil consistency check')
              trim(field % field) == 'GHT' .or. &
              trim(field % field) == 'SOILHGT' .or. &
              trim(field % field) == 'PRES' .or. &
-             trim(field % field) == 'PRESSURE') then
+             trim(field % field) == 'PRESSURE'.or. &
+! Chemistry
+             trim(field % field) == 'MASSDEN' .or. &
+             trim(field % field) == 'SMKF' .or. &
+             trim(field % field) == 'DSTF' .or. &
+             trim(field % field) == 'DSTC') then
 
             if (trim(field % field) /= 'SOILHGT') then
 
@@ -8177,6 +8324,35 @@ call mpas_log_write('Done with soil consistency check')
                lonPoints => lonCell
                call mpas_pool_get_array(fg, 'soilz', destField1d)
                ndims = 1
+! Chemistry
+            else if (trim(field % field) == 'MASSDEN' ) then
+                call mpas_log_write('Interpolating MASSDEN at $i $r', intArgs=(/k/), realArgs=(/vert_level(k)/))
+                nInterpPoints = nCells
+                latPoints => latCell
+                lonPoints => lonCell
+                call mpas_pool_get_array(fg, 'MASSDEN', destField2d)
+                ndims = 2
+            else if (trim(field % field) == 'SMKF' ) then
+                call mpas_log_write('Interpolating SMKF at $i $r', intArgs=(/k/), realArgs=(/vert_level(k)/))
+                nInterpPoints = nCells
+                latPoints => latCell
+                lonPoints => lonCell
+                call mpas_pool_get_array(fg, 'smoke_fine', destField2d)
+                ndims = 2
+            else if (trim(field % field) == 'DSTF' ) then
+                call mpas_log_write('Interpolating DSTF at $i $r', intArgs=(/k/), realArgs=(/vert_level(k)/))
+                nInterpPoints = nCells
+                latPoints => latCell
+                lonPoints => lonCell
+                call mpas_pool_get_array(fg, 'dust_fine', destField2d)
+                ndims = 2
+            else if (trim(field % field) == 'DSTC' ) then
+                call mpas_log_write('Interpolating DSTC at $i $r', intArgs=(/k/), realArgs=(/vert_level(k)/))
+                nInterpPoints = nCells
+                latPoints => latCell
+                lonPoints => lonCell
+                call mpas_pool_get_array(fg, 'dust_coarse', destField2d)
+                ndims = 2
             end if
 
             allocate(rslab(-2:field % nx+3, field % ny))
@@ -8323,6 +8499,11 @@ call mpas_log_write('Done with soil consistency check')
       allocate(sorted_arrQ8(2,nfglevels_actual))
       allocate(sorted_arrQ9(2,nfglevels_actual))
       allocate(sorted_arrQ10(2,nfglevels_actual))
+! Chemistry
+      if (associated(index_MASSDEN     )) allocate(sorted_arrQ11(2,nfglevels_actual))
+      if (associated(index_smoke_fine  )) allocate(sorted_arrQ12(2,nfglevels_actual))
+      if (associated(index_dust_fine   )) allocate(sorted_arrQ14(2,nfglevels_actual))
+      if (associated(index_dust_coarse )) allocate(sorted_arrQ15(2,nfglevels_actual))
 
       do iCell=1,nCells
 
@@ -8391,6 +8572,11 @@ call mpas_log_write('Done with soil consistency check')
          sorted_arrQ8(:,:) = -999.0
          sorted_arrQ9(:,:) = -999.0
          sorted_arrQ10(:,:) = -999.0
+! Chemistry
+         if (associated(index_MASSDEN     )) sorted_arrQ11(:,:) = -999.0
+         if (associated(index_smoke_fine  )) sorted_arrQ12(:,:) = -999.0
+         if (associated(index_dust_fine   )) sorted_arrQ14(:,:) = -999.0
+         if (associated(index_dust_coarse )) sorted_arrQ15(:,:) = -999.0
          scalars(index_nwfa,:,iCell) = 0._RKIND
          scalars(index_nifa,:,iCell) = 0._RKIND
          scalars(index_qc,:,iCell) = 0._RKIND
@@ -8403,6 +8589,19 @@ call mpas_log_write('Done with soil consistency check')
          scalars(index_nr,:,iCell) = 0._RKIND
          scalars(index_ns,:,iCell) = 0._RKIND
          scalars(index_ng,:,iCell) = 0._RKIND
+! Chemistry
+         if (associated(index_MASSDEN      )) then
+            if (index_MASSDEN > 0      )  scalars(index_MASSDEN,:,iCell) = 0._RKIND
+         endif
+         if (associated(index_smoke_fine   )) then
+            if (index_smoke_fine > 0   )  scalars(index_smoke_fine,:,iCell) = 0._RKIND
+         endif
+         if (associated(index_dust_fine    )) then
+            if (index_dust_fine > 0    )  scalars(index_dust_fine,:,iCell) = 0._RKIND
+         endif
+         if (associated(index_dust_coarse  )) then
+            if (index_dust_coarse > 0  )  scalars(index_dust_coarse,:,iCell) = 0._RKIND
+         endif
 
          do k = 1, nfglevels_actual
             sorted_arrQ1(1,k) = z_fg(k,iCell)
@@ -8415,6 +8614,11 @@ call mpas_log_write('Done with soil consistency check')
             sorted_arrQ8(1,k) = z_fg(k,iCell)
             sorted_arrQ9(1,k) = z_fg(k,iCell)
             sorted_arrQ10(1,k) = z_fg(k,iCell)
+! Chemistry
+           if (associated(index_MASSDEN     )) sorted_arrQ11(1,k) = z_fg(k,iCell)
+           if (associated(index_smoke_fine  )) sorted_arrQ12(1,k) = z_fg(k,iCell)
+           if (associated(index_dust_fine   )) sorted_arrQ14(1,k) = z_fg(k,iCell)
+           if (associated(index_dust_coarse )) sorted_arrQ15(1,k) = z_fg(k,iCell)
             if (vert_level(k) == 200100.0) then
                 sorted_arrQ1(1,k) = 99999.0
                 sorted_arrQ2(1,k) = 99999.0
@@ -8426,6 +8630,11 @@ call mpas_log_write('Done with soil consistency check')
                 sorted_arrQ8(1,k) = 99999.0
                 sorted_arrQ9(1,k) = 99999.0
                 sorted_arrQ10(1,k) = 99999.0
+! Chemistry
+                if (associated(index_MASSDEN     )) sorted_arrQ11(1,k) = 99999.0
+                if (associated(index_smoke_fine  )) sorted_arrQ12(1,k) = 99999.0
+                if (associated(index_dust_fine   )) sorted_arrQ14(1,k) = 99999.0
+                if (associated(index_dust_coarse )) sorted_arrQ15(1,k) = 99999.0
              endif
             sorted_arrQ1(2,k) = max(0._RKIND,qc_fg(k,iCell))
             sorted_arrQ2(2,k) = max(0._RKIND,qr_fg(k,iCell))
@@ -8437,6 +8646,11 @@ call mpas_log_write('Done with soil consistency check')
             sorted_arrQ8(2,k) = max(0._RKIND,qnr_fg(k,iCell))
             sorted_arrQ9(2,k) = max(0._RKIND,qnwfa_fg(k,iCell))
             sorted_arrQ10(2,k) = max(0._RKIND,qnifa_fg(k,iCell))
+! Chemistry
+            if (associated(MASSDEN_fg     ))sorted_arrQ11(2,k) = max(0._RKIND,MASSDEN_fg(k,iCell))
+            if (associated(smoke_fine_fg  ))sorted_arrq12(2,k) = max(0._rkind,smoke_fine_fg(k,icell))
+            if (associated(dust_fine_fg   ))sorted_arrq14(2,k) = max(0._rkind,dust_fine_fg(k,icell))
+            if (associated(dust_coarse_fg ))sorted_arrq15(2,k) = max(0._rkind,dust_coarse_fg(k,icell))
          end do
 
          call mpas_quicksort(nfglevels_actual, sorted_arrQ1)
@@ -8449,6 +8663,11 @@ call mpas_log_write('Done with soil consistency check')
          call mpas_quicksort(nfglevels_actual, sorted_arrQ8)
          call mpas_quicksort(nfglevels_actual, sorted_arrQ9)
          call mpas_quicksort(nfglevels_actual, sorted_arrQ10)
+! Chemistry
+         if (associated(index_MASSDEN     ))        call mpas_quicksort(nfglevels_actual, sorted_arrQ11)
+         if (associated(index_smoke_fine  ))        call mpas_quicksort(nfglevels_actual, sorted_arrQ12)
+         if (associated(index_dust_fine   ))        call mpas_quicksort(nfglevels_actual, sorted_arrQ14)
+         if (associated(index_dust_coarse ))        call mpas_quicksort(nfglevels_actual, sorted_arrQ15)
          do k = nVertLevels, 1, -1
             target_z = 0.5 * (zgrid(k,iCell) + zgrid(k+1,iCell))
             scalars(index_nwfa,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
@@ -8471,6 +8690,23 @@ call mpas_log_write('Done with soil consistency check')
                                         sorted_arrQ7(:,1:nfglevels_actual-1), order=1, extrap=0)
             scalars(index_nr,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                         sorted_arrQ8(:,1:nfglevels_actual-1), order=1, extrap=0)
+! JLS
+            if ( associated(index_MASSDEN )) then
+               if (  index_MASSDEN > 0    ) scalars(index_MASSDEN,k,iCell) = conv_aer_kg2ug * vertical_interp(target_z, nfglevels_actual-1, &
+                                        sorted_arrQ11(:,1:nfglevels_actual-1), order=1, extrap=0)
+            endif
+            if ( associated(index_smoke_fine )) then
+                if ( index_smoke_fine > 0  ) scalars(index_smoke_fine,k,iCell) = conv_aer_kg2ug * vertical_interp(target_z, nfglevels_actual-1, &
+                                        sorted_arrQ12(:,1:nfglevels_actual-1), order=1, extrap=0)
+            endif
+            if ( associated(index_dust_fine )) then
+               if ( index_dust_fine > 0) scalars(index_dust_fine,k,iCell) = conv_aer_kg2ug * vertical_interp(target_z, nfglevels_actual-1, &
+                                        sorted_arrQ14(:,1:nfglevels_actual-1), order=1, extrap=0)
+            endif
+            if ( associated(index_dust_coarse )) then
+               if ( index_dust_coarse > 0) scalars(index_dust_coarse,k,iCell) = conv_aer_kg2ug * vertical_interp(target_z, nfglevels_actual-1, &
+                                        sorted_arrQ15(:,1:nfglevels_actual-1), order=1, extrap=0)
+            endif
             if (target_z < z_fg(1,iCell) .and. k < nVertLevels) then
                 scalars(index_nwfa,k,iCell) = scalars(index_nwfa,k+1,iCell)
                 scalars(index_nifa,k,iCell) = scalars(index_nifa,k+1,iCell)
@@ -8484,6 +8720,19 @@ call mpas_log_write('Done with soil consistency check')
                 scalars(index_nr,k,iCell) = scalars(index_nr,k+1,iCell)
                 scalars(index_ns,k,iCell) = scalars(index_ns,k+1,iCell)
                 scalars(index_ng,k,iCell) = scalars(index_ng,k+1,iCell)
+! Chemistry
+                if ( associated(index_MASSDEN     )) then
+                   if (index_MASSDEN > 0      ) scalars(index_MASSDEN,k,iCell) = scalars(index_MASSDEN,k+1,iCell)
+                endif
+                if ( associated(index_smoke_fine  )) then
+                   if (index_smoke_fine > 0   ) scalars(index_smoke_fine,k,iCell) = scalars(index_smoke_fine,k+1,iCell)
+                endif
+                if ( associated(index_dust_fine   )) then
+                   if (index_dust_fine > 0    ) scalars(index_dust_fine,k,iCell) = scalars(index_dust_fine,k+1,iCell)
+                endif
+                if ( associated(index_dust_coarse )) then
+                   if (index_dust_coarse > 0  ) scalars(index_dust_coarse,k,iCell) = scalars(index_dust_coarse,k+1,iCell)
+                endif
             endif
          end do
 
@@ -8528,7 +8777,11 @@ call mpas_log_write('Done with soil consistency check')
 
       deallocate(sorted_arr)
       deallocate(sorted_arrQ1,sorted_arrQ2,sorted_arrQ3,sorted_arrQ4,sorted_arrQ5,sorted_arrQ6,sorted_arrQ7,sorted_arrQ8,sorted_arrQ9,sorted_arrQ10)
-
+! Chemistry
+      if (associated(index_MASSDEN     )) deallocate(sorted_arrQ11)
+      if (associated(index_smoke_fine  )) deallocate(sorted_arrQ12)
+      if (associated(index_dust_fine   )) deallocate(sorted_arrQ14)
+      if (associated(index_dust_coarse )) deallocate(sorted_arrQ15)
 
       ! Diagnose the water vapor mixing ratios:
       global_sh_min = 0._RKIND

--- a/src/core_init_atmosphere/mpas_init_atm_core_interface.F
+++ b/src/core_init_atmosphere/mpas_init_atm_core_interface.F
@@ -125,11 +125,28 @@ module init_atm_core_interface
       integer, pointer :: config_init_case
       logical, pointer :: noahmp, config_noahmp_static
 
+      logical, pointer :: mpas_smoke_in, mpas_dust_in, mpas_anthro_in
+      character(len=StrKIND),pointer:: config_smoke_scheme, config_dust_scheme, config_anthro_scheme
+
 
       ierr = init_atm_setup_packages_when(configs, packages)
       if (ierr /= 0) then
          return
       end if
+
+! Chemistry
+      call mpas_pool_get_config(configs,'config_smoke_scheme', config_smoke_scheme)
+      call mpas_pool_get_config(configs,'config_dust_scheme', config_dust_scheme)
+      call mpas_pool_get_config(configs,'config_anthro_scheme', config_anthro_scheme)
+      nullify(mpas_smoke_in)
+      call  mpas_pool_get_package(packages,'mpas_smoke_inActive',mpas_smoke_in)
+      if(config_smoke_scheme.ne.'off')  mpas_smoke_in=.true.
+      nullify(mpas_dust_in)
+      call  mpas_pool_get_package(packages,'mpas_dust_inActive',mpas_dust_in)
+      if(config_dust_scheme.ne.'off')  mpas_dust_in=.true.
+      nullify(mpas_anthro_in)
+      call  mpas_pool_get_package(packages,'mpas_anthro_inActive',mpas_anthro_in)
+      if(config_anthro_scheme.ne.'off')  mpas_anthro_in=.true.
 
       call mpas_pool_get_config(configs, 'config_init_case', config_init_case)
       call mpas_pool_get_config(configs, 'config_static_interp', config_static_interp)

--- a/src/core_init_atmosphere/registry.chemistry.xml
+++ b/src/core_init_atmosphere/registry.chemistry.xml
@@ -81,9 +81,6 @@
         <var_struct name="state" time_levs="1">
                 <var_array name="scalars" type="real" dimensions="nVertLevels nCells Time" packages="met_stage_out">
 
-                      <var name="MASSDEN" array_group="chemistry" units="kg kg^{-1}"
-                           description="fine smoke mixing ratio"/>
-
                       <var name="smoke_fine" array_group="chemistry" units="kg kg^{-1}"
                            description="fine smoke mixing ratio"
                            packages="mpas_smoke_in"/>
@@ -109,16 +106,11 @@
 
                         <var name="lbc_dust_coarse" array_group="chemistry"  packages="mpas_dust_in" units="kg kg^{-1} s^{-1}"
                              description="Lateral boundary tendency of coarse dust mixing ratio"/>
-
-                        <var name="lbc_MASSDEN" array_group="chemistry" units="kg kg^{-1} s^{-1}"
-                             description="Lateral boundary tendency of fine smoke mixing ratio"/>
                 </var_array>
 
         </var_struct>
 
         <var_struct name="fg" time_levs="1">
-                <var name="MASSDEN_fg" name_in_code="MASSDEN" type="real" dimensions="nFGLevels nCells Time" units="kg^{-1}"
-		     description="First guess smoke aerosols"/>
                 <var name="smoke_fine_fg" name_in_code="smoke_fine" type="real" dimensions="nFGLevels nCells Time" units="kg^{-1}"
 		     packages="mpas_smoke_in;mpas_anthro_in" description="First guess fine smoke aerosols"/>
                 <var name="dust_fine_fg" name_in_code="dust_fine" type="real" dimensions="nFGLevels nCells Time" units="kg^{-1}"

--- a/src/core_init_atmosphere/registry.chemistry.xml
+++ b/src/core_init_atmosphere/registry.chemistry.xml
@@ -29,6 +29,10 @@
            units="-"
            description="configuration for mpas dust model"
            possible_values="`on',`off'"/>
+      <nml_option name="config_anthro_scheme" type="character" default_value="off" in_defaults="false"
+           units="-"
+           description="configuration for mpas anthropogenic emissions model"
+           possible_values="`on',`off'"/>
       <nml_option name="num_chem" type="integer" default_value="0"
            units="-"
            description="Number of chemical tracers"
@@ -71,27 +75,6 @@
 
 
 <!-- **************************************************************************************** -->
-<!-- *************************************** Streams **************************************** -->
-<!-- **************************************************************************************** -->
-
-	<streams>
-		<stream name="lbc"
-                        type="output"
-                        filename_template="lbc.$Y-$M-$D_$h.$m.$s.nc"
-                        output_interval="3:00:00"
-                        filename_interval="output_interval"
-                        packages="lbcs"
-                        immutable="true">
-
-			<var name="xtime"/>
-			<var name="Time"/>
-			<var_struct name="lbc_state"/>
-		</stream>
-
-	</streams>
-
-
-<!-- **************************************************************************************** -->
 <!-- ************************************** Variables *************************************** -->
 <!-- **************************************************************************************** -->
 
@@ -108,10 +91,12 @@
                       <var name="dust_fine" array_group="chemistry" units="kg kg^{-1}"
                            description="fine dust mixing ratio"
                            packages="mpas_dust_in;mpas_anthro_in"/>
- 
+
                       <var name="dust_coarse" array_group="chemistry" units="kg kg^{-1}"
                            description="coarse dust mixing ratio"
                            packages="mpas_dust_in;mpas_anthro_in"/>
+
+                </var_array>
         </var_struct>
 
         <var_struct name="lbc_state" time_levs="1">
@@ -121,7 +106,7 @@
 
                         <var name="lbc_dust_fine" array_group="chemistry"  packages="mpas_dust_in" units="kg kg^{-1} s^{-1}"
                              description="Lateral boundary tendency of fine dust mixing ratio"/>
-  
+
                         <var name="lbc_dust_coarse" array_group="chemistry"  packages="mpas_dust_in" units="kg kg^{-1} s^{-1}"
                              description="Lateral boundary tendency of coarse dust mixing ratio"/>
 
@@ -140,4 +125,5 @@
 		     packages="mpas_dust_in;mpas_anthro_in" description="First guess fine dust aerosols"/>
                 <var name="dust_coarse_fg" name_in_code="dust_coarse" type="real" dimensions="nFGLevels nCells Time" units="kg^{-1}"
 		     packages="mpas_dust_in;mpas_anthro_in" description="First guess coarse dust aerosols"/>
+
         </var_struct>


### PR DESCRIPTION
There are three aerosol tracers (smoke, dust, and coarsepm) in RRFS-A outputs. This PR reads smoke/dust from RRFS-A as aerosol initial and boundary conditions for MPAS_dev2 realtime run.

### Priority Reviewers

* Please list the developers/collaborators you'd like to prioritize for review
* Example:
  - @clark-evans
