### PR TITLE
Fix units designations of GW drag diagnostic variables dusfcg, dtaux2d, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MPAS-v8.3.0
+MPAS-v8.3.1
 ====
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for

--- a/cmake/Modules/FindPnetCDF.cmake
+++ b/cmake/Modules/FindPnetCDF.cmake
@@ -133,19 +133,20 @@ set(_new_components)
 if(PnetCDF_Fortran_FOUND AND NOT TARGET PnetCDF::PnetCDF_Fortran)
     add_library(PnetCDF::PnetCDF_Fortran INTERFACE IMPORTED)
     set_target_properties(PnetCDF::PnetCDF_Fortran PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${PnetCDF_INCLUDE_DIR}
-                                                              INTERFACE_LINK_DIRECTORIES ${PnetCDF_LIB_DIR})
+                                                              INTERFACE_LINK_DIRECTORIES ${PnetCDF_LIB_DIR}
+                                                              INTERFACE_LINK_LIBRARIES pnetcdf)
     if(PnetCDF_MODULE_DIR AND NOT PnetCDF_MODULE_DIR STREQUAL PnetCDF_INCLUDE_DIR )
         set_property(TARGET PnetCDF::PnetCDF_Fortran APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${PnetCDF_MODULE_DIR})
     endif()
     set(_new_components 1)
-    target_link_libraries(PnetCDF::PnetCDF_Fortran INTERFACE -lpnetcdf)
 endif()
 
 # PnetCDF::PnetCDF_C imported interface target
 if(PnetCDF_C_FOUND AND NOT TARGET PnetCDF::PnetCDF_C)
     add_library(PnetCDF::PnetCDF_C INTERFACE IMPORTED)
     set_target_properties(PnetCDF::PnetCDF_C PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${PnetCDF_INCLUDE_DIR}
-                                                        INTERFACE_LINK_DIRECTORIES ${PnetCDF_LIB_DIR})
+                                                        INTERFACE_LINK_DIRECTORIES ${PnetCDF_LIB_DIR}
+                                                        INTERFACE_LINK_LIBRARIES pnetcdf)
     set(_new_components 1)
 endif()
 
@@ -153,7 +154,8 @@ endif()
 if(PnetCDF_CXX_FOUND AND NOT TARGET PnetCDF::PnetCDF_CXX)
     add_library(PnetCDF::PnetCDF_CXX INTERFACE IMPORTED)
     set_target_properties(PnetCDF::PnetCDF_CXX PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${PnetCDF_INCLUDE_DIR}
-                                                          INTERFACE_LINK_DIRECTORIES ${PnetCDF_LIB_DIR})
+                                                          INTERFACE_LINK_DIRECTORIES ${PnetCDF_LIB_DIR}
+                                                          INTERFACE_LINK_LIBRARIES pnetcdf)
     set(_new_components 1)
 endif()
 

--- a/src/core_atmosphere/Externals.cfg
+++ b/src/core_atmosphere/Externals.cfg
@@ -2,7 +2,7 @@
 local_path = ./physics_mmm
 protocol = git
 repo_url = https://github.com/NCAR/MMM-physics.git
-tag = 20240626-MPASv8.2
+tag = 20250616-MPASv8.3
 required = True
 
 [GSL_UGWP]

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.3.0">
+<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.3.1">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -2948,10 +2948,10 @@
                 <!-- ... PARAMETERIZATION OF GRAVITY WAVE DRAG OVER OROGRAPHY:                                          -->
                 <!-- ================================================================================================== -->
 
-		<var name="dusfcg" type="real" dimensions="nCells Time" units="Pa m s^{-1}"
+		<var name="dusfcg" type="real" dimensions="nCells Time" units="Pa"
                      description="vertically-integrated gravity wave drag over orography u-stress"/>
 
-                <var name="dvsfcg" type="real" dimensions="nCells Time" units="Pa m s^{-1}"
+                <var name="dvsfcg" type="real" dimensions="nCells Time" units="Pa"
                      description="vertically-integrated gravity wave drag over orography v-stress"/>
 
                 <var name="dusfc_ls" type="real" dimensions="nCells Time" units="Pa"
@@ -2986,10 +2986,10 @@
                      description="vertically-integrated turb orog form drag v-stress"
                      packages="ugwp_diags_stream"/>
 
-                <var name="dtaux3d" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+                <var name="dtaux3d" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
                      description="gravity wave drag over orography u-stress"/>
 
-                <var name="dtauy3d" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+                <var name="dtauy3d" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
                      description="gravity wave drag over orography v-stress"/>
 
                 <var name="dtaux3d_ls" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -37,21 +37,8 @@ module atm_time_integration
    
    use mpas_atm_iau  
 
-   !
-   ! Abstract interface for routine used to communicate halos of fields
-   ! in a named group
-   !
-   abstract interface
-      subroutine halo_exchange_routine(domain, halo_group, ierr)
-
-         use mpas_derived_types, only : domain_type
-
-         type (domain_type), intent(inout) :: domain
-         character(len=*), intent(in) :: halo_group
-         integer, intent(out), optional :: ierr
-
-      end subroutine halo_exchange_routine
-   end interface
+   ! Provides definition of halo_exchange_routine
+#include "mpas_halo_interface.inc"
 
    integer :: timerid, secs, u_secs
 

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -13,21 +13,8 @@ module atm_core
    use mpas_log, only : mpas_log_write, mpas_log_info
    use mpas_io_units, only : mpas_new_unit, mpas_release_unit
 
-   !
-   ! Abstract interface for routine used to communicate halos of fields
-   ! in a named group
-   !
-   abstract interface
-      subroutine halo_exchange_routine(domain, halo_group, ierr)
-
-         use mpas_derived_types, only : domain_type
-
-         type (domain_type), intent(inout) :: domain
-         character(len=*), intent(in) :: halo_group
-         integer, intent(out), optional :: ierr
-
-      end subroutine halo_exchange_routine
-   end interface
+   ! Provides definition of halo_exchange_routine
+#include "mpas_halo_interface.inc"
 
    type (MPAS_Clock_type), pointer :: clock
 

--- a/src/core_atmosphere/mpas_atm_halos.F
+++ b/src/core_atmosphere/mpas_atm_halos.F
@@ -10,21 +10,8 @@ module mpas_atm_halos
    use mpas_pool_routines
    use mpas_log, only : mpas_log_write, mpas_log_info
 
-   !
-   ! Abstract interface for routine used to communicate halos of fields
-   ! in a named group
-   !
-   abstract interface
-      subroutine halo_exchange_routine(domain, halo_group, ierr)
-
-         use mpas_derived_types, only : domain_type
-
-         type (domain_type), intent(inout) :: domain
-         character(len=*), intent(in) :: halo_group
-         integer, intent(out), optional :: ierr
-
-      end subroutine halo_exchange_routine
-   end interface
+   ! Provides definition of halo_exchange_routine
+#include "mpas_halo_interface.inc"
 
    procedure (halo_exchange_routine), pointer :: exchange_halo_group
 

