### PR TITLE
hotfix to the build failure using `make -j8` with spack-stack 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MPAS-v8.3.1-2.17
+MPAS-v8.3.1-2.18
 ====
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for

--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -73,7 +73,7 @@ core_SMOKE: core_physics_init
 core_mynnedmf: core_physics_init core_physics_mmm
 	(cd physics_noaa/MYNN-EDMF; cp ./MPAS/Makefile .; cp ./MPAS/module_bl_mynnedmf_driver.F90 .; cp ./MPAS/module_bl_mynnedmf_common.F90 .; $(MAKE) all)
 
-core_mynnsfc:
+core_mynnsfc: core_physics_init
 	(cd physics_noaa/MYNN-SFC; cp ./MPAS/Makefile .; cp ./MPAS/module_sf_mynnsfc_driver.F90 .; cp ./MPAS/module_sf_mynnsfc_common.F90 .; $(MAKE) all)
 
 core_RUCLSM: core_physics_init core_physics_mmm
@@ -88,7 +88,7 @@ core_UGWP: core_physics_init
 core_physics_wrf: core_physics_init core_physics_mmm core_UGWP
 	(cd physics_wrf; $(MAKE) all COREDEF="$(COREDEF)")
 
-core_physics_noahmp:
+core_physics_noahmp: core_physics_init
 	(cd physics_noahmp/utility; $(MAKE) all COREDEF="$(COREDEF)")
 	(cd physics_noahmp/src; $(MAKE) all COREDEF="$(COREDEF)")
 	(cd physics_noahmp/drivers/mpas; $(MAKE) all COREDEF="$(COREDEF)")


### PR DESCRIPTION
This PR adds the `core_physics_init` dependency for `core_mynnsfc` and `core_physics_noahmp` in `src/core_atmosphere/physics/Makefile` to fix the build failure using `make -j8` with spack-stack.

Resolve issue #220 

### Priority Reviewers
- @clark-evans
- @dustinswales 
