### PR TITLE
Fix units designation of GW drag diagnostic variables dusfcg, dtaux…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MPAS-v8.3.1-2.1
+MPAS-v8.3.1-2.2
 ====
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -3652,10 +3652,10 @@
                 <!-- ... PARAMETERIZATION OF GRAVITY WAVE DRAG OVER OROGRAPHY:                                          -->
                 <!-- ================================================================================================== -->
 
-		<var name="dusfcg" type="real" dimensions="nCells Time" units="Pa m s^{-1}"
+		<var name="dusfcg" type="real" dimensions="nCells Time" units="Pa"
                      description="vertically-integrated gravity wave drag over orography u-stress"/>
 
-                <var name="dvsfcg" type="real" dimensions="nCells Time" units="Pa m s^{-1}"
+                <var name="dvsfcg" type="real" dimensions="nCells Time" units="Pa"
                      description="vertically-integrated gravity wave drag over orography v-stress"/>
 
                 <var name="dusfc_ls" type="real" dimensions="nCells Time" units="Pa"
@@ -3690,10 +3690,10 @@
                      description="vertically-integrated turb orog form drag v-stress"
                      packages="ugwp_diags_stream"/>
 
-                <var name="dtaux3d" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+                <var name="dtaux3d" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
                      description="gravity wave drag over orography u-stress"/>
 
-                <var name="dtauy3d" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+                <var name="dtauy3d" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
                      description="gravity wave drag over orography v-stress"/>
 
                 <var name="dtaux3d_ls" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.3.1-2.1">
+<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.3.1-2.2">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.3.1-2.1">
+<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.3.1-2.2">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->


### PR DESCRIPTION
This PR corrects the units designations of the gravity wave drag diagnostics variables dusfcg, dvsfcg, dtaux3d and dtauy3d as follows:

The units for the “dusfcg” and “dvsfcg” variables are currently “Pa m s^{-1}” when they actually should simply be “Pa”. These variables represent the vertical integral of “d(tau)/dz”, which turns out to be the GWD at the surface, whose units are “Pa”.

The units for the “dtaux” and “dtauy” variables are currently “m s^{-1}” when they actually should be “m s^{-2}”. These variables represent the vertical divergence of the horizontal GWD momentum flux ( (-1/rho) * d(tau)/dz ), where tau is the
GWD momentum flux or “wave stress” (units are Pascal).

This code has not been tested as the changes are extremely minor and they do not change the model results.