--- a/src/core_atmosphere/physics/mpas_atmphys_todynamics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_todynamics.F
@@ -41,21 +41,8 @@
 !   number concentrations due to PBL processes.
 !   Laura D. Fowler (laura@ucar.edu) / 2024-05-16.
 
-!
-! Abstract interface for routine used to communicate halos of fields
-! in a named group
-!
- abstract interface
-    subroutine halo_exchange_routine(domain, halo_group, ierr)
-
-       use mpas_derived_types, only : domain_type
-
-       type (domain_type), intent(inout) :: domain
-       character(len=*), intent(in) :: halo_group
-       integer, intent(out), optional :: ierr
-
-    end subroutine halo_exchange_routine
- end interface
+ ! Provides definition of halo_exchange_routine
+#include "mpas_halo_interface.inc"
 
 
  contains

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.3.0">
+<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.3.1">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -5459,7 +5459,6 @@ call mpas_log_write('Done with soil consistency check')
             target_z = 0.5 * (zgrid(k,iCell) + zgrid(k+1,iCell))
             relhum(k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                        sorted_arr(:,1:nfglevels_actual-1), order=1, extrap=0)
-            if (target_z < z_fg(1,iCell) .and. k < nVertLevels) relhum(k,iCell) = relhum(k+1,iCell)
          end do
 
 
@@ -5477,7 +5476,6 @@ call mpas_log_write('Done with soil consistency check')
             target_z = 0.5 * (zgrid(k,iCell) + zgrid(k+1,iCell))
             spechum(k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                         sorted_arr(:,1:nfglevels_actual-1), order=1, extrap=0)
-            if (target_z < z_fg(1,iCell) .and. k < nVertLevels) spechum(k,iCell) = spechum(k+1,iCell)
          end do
 
 

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -5823,6 +5823,7 @@ call mpas_log_write('Done with soil consistency check')
       use mpas_dmpar, only : mpas_dmpar_exch_halo_field, mpas_dmpar_min_real, mpas_dmpar_max_real
       use mpas_stream_manager, only : MPAS_stream_mgr_stream_exists, MPAS_stream_mgr_read
       use mpas_derived_types, only : MPAS_STREAM_MGR_NOERR
+      use mpas_vector_operations, only : mpas_initialize_vectors
 
       implicit none
 
@@ -5992,6 +5993,13 @@ call mpas_log_write('Done with soil consistency check')
       !
       call atm_initialize_advection_rk(mesh, nCells, nEdges, maxEdges, on_a_sphere, sphere_radius)
       call atm_initialize_deformation_weights(mesh, nCells, on_a_sphere, sphere_radius)
+
+
+      !
+      ! Compute edgeNormalVectors, cellTangentPlane, and localVerticalUnitVectors
+      ! (NB: these are the same fields computed by the mpas_rbf_interp_initialize routine)
+      !
+      call mpas_initialize_vectors(mesh)
 
 
       !

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="landice" core_abbrev="li" version="8.3.0">
+<registry model="mpas" core="landice" core_abbrev="li" version="8.3.1">
 
 
 <!-- ======================================================================= -->

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="ocean" core_abbrev="ocn" version="8.3.0">
+<registry model="mpas" core="ocean" core_abbrev="ocn" version="8.3.1">
 
 	<dims>
 		<dim name="nCells" units="unitless"

--- a/src/core_seaice/Registry.xml
+++ b/src/core_seaice/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="seaice" core_abbrev="seaice" version="8.3.0">
+<registry model="mpas" core="seaice" core_abbrev="seaice" version="8.3.1">
 
 	<dims>
 		<dim name="nCells"

--- a/src/core_sw/Registry.xml
+++ b/src/core_sw/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="sw" core_abbrev="sw" version="8.3.0">
+<registry model="mpas" core="sw" core_abbrev="sw" version="8.3.1">
 	<dims>
 		<dim name="nCells"/>
 		<dim name="nEdges"/>

--- a/src/core_test/Makefile
+++ b/src/core_test/Makefile
@@ -11,7 +11,8 @@ OBJS = mpas_test_core.o \
        mpas_test_core_string_utils.o \
        mpas_test_core_dmpar.o \
        mpas_test_core_stream_inquiry.o \
-       mpas_test_openacc.o
+       mpas_test_openacc.o \
+       mpas_test_core_stream_list.o
 
 all: core_test
 
@@ -42,7 +43,8 @@ mpas_test_core.o: mpas_test_core_halo_exch.o mpas_test_core_streams.o \
                   mpas_test_core_field_tests.o mpas_test_core_timekeeping_tests.o \
                   mpas_test_core_sorting.o mpas_halo_testing.o \
                   mpas_test_core_string_utils.o mpas_test_core_dmpar.o \
-                  mpas_test_core_stream_inquiry.o mpas_test_openacc.o
+                  mpas_test_core_stream_inquiry.o mpas_test_openacc.o \
+                  mpas_test_core_stream_list.o
 
 mpas_test_core_halo_exch.o:
 

--- a/src/core_test/Registry.xml
+++ b/src/core_test/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="test" core_abbrev="test" version="8.3.0">
+<registry model="mpas" core="test" core_abbrev="test" version="8.3.1">
 	<dims>
 		<dim name="nCells"/>
 		<dim name="nEdges"/>

--- a/src/core_test/mpas_test_core.F
+++ b/src/core_test/mpas_test_core.F
@@ -91,6 +91,7 @@ module test_core
       use mpas_vector_operations
       use mpas_geometry_utils
       use test_core_streams, only : test_core_streams_test
+      use mpas_test_core_stream_list, only : mpas_test_stream_list
       use test_core_sorting, only : test_core_test_sorting
       use mpas_halo_testing, only : mpas_halo_tests
       use test_core_string_utils, only : mpas_test_string_utils
@@ -171,6 +172,16 @@ module test_core
       else
          call mpas_log_write('Stream tests: FAILURE', MPAS_LOG_ERR)
       end if
+      call mpas_log_write('')
+
+      ! Run stream list tests
+      call mpas_test_stream_list(iErr)
+      if (iErr == 0) then
+          call mpas_log_write('Stream list tests: SUCCESS')
+      else
+          call mpas_log_write('Stream list tests: FAILURE', MPAS_LOG_ERR)
+      end if
+      call mpas_log_write('')
 
       ! Run string util tests
       call mpas_log_write('')

--- a/src/core_test/mpas_test_core.F
+++ b/src/core_test/mpas_test_core.F
@@ -164,11 +164,12 @@ module test_core
       end if
       !$omp end parallel
 
+      ! Run stream tests
       call test_core_streams_test(domain, threadErrs, iErr)
       if ( iErr == 0 ) then
-         call mpas_log_write('Stream I/O tests: SUCCESS')
+         call mpas_log_write('Stream tests: SUCCESS')
       else
-         call mpas_log_write('Stream I/O tests: FAILURE', MPAS_LOG_ERR)
+         call mpas_log_write('Stream tests: FAILURE', MPAS_LOG_ERR)
       end if
 
       ! Run string util tests

