### PR TITLE
Implement equation of time in RRTMG shortwave radiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MPAS-v8.3.1-2.11
+MPAS-v8.3.1-2.12
 ====
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
@@ -1023,6 +1023,7 @@
               swdnt      = swdnt_p       , swdntc   = swdntc_p    , swupb      = swupb_p      , &
               swupbc     = swupbc_p      , swdnb    = swdnb_p     , swdnbc     = swdnbc_p     , &
               swddir     = swddir_p      , swddni   = swddni_p    , swddif     = swddif_p     , &
+              julian     = curr_julday   ,                                                      &
               ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,           &
               ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,           &
               its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte             &

--- a/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_sw.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_sw.F
@@ -10036,7 +10036,7 @@ CONTAINS
                        swupt,swuptc,swdnt,swdntc,                      &
                        swupb,swupbc,swdnb,swdnbc,                      &
                        swupflx, swupflxc, swdnflx, swdnflxc,           &
-                       swddir,swddni,swddif,                           &
+                       swddir,swddni,swddif,julian,                    &
                        ids,ide, jds,jde, kds,kde,                      & 
                        ims,ime, jms,jme, kms,kme,                      &
                        its,ite, jts,jte, kts,kte                       &
@@ -10054,6 +10054,7 @@ CONTAINS
  integer,intent(in):: icloud,cldovrlp,idcor
  integer,intent(in):: has_reqc,has_reqi,has_reqs
  integer,intent(in),optional:: o3input
+ real,intent(in):: julian
 
  real,intent(in):: radt,degrad,xtime,declin,solcon,gmt
  real,intent(in),dimension(ims:ime,jms:jme):: xlat,xlong
@@ -10101,6 +10102,7 @@ CONTAINS
  integer:: i,j,k,n
 
  real:: coszrs,xt24,tloctm,hrang,xxlat,adjes,scon
+ real:: da,eot
  real:: ro,dz
  real:: corr
  real:: gliqwp,gicewp,gsnowp,gravmks
@@ -10197,9 +10199,14 @@ CONTAINS
 
        !--- calculate the cosine of the solar zenith angle at the current time step to determine if the sun is
        !    above or below the horizon (xt24 is the fractional part of simulation days plus half of radt in 
-       !    units of minutes, julian is in days, and radt is in minutes). do not call rrtmg_sw is night-time:
+       !    units of minutes, julian is in days, and radt is in minutes). eot (equation of time) is a correction
+       !    of mean solar time due to the difference between that time and the apparent solar time. 
+       !    do not call rrtmg_sw is night-time:
        dorrsw = .true.
-       xt24 = mod(xtime+radt*0.5,1440.)
+       da=6.2831853071795862*(julian-1.)/365.
+       eot=(0.000075+0.001868*cos(da)-0.032077*sin(da) &
+            -0.014615*cos(2*da)-0.04089*sin(2*da))*(229.18)
+       xt24 = mod(xtime+radt*0.5,1440.)+eot
        tloctm = gmt + xt24/60. + xlong(i,j)/15.
        hrang = 15. * (tloctm-12.) * degrad
        xxlat = xlat(i,j) * degrad

--- a/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_sw.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_sw.F
@@ -10201,6 +10201,7 @@ CONTAINS
        !    above or below the horizon (xt24 is the fractional part of simulation days plus half of radt in 
        !    units of minutes, julian is in days, and radt is in minutes). eot (equation of time) is a correction
        !    of mean solar time due to the difference between that time and the apparent solar time. 
+       !    eot is based on the second equation at https://gml.noaa.gov/grad/solcalc/solareqns.PDF
        !    do not call rrtmg_sw is night-time:
        dorrsw = .true.
        da=6.2831853071795862*(julian-1.)/365.


### PR DESCRIPTION
This PR implements the equation of time shortwave radiation correction in the RRTMG shortwave radiation parameterization. It is based on MPAS-Dev/MPAS-Model PR #1172 (https://github.com/MPAS-Dev/MPAS-Model/pull/1172). This is expected to correct for the ~15-min insolation time biases seen within our real-time MPAS forecasts over the last 15 months.

I expect this to be answer changing, as it affects the incident shortwave radiation. The regression tests indicate small differences in forecast output at all forecast times (12, 24, 36, 48, 60 min).

### Priority Reviewers

* Please list the developers/collaborators you'd like to prioritize for review
  - @joeolson42 
  - @AndersJensen-NOAA 
