### PR TITLE
Update ubuntu Intel CI

### DIFF
--- a/.github/workflows/build_mpas_intel.yml
+++ b/.github/workflows/build_mpas_intel.yml
@@ -1,6 +1,6 @@
 name: Build (Intel) MPAS Standalone
 
-on: [pull_request,workflow_dispatch]
+on: [push,pull_request,workflow_dispatch]
 
 jobs:
   build_mpas_intel:

--- a/.github/workflows/build_mpas_intel.yml
+++ b/.github/workflows/build_mpas_intel.yml
@@ -1,6 +1,6 @@
 name: Build (Intel) MPAS Standalone
 
-on: [push,pull_request,workflow_dispatch]
+on: [pull_request,workflow_dispatch]
 
 jobs:
   build_mpas_intel:

--- a/.github/workflows/build_mpas_intel.yml
+++ b/.github/workflows/build_mpas_intel.yml
@@ -36,7 +36,7 @@ jobs:
         echo "ls -l src/core_atmosphere/physics/physics_mmm"
 
     - name: "Install Intel compilers & MPI"
-      uses: dustinswales/ci-install-intel-toolkit@ubuntu20p04
+      uses: NOAA-EMC/ci-install-intel-toolkit@ufs-community-mpas-ci-v1.0
       with:
         install-mpi: true
 

--- a/.github/workflows/build_mpas_intel.yml
+++ b/.github/workflows/build_mpas_intel.yml
@@ -36,7 +36,7 @@ jobs:
         echo "ls -l src/core_atmosphere/physics/physics_mmm"
 
     - name: "Install Intel compilers & MPI"
-      uses: NOAA-EMC/ci-install-intel-toolkit@develop
+      uses: NOAA-EMC/ci-install-intel-toolkit@ufs-community-mpas-ci-v2.0
       with:
         install-mpi: true
         install-oneapi: false

--- a/.github/workflows/build_mpas_intel.yml
+++ b/.github/workflows/build_mpas_intel.yml
@@ -1,6 +1,6 @@
 name: Build (Intel) MPAS Standalone
 
-on: [push, pull_request,workflow_dispatch]
+on: [pull_request,workflow_dispatch]
 
 jobs:
   build_mpas_intel:

--- a/.github/workflows/build_mpas_intel.yml
+++ b/.github/workflows/build_mpas_intel.yml
@@ -6,7 +6,7 @@ jobs:
   build_mpas_intel:
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false  # Disable fail-fast
       matrix:
@@ -36,7 +36,7 @@ jobs:
         echo "ls -l src/core_atmosphere/physics/physics_mmm"
 
     - name: "Install Intel compilers & MPI"
-      uses: NOAA-EMC/ci-install-intel-toolkit@develop
+      uses: dustinswales/ci-install-intel-toolkit@ubuntu20p04
       with:
         install-mpi: true
 

--- a/.github/workflows/build_mpas_intel.yml
+++ b/.github/workflows/build_mpas_intel.yml
@@ -1,6 +1,6 @@
 name: Build (Intel) MPAS Standalone
 
-on: [pull_request,workflow_dispatch]
+on: [push, pull_request,workflow_dispatch]
 
 jobs:
   build_mpas_intel:

--- a/.github/workflows/build_mpas_intel.yml
+++ b/.github/workflows/build_mpas_intel.yml
@@ -6,7 +6,7 @@ jobs:
   build_mpas_intel:
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false  # Disable fail-fast
       matrix:

--- a/.github/workflows/build_mpas_intel.yml
+++ b/.github/workflows/build_mpas_intel.yml
@@ -6,7 +6,7 @@ jobs:
   build_mpas_intel:
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false  # Disable fail-fast
       matrix:
@@ -36,9 +36,11 @@ jobs:
         echo "ls -l src/core_atmosphere/physics/physics_mmm"
 
     - name: "Install Intel compilers & MPI"
-      uses: NOAA-EMC/ci-install-intel-toolkit@ufs-community-mpas-ci-v1.0
+      uses: NOAA-EMC/ci-install-intel-toolkit@develop
       with:
         install-mpi: true
+        install-oneapi: false
+        mpi-wrapper-setup: classic
 
     - name: Cache Intel
       id: cache-INTEL

--- a/.github/workflows/build_mpas_intel.yml
+++ b/.github/workflows/build_mpas_intel.yml
@@ -6,7 +6,7 @@ jobs:
   build_mpas_intel:
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false  # Disable fail-fast
       matrix:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MPAS-v8.3.1-2.10
+MPAS-v8.3.1-2.11
 ====
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for


### PR DESCRIPTION
This change updates the Intel build tests to use ubuntu-latest and incorporates new advancements made in [NOAA-EMC/ci-install-intel-toolkit](https://github.com/NOAA-EMC/ci-install-intel-toolkit)

Previously, our tests were always pointing to the HEAD of develop in [NOAA-EMC/ci-install-intel-toolkit](https://github.com/NOAA-EMC/ci-install-intel-toolkit). This caused problems if/when NOAA-EMC/ci-install-intel-toolkit was updated. This was an oversight on my end when creating the scripts.

With this PR the tests now point to stable [tags](https://github.com/NOAA-EMC/ci-install-intel-toolkit/tags).

Thanks to @AlexanderRichert-NOAA for creating these tags and his help getting our tests working again.

This addresses #205 

### Priority Reviewers
@clark-evans