--- a/src/core_test/mpas_test_core_stream_list.F
+++ b/src/core_test/mpas_test_core_stream_list.F
@@ -1,0 +1,653 @@
+! Copyright (c) 2025 The University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at https://mpas-dev.github.io/license.html .
+!
+module mpas_test_core_stream_list
+
+   use mpas_derived_types
+   use mpas_log
+   use mpas_stream_list
+
+   implicit none
+   private
+
+   public :: mpas_test_stream_list
+
+contains
+
+   !**************************************************************************************
+   !  Subroutine mpas_test_create_list
+   !
+   !> \brief   Test creating an empty stream list and verify initialization.
+   !>
+   !> \details This subroutine tests the creation of a new MPAS stream list, ensuring
+   !>          that the list is properly initialized with zero items and no head stream.
+   !>          The list is then destroyed to clean up any allocated memory.
+   !>
+   !> \param err  The error code that indicates the result of the test.
+   !
+   !--------------------------------------------------------------------------------------
+   subroutine mpas_test_create_list(err)
+      integer, intent(out) :: err
+      type(MPAS_stream_list_type), pointer :: list
+
+      err = 0
+
+      call MPAS_stream_list_create(list)
+
+      if (.not. associated(list)) then
+         err = err + 1
+      end if
+
+      if (list%nItems /= 0) then
+         err = err + 1
+      end if
+
+      if (associated(list%head)) then
+         err = err + 1
+      end if
+
+      call MPAS_stream_list_destroy(list)
+   end subroutine mpas_test_create_list
+
+   !**************************************************************************************
+   !  Subroutine mpas_test_insert_single
+   !
+   !> \brief   Test inserting a single stream into the list and verify correct insertion.
+   !>
+   !> \details This subroutine tests the insertion of a single stream into an MPAS
+   !>          stream list. It verifies that the stream is correctly added to the
+   !>          list, and checks that the list contains the expected stream with the
+   !>          correct number of items.
+   !>
+   !> \param err  The error code that indicates the result of the test.
+   !
+   !--------------------------------------------------------------------------------------
+   subroutine mpas_test_insert_single(err)
+      integer, intent(out) :: err
+      type(MPAS_stream_list_type), pointer :: list, stream
+      integer :: ierr
+
+      err = 0
+
+      call MPAS_stream_list_create(list)
+      allocate(stream)
+      stream%name = 'stream1'
+
+      call MPAS_stream_list_insert(list, stream, ierr)
+
+      if (ierr /= MPAS_STREAM_LIST_NOERR) then
+         err = err + 1
+      end if
+
+      if (.not. associated(list%head)) then
+         err = err + 1
+      end if
+
+      if (list%nItems /= 1) then
+         err = err + 1
+      end if
+
+      if (trim(list%head%name) /= 'stream1') then
+         err = err + 1
+      end if
+
+      call MPAS_stream_list_destroy(list)
+   end subroutine mpas_test_insert_single
+
+   !**************************************************************************************
+   !  Subroutine mpas_test_query_exact_match
+   !
+   !> \brief   Test querying for an exact stream match and ensure correct stream is found.
+   !>
+   !> \details This subroutine tests querying a stream list for an exact match of a
+   !>          stream's name. It ensures that the correct stream is found and that
+   !>          the query operation behaves as expected.
+   !>
+   !> \param err  The error code that indicates the result of the test.
+   !
+   !--------------------------------------------------------------------------------------
+   subroutine mpas_test_query_exact_match(err)
+      integer, intent(out) :: err
+      type(MPAS_stream_list_type), pointer :: list, stream, found
+      logical :: matched
+
+      err = 0
+
+      call MPAS_stream_list_create(list)
+      allocate(stream)
+      stream%name = 'stream1'
+      call MPAS_stream_list_insert(list, stream)
+      found => null()
+
+      matched = MPAS_stream_list_query(list, 'stream1', found)
+
+      if (.not. matched) then
+         err = err + 1
+      end if
+
+      if (.not. associated(found)) then
+         err = err + 1
+      else if (trim(found%name) /= 'stream1') then
+         err = err + 1
+      end if
+
+      call MPAS_stream_list_destroy(list)
+   end subroutine mpas_test_query_exact_match
+
+   !**************************************************************************************
+   !  Subroutine mpas_test_remove_existing_streams
+   !
+   !> \brief   Test removing streams from the beginning, middle, and end of a list.
+   !>
+   !> \details This subroutine verifies that removing streams from different positions
+   !>          in an MPAS stream list works as expected. It inserts three streams into
+   !>          the list, then removes one from the middle, one from the end, and one
+   !>          from the beginning, checking that the correct stream is removed in each
+   !>          case and that the operation returns a success code.
+   !>
+   !> \param err  The error code that indicates the result of the test.
+   !>
+   !--------------------------------------------------------------------------------------
+   subroutine mpas_test_remove_existing_streams(err)
+      integer, intent(out) :: err
+      type(MPAS_stream_list_type), pointer :: list, s1, s2, s3, &
+            removed1, removed2, removed3
+      integer :: ierr
+
+      err = 0
+
+      allocate(s1)
+      s1%name = 'stream1'
+      allocate(s2)
+      s2%name = 'stream2'
+      allocate(s3)
+      s3%name = 'stream3'
+
+      call MPAS_stream_list_create(list, ierr=ierr)
+      if (ierr /= MPAS_STREAM_LIST_NOERR) then
+         err = err + 1
+      end if
+
+      call MPAS_stream_list_insert(list, s1, ierr=ierr)
+      if (ierr /= MPAS_STREAM_LIST_NOERR) then
+         err = err + 1
+      end if
+
+      call MPAS_stream_list_insert(list, s2, ierr=ierr)
+      if (ierr /= MPAS_STREAM_LIST_NOERR) then
+         err = err + 1
+      end if
+
+      call MPAS_stream_list_insert(list, s3, ierr=ierr)
+      if (ierr /= MPAS_STREAM_LIST_NOERR) then
+         err = err + 1
+      end if
+
+      ! Remove from the middle
+      call MPAS_stream_list_remove(list, 'stream2', removed2, ierr=ierr)
+      if (ierr /= MPAS_STREAM_LIST_NOERR) then
+         err = err + 1
+      end if
+      if (.not. associated(removed2)) then
+         err = err + 1
+      end if
+      if (trim(removed2%name) /= 'stream2') then
+         err = err + 1
+      end if
+
+      ! Remove from the end
+      call MPAS_stream_list_remove(list, 'stream3', removed3, ierr=ierr)
+      if (ierr /= MPAS_STREAM_LIST_NOERR) then
+         err = err + 1
+      end if
+      if (.not. associated(removed3)) then
+         err = err + 1
+      end if
+      if (trim(removed3%name) /= 'stream3') then
+         err = err + 1
+      end if
+
+      ! Remove from the beginning
+      call MPAS_stream_list_remove(list, 'stream1', removed1, ierr=ierr)
+      if (ierr /= MPAS_STREAM_LIST_NOERR) then
+         err = err + 1
+      end if
+      if (.not. associated(removed1)) then
+         err = err + 1
+      end if
+      if (trim(removed1%name) /= 'stream1') then
+         err = err + 1
+      end if
+
+      call MPAS_stream_list_destroy(list)
+      deallocate(removed1)
+      deallocate(removed2)
+      deallocate(removed3)
+   end subroutine mpas_test_remove_existing_streams
+
+   !**************************************************************************************
+   !  Subroutine mpas_test_insert_non_adjacent_duplicate
+   !
+   !> \brief   Test inserting a non-adjacent duplicate of the first item added to the list.
+   !>
+   !> \details This subroutine verifies that inserting a duplicate of the first stream
+   !>          added to an MPAS stream list results in the correct duplicate error
+   !>          code when the duplicate is not inserted immediately after the original.
+   !>          It does so by inserting two unique streams into the list, then attempting
+   !>          to insert the first stream again. This confirms that duplicate detection
+   !>          works for non-adjacent duplicates in insertion order.
+   !>
+   !> \param err  The error code that indicates the result of the test.
+   !--------------------------------------------------------------------------------------
+   subroutine mpas_test_insert_non_adjacent_duplicate(err)
+      integer, intent(out) :: err
+      type(MPAS_stream_list_type), pointer :: list
+      type(MPAS_stream_list_type), pointer :: s1, s2
+      integer :: ierr
+
+      err = 0
+      call MPAS_stream_list_create(list)
+
+      allocate(s1)
+      s1%name = 'stream1'
+      allocate(s2)
+      s2%name = 'stream2'
+
+      call MPAS_stream_list_insert(list, s1, ierr)
+      if (ierr /= MPAS_STREAM_LIST_NOERR) then
+         err = err + 1
+      end if
+
+      call MPAS_stream_list_insert(list, s2, ierr)
+      if (ierr /= MPAS_STREAM_LIST_NOERR) then
+         err = err + 1
+      end if
+
+      call MPAS_stream_list_insert(list, s1, ierr)
+      if (ierr /= MPAS_STREAM_LIST_DUPLICATE) then
+         err = err + 1
+      end if
+      if (MPAS_stream_list_length(list) /= 2) then
+         err = err + 1
+      end if
+      ! Verify that inserting s1 again does not break the linkage bewtween s1 and s2
+      if (.not. associated(s1%next)) then
+         err = err + 1
+      end if
+
+      call MPAS_stream_list_destroy(list)
+   end subroutine mpas_test_insert_non_adjacent_duplicate
+
+   !**************************************************************************************
+   !  Subroutine mpas_test_remove_from_empty_list
+   !
+   !> \brief   Test attempting to remove a stream from an empty list, expect error.
+   !>
+   !> \details This subroutine tests the behavior of attempting to remove a stream
+   !>          from an empty list. It ensures that the correct error
+   !>          is returned when the stream is not found.
+   !>
+   !> \param err  The error code that indicates the result of the test.
+   !
+   !--------------------------------------------------------------------------------------
+   subroutine mpas_test_remove_from_empty_list(err)
+      integer, intent(out) :: err
+      type(MPAS_stream_list_type), pointer :: list, removed
+      integer :: ierr
+
+      err = 0
+
+      call MPAS_stream_list_create(list)
+
+      call MPAS_stream_list_remove(list, 'stream1', removed, ierr)
+      if (ierr /= MPAS_STREAM_LIST_NOT_FOUND) then
+         err = err + 1
+      end if
+      if (associated(removed)) then
+         err = err + 1
+      end if
+      call MPAS_stream_list_destroy(list)
+   end subroutine mpas_test_remove_from_empty_list
+
+   !**************************************************************************************
+   !  Subroutine mpas_test_remove_not_found
+   !
+   !> \brief   Attempt to remove a stream not in a non-empty list; expect NOT_FOUND.
+   !>
+   !> \details This subroutine populates the list with a couple of streams, then
+   !>          attempts to remove a stream name that does not exist. It verifies that
+   !>          MPAS_STREAM_LIST_NOT_FOUND is returned and that no node is returned.
+   !>
+   !> \param err  The error code that indicates the result of the test.
+   !>
+   !--------------------------------------------------------------------------------------
+   subroutine mpas_test_remove_not_found(err)
+      integer, intent(out) :: err
+      type(MPAS_stream_list_type), pointer :: list, removed
+      type(MPAS_stream_list_type), pointer :: s1, s2
+      integer :: ierr
+
+      err = 0
+
+      allocate(s1)
+      s1%name = 'stream1'
+      allocate(s2)
+      s2%name = 'stream2'
+
+      call MPAS_stream_list_create(list)
+
+      call MPAS_stream_list_insert(list, s1, ierr)
+      if (ierr /= MPAS_STREAM_LIST_NOERR) then
+         err = err + 1
+      end if
+
+      call MPAS_stream_list_insert(list, s2, ierr)
+      if (ierr /= MPAS_STREAM_LIST_NOERR) then
+         err = err + 1
+      end if
+
+      call MPAS_stream_list_remove(list, 'stream3', removed, ierr)
+      if (ierr /= MPAS_STREAM_LIST_NOT_FOUND) then
+         err = err + 1
+      end if
+      if (associated(removed)) then
+         err = err + 1
+      end if
+
+      call MPAS_stream_list_destroy(list)
+   end subroutine mpas_test_remove_not_found
+
+   !**************************************************************************************
+   !  Subroutine mpas_test_list_length
+   !
+   !> \brief   Test the length of the stream list after inserting multiple streams.
+   !>
+   !> \details This subroutine tests that the length of an MPAS stream list is correctly
+   !>          updated after multiple streams are inserted. It verifies that the length
+   !>          matches the expected value.
+   !>
+   !> \param err  The error code that indicates the result of the test.
+   !
+   !--------------------------------------------------------------------------------------
+   subroutine mpas_test_list_length(err)
+      integer, intent(out) :: err
+      type(MPAS_stream_list_type), pointer :: list, s1, s2, s3
+
+      err = 0
+      call MPAS_stream_list_create(list)
+
+      allocate(s1)
+      s1%name = 'stream1'
+      allocate(s2)
+      s2%name = 'stream2'
+      allocate(s3)
+      s3%name = 'stream3'
+
+      call MPAS_stream_list_insert(list, s1)
+      if (MPAS_stream_list_length(list) /= 1) then
+         err = err + 1
+      end if
+      call MPAS_stream_list_insert(list, s2)
+      if (MPAS_stream_list_length(list) /= 2) then
+         err = err + 1
+      end if
+      call MPAS_stream_list_insert(list, s3)
+      if (MPAS_stream_list_length(list) /= 3) then
+         err = err + 1
+      end if
+
+      call MPAS_stream_list_destroy(list)
+   end subroutine mpas_test_list_length
+
+   !**************************************************************************************
+   !  Subroutine mpas_test_query_partial_match
+   !
+   !> \brief   Test querying for a partial stream name match, ensuring no match is found.
+   !>
+   !> \details This subroutine tests the querying of a stream list for a partial match
+   !>          of a stream's name. It verifies that no match is found for a partial
+   !>          name match.
+   !>
+   !> \param err  The error code that indicates the result of the test.
+   !
+   !--------------------------------------------------------------------------------------
+   subroutine mpas_test_query_partial_match(err)
+      integer, intent(out) :: err
+      type(MPAS_stream_list_type), pointer :: list, stream, found
+      logical :: matched
+      integer :: ierr
+
+      err = 0
+      call MPAS_stream_list_create(list)
+      allocate(stream)
+      stream%name = 'stream1'
+      nullify(found)
+
+      call MPAS_stream_list_insert(list, stream)
+
+      matched = MPAS_stream_list_query(list, 'stream', found, ierr)
+
+      if (ierr /= MPAS_STREAM_LIST_NOERR) then
+         err = err + 1
+      end if
+      if (matched .or. associated(found)) then
+         err = err + 1
+      end if
+
+      call MPAS_stream_list_destroy(list)
+   end subroutine mpas_test_query_partial_match
+
+   !**************************************************************************************
+   !  Subroutine mpas_test_insert_duplicate_at_begin
+   !
+   !> \brief   Test inserting a duplicate stream at the beginning of the list.
+   !>
+   !> \details This subroutine tests the insertion of a duplicate stream at the
+   !>          beginning of an MPAS stream list. It ensures that the correct error
+   !>          is returned when attempting to insert a duplicate stream.
+   !>
+   !> \param err  The error code that indicates the result of the test.
+   !
+   !--------------------------------------------------------------------------------------
+   subroutine mpas_test_insert_duplicate_at_begin(err)
+      integer, intent(out) :: err
+      type(MPAS_stream_list_type), pointer :: list
+      type(MPAS_stream_list_type), pointer :: s1
+      integer :: ierr
+
+      err = 0
+      call MPAS_stream_list_create(list)
+
+      allocate(s1)
+      s1%name = 'stream1'
+
+      call MPAS_stream_list_insert(list, s1, ierr)
+      if (ierr /= MPAS_STREAM_LIST_NOERR) then
+         err = err + 1
+      end if
+
+      call MPAS_stream_list_insert(list, s1, ierr)
+      if (ierr /= MPAS_STREAM_LIST_DUPLICATE) then
+         err = err + 1
+      end if
+      if (MPAS_stream_list_length(list) /= 1) then
+         err = err + 1
+      end if
+
+      call MPAS_stream_list_destroy(list)
+   end subroutine mpas_test_insert_duplicate_at_begin
+
+   !**************************************************************************************
+   !  Subroutine mpas_test_insert_duplicate_at_end
+   !
+   !> \brief   Test inserting a duplicate stream at the end of the list.
+   !>
+   !> \details This subroutine tests the insertion of a duplicate stream at the
+   !>          end of an MPAS stream list. It ensures that the correct error
+   !>          is returned when attempting to insert a duplicate stream.
+   !>
+   !> \param err  The error code that indicates the result of the test.
+   !
+   !--------------------------------------------------------------------------------------
+   subroutine mpas_test_insert_duplicate_at_end(err)
+      integer, intent(out) :: err
+      type(MPAS_stream_list_type), pointer :: list
+      type(MPAS_stream_list_type), pointer :: s1, s2
+      integer :: ierr
+
+      err = 0
+      call MPAS_stream_list_create(list)
+
+      allocate(s1)
+      s1%name = 'stream1'
+
+      allocate(s2)
+      s2%name = 'stream2'
+
+      call MPAS_stream_list_insert(list, s1, ierr)
+      if (ierr /= MPAS_STREAM_LIST_NOERR) then
+         err = err + 1
+      end if
+
+      call MPAS_stream_list_insert(list, s2, ierr)
+      if (ierr /= MPAS_STREAM_LIST_NOERR) then
+         err = err + 1
+      end if
+
+      call MPAS_stream_list_insert(list, s2, ierr)
+      if (ierr /= MPAS_STREAM_LIST_DUPLICATE) then
+         err = err + 1
+      end if
+      if (MPAS_stream_list_length(list) /= 2) then
+         err = err + 1
+      end if
+
+      call MPAS_stream_list_destroy(list)
+   end subroutine mpas_test_insert_duplicate_at_end
+
+   !**************************************************************************************
+   !  Subroutine mpas_test_stream_list
+   !
+   !> \brief   Core test suite for MPAS stream list routines.
+   !>
+   !> \details This subroutine runs all the test cases for the MPAS stream list
+   !>          routines, including tests for stream creation, insertion, querying,
+   !>          removal, and checking for duplicate entries. Each test case is executed
+   !>          and its result is logged with a success or failure message.
+   !>
+   !> \param err  The error code that indicates the result of the test. It accumulates
+   !>             errors from all individual test cases.
+   !
+   !--------------------------------------------------------------------------------------
+   subroutine mpas_test_stream_list(err)
+      integer, intent(out) :: err
+      integer :: test_err
+
+      err = 0
+
+      call mpas_log_write('Testing MPAS stream list routines:')
+
+      ! Test stream list creation and verify initialization.
+      call mpas_test_create_list(test_err)
+      if (test_err == 0) then
+         call mpas_log_write('   mpas_test_create_list: SUCCESS')
+      else
+         err = err + test_err
+         call mpas_log_write('   mpas_test_create_list: FAILURE')
+      end if
+
+      ! Test inserting a single stream into the list and verify correct insertion.
+      call mpas_test_insert_single(test_err)
+      if (test_err == 0) then
+         call mpas_log_write('   mpas_test_insert_single: SUCCESS')
+      else
+         err = err + test_err
+         call mpas_log_write('   mpas_test_insert_single: FAILURE')
+      end if
+
+      ! Test querying for an exact stream match and ensure correct stream is found.
+      call mpas_test_query_exact_match(test_err)
+      if (test_err == 0) then
+         call mpas_log_write('   mpas_test_query_exact_match: SUCCESS')
+      else
+         err = err + test_err
+         call mpas_log_write('   mpas_test_query_exact_match: FAILURE')
+      end if
+
+      ! Test removing streams at beginning, middle, and end of a list.
+      call mpas_test_remove_existing_streams(test_err)
+      if (test_err == 0) then
+         call mpas_log_write('   mpas_test_remove_existing_streams: SUCCESS')
+      else
+         err = err + test_err
+         call mpas_log_write('   mpas_test_remove_existing_streams: FAILURE')
+      end if
+
+      ! Test inserting a non-adjacent duplicate of the first stream added.
+      call mpas_test_insert_non_adjacent_duplicate(test_err)
+      if (test_err == 0) then
+         call mpas_log_write('   mpas_test_insert_non_adjacent_duplicate: SUCCESS')
+      else
+         err = err + test_err
+         call mpas_log_write('   mpas_test_insert_non_adjacent_duplicate: FAILURE')
+      end if
+
+      ! Test attempting to remove a non-existent stream from an empty list, expect error.
+      call mpas_test_remove_from_empty_list(test_err)
+      if (test_err == 0) then
+         call mpas_log_write('   mpas_test_remove_from_empty_list: SUCCESS')
+      else
+         err = err + test_err
+         call mpas_log_write('   mpas_test_remove_from_empty_list: FAILURE')
+      end if
+
+      ! Test attempting to remove a stream not found in the list, expect error.
+      call mpas_test_remove_not_found(test_err)
+      if (test_err == 0) then
+         call mpas_log_write('   mpas_test_remove_not_found: SUCCESS')
+      else
+         err = err + test_err
+         call mpas_log_write('   mpas_test_remove_not_found: FAILURE')
+      end if
+
+      ! Test the length of the stream list after inserting multiple streams.
+      call mpas_test_list_length(test_err)
+      if (test_err == 0) then
+         call mpas_log_write('   mpas_test_list_length: SUCCESS')
+      else
+         err = err + test_err
+         call mpas_log_write('   mpas_test_list_length: FAILURE')
+      end if
+
+      ! Test querying for a partial stream name match, ensuring no match is found.
+      call mpas_test_query_partial_match(test_err)
+      if (test_err == 0) then
+         call mpas_log_write('   mpas_test_query_partial_match: SUCCESS')
+      else
+         err = err + test_err
+         call mpas_log_write('   mpas_test_query_partial_match: FAILURE')
+      end if
+
+      ! Test inserting a duplicate stream at the beginning of the list.
+      call mpas_test_insert_duplicate_at_begin(test_err)
+      if (test_err == 0) then
+         call mpas_log_write('   mpas_test_insert_duplicate_at_begin: SUCCESS')
+      else
+         err = err + test_err
+         call mpas_log_write('   mpas_test_insert_duplicate_at_begin: FAILURE')
+      end if
+
+      ! Test inserting a duplicate stream at the end of the list.
+      call mpas_test_insert_duplicate_at_end(test_err)
+      if (test_err == 0) then
+         call mpas_log_write('   mpas_test_insert_duplicate_at_end: SUCCESS')
+      else
+         err = err + test_err
+         call mpas_log_write('   mpas_test_insert_duplicate_at_end: FAILURE')
+      end if
+   end subroutine mpas_test_stream_list
+
+end module mpas_test_core_stream_list

