### PR TITLE
update derecho spack-stack to version 1.9.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MPAS-v8.3.1-2.7
+MPAS-v8.3.1-2.8
 ====
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for

--- a/modulefiles/mpas/derecho.intel.lua
+++ b/modulefiles/mpas/derecho.intel.lua
@@ -3,7 +3,7 @@ This module loads libraries for MPAS-Model
 ]])
 
 --whatis([===[Loads libraries for MPAS-Model ]===])
-prepend_path("MODULEPATH", '/glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-1.9.3/envs/rebuild-ue-oneapi-2024.2.1/install/modulefiles/Core')
+prepend_path("MODULEPATH", '/glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-1.9.3/envs/ue-oneapi-2024.2.1/install/modulefiles/Core')
 
 load("stack-oneapi/2024.2.1")
 load("stack-cray-mpich/8.1.29")

--- a/modulefiles/mpas/derecho.intel.lua
+++ b/modulefiles/mpas/derecho.intel.lua
@@ -3,24 +3,21 @@ This module loads libraries for MPAS-Model
 ]])
 
 --whatis([===[Loads libraries for MPAS-Model ]===])
-prepend_path("MODULEPATH", "/glade/work/epicufsrt/contrib/spack-stack/derecho/modulefiles")
-prepend_path("MODULEPATH", "/glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-1.8.0/envs/ue-intel-2021.10.0/install/modulefiles/Core")
+prepend_path("MODULEPATH", '/glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-1.9.3/envs/rebuild-ue-oneapi-2024.2.1/install/modulefiles/Core')
 
-load("stack-intel/2021.10.0")
-load("stack-cray-mpich/8.1.25")
-
+load("stack-oneapi/2024.2.1")
+load("stack-cray-mpich/8.1.29")
 load("cmake/3.27.9")
 load("parallel-netcdf/1.12.3")
 load("parallelio/2.6.2")
 
-setenv("CMAKE_C_COMPILER", "mpicc")
-setenv("CMAKE_CXX_COMPILER", "mpic++")
-setenv("CMAKE_Fortran_COMPILER", "mpifort")
-
 if mode() == "load" then
-  --setenv("PNETCDF", os.getenv("PARALLEL_NETCDF_ROOT"))
   setenv("PNETCDF", os.getenv("parallel_netcdf_ROOT"))
 end
 if mode() == "unload" then
   unsetenv("PNETCDF")
 end
+
+setenv("CMAKE_C_COMPILER", "mpicc")
+setenv("CMAKE_CXX_COMPILER", "mpic++")
+setenv("CMAKE_Fortran_COMPILER", "mpifort")


### PR DESCRIPTION
Most rrfs components have been upgraded to spack-stack-1.9.3.
This PR updates the derecho modulefile to use spack-stack-1.9.3 as well for consistency.

### Priority Reviewers
  - @clark-evans
  - @dustinswales 
