### PR TITLE
Fix errant comment in core_init_atmosphere/Registry.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MPAS-v8.3.1-2.6
+MPAS-v8.3.1-2.7
 ====
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -44,11 +44,11 @@
                      description="The number of prescribed pressure levels in the climatological GOCART data set"/>
                 <dim name="nMonths" definition="namelist:config_months"
                      description="The number of months in a year"/>
-		<dim name="nlcat" definition="namelist:config_landuse_data" calculation='20 + 4 * merge(1,0,config_landuse_data(1:4)=="USGS")'
+                <dim name="nlcat" definition="namelist:config_landuse_data" calculation='20 + 4 * merge(1,0,config_landuse_data(1:4)=="USGS")'
                      description="The number of landuse categories used in the land surface model"/>
                 <dim name="nscat" definition="16" definition:"namelist:config_nsoilcat"
                      description="The number of soil categories used in the land surface model"/>
-	        <dim name="nVegOpt" definition="namelist:config_nvegopt"
+                <dim name="nVegOpt" definition="namelist:config_nvegopt"
                      description="The number of vegetation fraction option: 1 - clim, 2 - real-time"/>
         </dims>
 

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -44,7 +44,6 @@
                      description="The number of prescribed pressure levels in the climatological GOCART data set"/>
                 <dim name="nMonths" definition="namelist:config_months"
                      description="The number of months in a year"/>
-                     description="The number of soil categories used in the land surface model"/>
 		<dim name="nlcat" definition="namelist:config_landuse_data" calculation='20 + 4 * merge(1,0,config_landuse_data(1:4)=="USGS")'
                      description="The number of landuse categories used in the land surface model"/>
                 <dim name="nscat" definition="16" definition:"namelist:config_nsoilcat"


### PR DESCRIPTION
As I began preparing documentation on how this repo differs from the authoritative MPAS-Dev/MPAS-Model, I found that the core_init_atmosphere/Registry.xml file has an errant comment at the end of the nMonths dimension definition. I don't think this is causing any issues, but I think it's good practice to remove it.

### Priority Reviewers

No preference - this is likely small and non-technical enough that @jderrico-noaa could be the sole reviewer prior to merge.