--- a/src/core_test/mpas_test_core_streams.F
+++ b/src/core_test/mpas_test_core_streams.F
@@ -19,7 +19,7 @@ module test_core_streams
 
    !***********************************************************************
    !
-   !  routine test_core_streams_test
+   !  routine test_read_write_real_streams
    !
    !> \brief   tests reading/writing single- and double-precision streams
    !> \author  Michael Duda
@@ -35,7 +35,7 @@ module test_core_streams
    !>  that are created by this routine.
    !
    !-----------------------------------------------------------------------
-   subroutine test_core_streams_test(domain, threadErrs, ierr)
+   subroutine test_read_write_real_streams(domain, threadErrs, ierr)
 
       use mpas_stream_manager
 
@@ -389,6 +389,171 @@ module test_core_streams
          ierr = 1
          call mpas_log_write('Error destroying ''R8_stream''.', MPAS_LOG_ERR)
          return
+      end if
+
+   end subroutine test_read_write_real_streams
+
+   !***********************************************************************
+   !  Subroutine test_remove_alarm
+   !
+   !> \brief   Tests the functionality of adding and removing alarms from
+   !>          input and output streams in the stream manager.
+   !>
+   !> \details This subroutine creates a stream, adds an alarm to both
+   !>          the stream and the clock, and verifies the correct handling
+   !>          of alarms in different scenarios. It ensures that alarms
+   !>          cannot be removed from the opposite list and can be removed
+   !>          from the correct list. The stream type (input or output)
+   !>          is passed as an argument to test both scenarios.
+   !>
+   !> \param domain      The domain object that contains the stream manager
+   !>                    and clock.
+   !> \param streamType  The type of the stream being tested (input or output).
+   !> \param ierr        The error code that indicates the result of the test.
+   !
+   !-----------------------------------------------------------------------
+   subroutine test_remove_alarm(domain, streamType, ierr)
+      use mpas_stream_manager
+      use mpas_timekeeping
+
+      implicit none
+
+      ! Arguments
+      type (domain_type), intent(inout) :: domain
+      integer, intent(in) :: streamType  ! MPAS_STREAM_INPUT or MPAS_STREAM_OUTPUT
+      integer, intent(out) :: ierr
+
+      ! Local variables
+      character(len = :), allocatable :: streamID
+      character(len = :), allocatable :: alarmID
+      character(len = :), allocatable :: fileName
+      integer :: oppositeType
+      type(MPAS_Time_type) :: alarmTime
+      integer :: err
+
+      ierr = 0
+      err = 0
+
+      ! Assign IDs and file name based on type
+      if (streamType == MPAS_STREAM_INPUT) then
+         streamID = 'test_input_alarm_stream'
+         alarmID = 'test_input_alarm'
+         fileName = 'test_input_alarm_stream.nc'
+         oppositeType = MPAS_STREAM_OUTPUT
+      else if (streamType == MPAS_STREAM_OUTPUT) then
+         streamID = 'test_output_alarm_stream'
+         alarmID = 'test_output_alarm'
+         fileName = 'test_output_alarm_stream.nc'
+         oppositeType = MPAS_STREAM_INPUT
+      else
+         call mpas_log_write('Invalid stream type passed to test_remove_alarm.', MPAS_LOG_ERR)
+         ierr = 1
+         return
+      end if
+
+      ! Create the stream
+      call MPAS_stream_mgr_create_stream(domain % streamManager, streamID, streamType, fileName, &
+            realPrecision = MPAS_IO_SINGLE_PRECISION, &
+            clobberMode = MPAS_STREAM_CLOBBER_TRUNCATE, &
+            ierr = err)
+      if (err /= MPAS_STREAM_MGR_NOERR) then
+         call mpas_log_write('Error creating stream.', MPAS_LOG_ERR)
+         ierr = ierr + abs(err)
+      end if
+
+      ! Add alarm to the clock
+      call mpas_add_clock_alarm(domain % clock, alarmID, alarmTime, ierr = err)
+      if (err /= 0) then
+         call mpas_log_write('Error adding alarm to clock.', MPAS_LOG_ERR)
+         ierr = ierr + abs(err)
+      end if
+
+      ! Add alarm to the stream
+      call MPAS_stream_mgr_add_alarm(domain % streamManager, streamID, alarmID, streamType, ierr = err)
+      if (err /= MPAS_STREAM_MGR_NOERR) then
+         call mpas_log_write('Error adding alarm to stream.', MPAS_LOG_ERR)
+         ierr = ierr + abs(err)
+      end if
+
+      ! Try removing from opposite list — should fail
+      call MPAS_stream_mgr_remove_alarm(domain % streamManager, streamID, alarmID, oppositeType, ierr = err)
+      if (err /= MPAS_STREAM_MGR_ERROR) then
+         if (streamType == MPAS_STREAM_INPUT) then
+            call mpas_log_write('Expected error when removing input alarm from output alarm list.', MPAS_LOG_ERR)
+         else
+            call mpas_log_write('Expected error when removing output alarm from input alarm list.', MPAS_LOG_ERR)
+         end if
+         err = 1
+         ierr = ierr + abs(err)
+      end if
+
+      ! Remove from correct list — should succeed
+      call MPAS_stream_mgr_remove_alarm(domain % streamManager, streamID, alarmID, streamType, ierr = err)
+      if (err /= MPAS_STREAM_MGR_NOERR) then
+         call mpas_log_write('Error removing alarm from stream.', MPAS_LOG_ERR)
+         ierr = ierr + abs(err)
+      end if
+
+   end subroutine test_remove_alarm
+
+   !***********************************************************************
+   !  Subroutine test_core_streams_test
+   !
+   !> \brief   Core test suite for stream I/O and alarm management in MPAS.
+   !>
+   !> \details This subroutine tests the functionality of reading/writing
+   !>          real-valued streams and managing alarms in streams. It calls
+   !>          individual tests for stream I/O operations and for adding/removing
+   !>          alarms from input and output streams. The results of each test
+   !>          are logged with a success or failure message.
+   !>
+   !> \param domain      The domain object that contains the stream manager
+   !>                    and clock.
+   !> \param threadErrs  An array to store any errors encountered during
+   !>                    the test.
+   !> \param ierr        The error code that indicates the result of the test.
+   !
+   !-----------------------------------------------------------------------
+   subroutine test_core_streams_test(domain, threadErrs, ierr)
+
+      use mpas_log
+
+      implicit none
+
+      type (domain_type), intent(inout) :: domain
+      integer, dimension(:), intent(out) :: threadErrs
+      integer, intent(out) :: ierr
+
+      integer :: test_status
+
+      ierr = 0
+      test_status = 0
+
+      call mpas_log_write('Testing reading/writing real-valued streams')
+      call test_read_write_real_streams(domain, threadErrs, test_status)
+      if (test_status == 0) then
+         call mpas_log_write('Stream I/O tests: SUCCESS')
+      else
+         call mpas_log_write('Stream I/O tests: FAILURE', MPAS_LOG_ERR)
+         ierr = ierr + abs(test_status)
+      end if
+
+      call mpas_log_write('Testing removing an output alarm from a stream.')
+      call test_remove_alarm(domain, MPAS_STREAM_OUTPUT, test_status)
+      if (test_status == 0) then
+         call mpas_log_write('Removing output alarm test: SUCCESS')
+      else
+         call mpas_log_write('Removing output alarm test: FAILURE', MPAS_LOG_ERR)
+         ierr = ierr + abs(test_status)
+      end if
+
+      call mpas_log_write('Testing removing an input alarm from a stream.')
+      call test_remove_alarm(domain, MPAS_STREAM_INPUT, test_status)
+      if (test_status == 0) then
+         call mpas_log_write('Removing input alarm test: SUCCESS')
+      else
+         call mpas_log_write('Removing input alarm test: FAILURE', MPAS_LOG_ERR)
+         ierr = ierr + abs(test_status)
       end if
 
    end subroutine test_core_streams_test

