### PR TITLE
Remove duplicate ugwp package definitions in core_atmosphere/Registry.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MPAS-v8.3.1-2.9
+MPAS-v8.3.1-2.10
 ====
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MPAS-v8.3.1-2.5
+MPAS-v8.3.1-2.7
 ====
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1266,47 +1266,6 @@
                         <var_array name="lbc_scalars" />
                 </stream>
 
-                <stream name="ugwp_oro_data_in"
-                        type="input"
-                        filename_template="x1.40962.ugwp_oro_data.nc"
-                        input_interval="initial_only"
-                        immutable="true"
-                        packages="ugwp_orog_stream">
-
-                        <var name="var2dls"/>
-                        <var name="conls"/>
-                        <var name="oa1ls"/>
-                        <var name="oa2ls"/>
-                        <var name="oa3ls"/>
-                        <var name="oa4ls"/>
-                        <var name="ol1ls"/>
-                        <var name="ol2ls"/>
-                        <var name="ol3ls"/>
-                        <var name="ol4ls"/>
-                        <var name="var2dss"/>
-                        <var name="conss"/>
-                        <var name="oa1ss"/>
-                        <var name="oa2ss"/>
-                        <var name="oa3ss"/>
-                        <var name="oa4ss"/>
-                        <var name="ol1ss"/>
-                        <var name="ol2ss"/>
-                        <var name="ol3ss"/>
-                        <var name="ol4ss"/>
-                </stream>
-
-                <stream name="ugwp_ngw_in"
-                        type="input"
-                        filename_template="ugwp_limb_tau.nc"
-                        input_interval="initial_only"
-                        immutable="true"
-                        packages="ugwp_ngw_stream">
-
-                        <var name="LATS"/>
-                        <var name="DAYS"/>
-                        <var name="ABSMF"/>
-                </stream>
-
 #ifdef DO_PHYSICS
                 <stream name="ugwp_oro_data_in"
                         type="input"


### PR DESCRIPTION
This PR removes duplicate/redundant definitions of packages _ugwp_oro_data_in_ and _ugwp_ngw_in_ in 'src/core_atmosphere/Registry.xml'.  It addresses [Issue #194](https://github.com/ufs-community/MPAS-Model/issues/194#issuecomment-3608908970).

The PR does not change the model results.