--- a/src/framework/CMakeLists.txt
+++ b/src/framework/CMakeLists.txt
@@ -69,6 +69,9 @@ if (MPAS_PROFILE)
     list(APPEND FRAMEWORK_LINK_LIBRARIES GPTL::GPTL)
 endif ()
 target_link_libraries(framework PUBLIC ${FRAMEWORK_LINK_LIBRARIES})
+target_include_directories(framework INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:include/framework>)
 
 install(TARGETS framework EXPORT ${PROJECT_NAME}Exports
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/src/framework/mpas_dmpar.F
+++ b/src/framework/mpas_dmpar.F
@@ -1378,7 +1378,7 @@ include 'mpif.h'
       integer, intent(in) :: noutlist !< Input: Number integers to receive
       integer, dimension(nprocs), intent(in) :: displs !< Input: Displacement in sending array
       integer, dimension(nprocs), intent(in) :: counts !< Input: Number of integers to distribute
-      integer, dimension(:), pointer :: inlist !< Input: List of integers to send
+      integer, dimension(:), intent(in) :: inlist !< Input: List of integers to send
       integer, dimension(noutlist), intent(inout) :: outlist !< Output: List of received integers
 
 #ifdef _MPI

--- a/src/framework/mpas_framework.F
+++ b/src/framework/mpas_framework.F
@@ -26,6 +26,10 @@ module mpas_framework
    use mpas_io
    use mpas_io_units
    use mpas_block_decomp
+#ifdef MPAS_USE_MUSICA
+   use musica_micm, only : get_micm_version
+   use musica_util, only : string_t
+#endif
 
    private :: report_acc_devices
 
@@ -207,7 +211,9 @@ module mpas_framework
       implicit none
 
       type (domain_type), pointer :: domain
-
+#ifdef MPAS_USE_MUSICA
+      type(string_t) :: micm_version
+#endif
 
       call mpas_log_write('')
       call mpas_log_write('Output from ''git describe --dirty'': '//trim(domain % core % git_version))
@@ -248,6 +254,14 @@ module mpas_framework
 #endif
 #else
                           'SMIOL')
+#endif
+      call mpas_log_write('  MUSICA support: ' // &
+#ifdef MPAS_USE_MUSICA
+                          'yes')
+      micm_version = get_micm_version()
+      call mpas_log_write('  - MICM version: '//trim(micm_version % value_))
+#else
+                          'no')
 #endif
       call mpas_log_write('')
 

--- a/src/framework/mpas_halo_interface.inc
+++ b/src/framework/mpas_halo_interface.inc
@@ -1,0 +1,15 @@
+   !
+   ! Abstract interface for routine used to communicate halos of fields
+   ! in a named group
+   !
+   abstract interface
+      subroutine halo_exchange_routine(domain, halo_group, ierr)
+
+         use mpas_derived_types, only : domain_type
+
+         type (domain_type), intent(inout) :: domain
+         character(len=*), intent(in) :: halo_group
+         integer, intent(out), optional :: ierr
+
+      end subroutine halo_exchange_routine
+   end interface

--- a/src/framework/mpas_pool_routines.F
+++ b/src/framework/mpas_pool_routines.F
@@ -4770,6 +4770,8 @@ module mpas_pool_routines
 
       type (mpas_pool_data_type), pointer :: mem
 
+      nullify(value)
+
       if ( present(record) ) then
          call mpas_pool_get_subpool(inPool, record, recordPool)
          mem => pool_get_member(recordPool, key, MPAS_POOL_CONFIG)
@@ -4811,6 +4813,8 @@ module mpas_pool_routines
       type (mpas_pool_type), pointer :: recordPool
 
       type (mpas_pool_data_type), pointer :: mem
+
+      nullify(value)
 
       if ( present(record) ) then
          call mpas_pool_get_subpool(inPool, record, recordPool)
@@ -4854,6 +4858,8 @@ module mpas_pool_routines
 
       type (mpas_pool_data_type), pointer :: mem
 
+      nullify(value)
+
       if ( present(record) ) then
          call mpas_pool_get_subpool(inPool, record, recordPool)
          mem => pool_get_member(recordPool, key, MPAS_POOL_CONFIG)
@@ -4896,6 +4902,8 @@ module mpas_pool_routines
       type (mpas_pool_type), pointer :: recordPool
 
       type (mpas_pool_data_type), pointer :: mem
+
+      nullify(value)
 
       if ( present(record) ) then
          call mpas_pool_get_subpool(inPool, record, recordPool)
@@ -5149,6 +5157,7 @@ module mpas_pool_routines
 
       type (mpas_pool_data_type), pointer :: mem
 
+      nullify(subPool)
 
       mem => pool_get_member(inPool, key, MPAS_POOL_SUBPOOL)
 
@@ -5228,6 +5237,7 @@ module mpas_pool_routines
 
       type (mpas_pool_data_type), pointer :: mem
 
+      nullify(package)
 
       mem => pool_get_member(inPool, key, MPAS_POOL_PACKAGE)
 

--- a/src/framework/mpas_stream_inquiry.F
+++ b/src/framework/mpas_stream_inquiry.F
@@ -249,7 +249,7 @@ contains
         call mpas_f_to_c_string(streamname, c_streamname)
 
         if (present(attname)) then
-            allocate(c_attname(len(attname)))
+            allocate(c_attname(len(attname)+1))
             call mpas_f_to_c_string(attname, c_attname)
             c_attname_ptr = c_loc(c_attname)
         else

--- a/src/framework/mpas_stream_list.F
+++ b/src/framework/mpas_stream_list.F
@@ -112,9 +112,9 @@ module mpas_stream_list
 
         if (present(ierr)) ierr = MPAS_STREAM_LIST_NOERR
 
-        nullify(stream % next)
         if (.not. associated(list % head)) then
             list % head => stream
+            nullify(stream % next)
         else
             node => list % head
             do while (associated(node))
@@ -125,6 +125,7 @@ module mpas_stream_list
                 end if
                 if (.not. associated(node % next)) then
                     node % next => stream
+                    nullify(stream % next)
                     exit
                 end if
                 node => node % next

--- a/src/framework/mpas_stream_list.F
+++ b/src/framework/mpas_stream_list.F
@@ -113,20 +113,22 @@ module mpas_stream_list
         if (present(ierr)) ierr = MPAS_STREAM_LIST_NOERR
 
         nullify(stream % next)
-
         if (.not. associated(list % head)) then
             list % head => stream
         else
             node => list % head
-            do while (associated(node % next))
+            do while (associated(node))
                 if (node % name == stream % name) then
                     if (present(ierr)) ierr = MPAS_STREAM_LIST_DUPLICATE
                     LIST_ERROR_WRITE('Found duplicate item '//trim(stream % name)//' in list.')
                     return
                 end if
+                if (.not. associated(node % next)) then
+                    node % next => stream
+                    exit
+                end if
                 node => node % next
             end do
-            node % next => stream
         end if
 
         list % nItems = list % nItems + 1

--- a/src/framework/mpas_stream_list.F
+++ b/src/framework/mpas_stream_list.F
@@ -2,8 +2,8 @@ module mpas_stream_list
 
 #define COMMA ,
 #define LIST_DEBUG_WRITE(M) ! call mpas_log_write(M)
-#define LIST_WARN_WRITE(M) call mpas_log_write( M , messageType=MPAS_LOG_WARN)
-#define LIST_ERROR_WRITE(M) call mpas_log_write( M , messageType=MPAS_LOG_ERR)
+#define LIST_WARN_WRITE(M) ! call mpas_log_write( M , messageType=MPAS_LOG_WARN)
+#define LIST_ERROR_WRITE(M) ! call mpas_log_write( M , messageType=MPAS_LOG_ERR)
 
     use mpas_kind_types, only : StrKIND
     use mpas_log

--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -1383,8 +1383,18 @@ module mpas_stream_manager
            nullify(alarmNode)
            if (direction == MPAS_STREAM_INPUT) then
                call MPAS_stream_list_remove(stream % alarmList_in, alarmID, alarmNode, ierr=ierr)
+               if (ierr /= MPAS_STREAM_LIST_NOERR) then
+                   if (present(ierr)) ierr = MPAS_STREAM_MGR_ERROR
+                   STREAM_ERROR_WRITE('Problems unlinking alarm from alarmList_in for stream: '//trim(streamID))
+                   return
+               end if
            else if (direction == MPAS_STREAM_OUTPUT) then
                call MPAS_stream_list_remove(stream % alarmList_out, alarmID, alarmNode, ierr=ierr)
+               if (ierr /= MPAS_STREAM_LIST_NOERR) then
+                   if (present(ierr)) ierr = MPAS_STREAM_MGR_ERROR
+                   STREAM_ERROR_WRITE('Problems unlinking alarm from alarmList_out for stream: '//trim(streamID))
+                   return
+               end if
            else
                if (present(ierr)) ierr = MPAS_STREAM_MGR_ERROR
                STREAM_ERROR_WRITE('Requested to remove alarm from invalid direction from stream '//trim(streamID))
@@ -1396,6 +1406,11 @@ module mpas_stream_manager
            !
            if (associated(alarmNode)) then
                call MPAS_stream_list_remove(alarmNode % xref % streamList, streamID, streamNode, ierr=ierr)
+               if (ierr /= MPAS_STREAM_LIST_NOERR) then
+                   if (present(ierr)) ierr = MPAS_STREAM_MGR_ERROR
+                   STREAM_ERROR_WRITE('Problems while removing stream from alarms streamList.')
+                   return
+               end if
            else
                if (direction == MPAS_STREAM_INPUT) then
                    STREAM_ERROR_WRITE('Input alarm '//trim(alarmID)//' does not exist on stream '//trim(streamID))
@@ -1417,9 +1432,19 @@ module mpas_stream_manager
                if (direction == MPAS_STREAM_INPUT) then
                    STREAM_ERROR_WRITE('Input alarm '//trim(alarmID)//' has no associated streams and will be deleted.')
                    call MPAS_stream_list_remove(manager % alarms_in, alarmID, alarmNode, ierr=ierr)
+                   if (ierr /= MPAS_STREAM_LIST_NOERR) then
+                       if (present(ierr)) ierr = MPAS_STREAM_MGR_ERROR
+                       STREAM_ERROR_WRITE('Problems while removing stream from list of input alarm')
+                       return
+                   end if
                else
                    STREAM_ERROR_WRITE('Output alarm '//trim(alarmID)//' has no associated streams and will be deleted.')
                    call MPAS_stream_list_remove(manager % alarms_out, alarmID, alarmNode, ierr=ierr)
+                   if (ierr /= MPAS_STREAM_LIST_NOERR) then
+                       if (present(ierr)) ierr = MPAS_STREAM_MGR_ERROR
+                       STREAM_ERROR_WRITE('Problems while removing stream from list of output alarm')
+                       return
+                   end if
                end if
            end if
         end if


### PR DESCRIPTION
This PR corrects the units designations of the gravity wave drag diagnostics variables dusfcg, dvsfcg, dtaux3d and dtauy3d as follows:

The units for the “dusfcg” and “dvsfcg” variables are currently “Pa m s^{-1}” when they actually should simply be “Pa”.  These variables represent the vertical integral of “d(tau)/dz”, which turns out to be the GWD at the surface, whose units are “Pa”.

The units for the “dtaux” and “dtauy” variables are currently “m s^{-1}” when they actually should be “m s^{-2}”.  These variables represent the vertical divergence of the horizontal GWD momentum flux ( (-1/rho) * d(tau)/dz ), where tau is the GWD momentum flux or “wave stress” (units are Pascal).

This code has not been tested as the changes are extremely minor and they do not change the model results.

