### PR TITLE
hotfix - enable CMake to checkout frozen references for physics_mmm and UGWP

### DIFF
--- a/src/core_atmosphere/CMakeLists.txt
+++ b/src/core_atmosphere/CMakeLists.txt
@@ -138,7 +138,7 @@ set(ATMOSPHERE_CORE_PHYSICS_SMOKE_SOURCES
 list(TRANSFORM ATMOSPHERE_CORE_PHYSICS_SMOKE_SOURCES PREPEND physics/physics_noaa/SMOKE/)
 
 set(ATMOSPHERE_CORE_PHYSICS_MMM_DIR ${CMAKE_CURRENT_SOURCE_DIR}/physics/physics_mmm)
-
+set(PHYSICS_MMM_REF "20250616-MPASv8.3")
 if(NOT EXISTS ${ATMOSPHERE_CORE_PHYSICS_MMM_DIR})
     set(PHYSICS_MMM_REPO_URL "https://github.com/NCAR/MMM-physics")
     execute_process(COMMAND git clone ${PHYSICS_MMM_REPO_URL} ${ATMOSPHERE_CORE_PHYSICS_MMM_DIR}
@@ -148,9 +148,19 @@ if(NOT EXISTS ${ATMOSPHERE_CORE_PHYSICS_MMM_DIR})
     if(NOT GIT_CLONE_RESULT EQUAL 0)
         message(FATAL_ERROR "Git clone failed with error: ${GIT_CLONE_ERROR}")
     endif()
-
+    # Checkout a specific tag or commit
+    execute_process(COMMAND git checkout ${PHYSICS_MMM_REF}
+                    WORKING_DIRECTORY ${ATMOSPHERE_CORE_PHYSICS_MMM_DIR}
+                    RESULT_VARIABLE GIT_CHECKOUT_RESULT
+                    OUTPUT_VARIABLE GIT_CHECKOUT_OUTPUT
+                    ERROR_VARIABLE GIT_CHECKOUT_ERROR)
+    if(NOT GIT_CHECKOUT_RESULT EQUAL 0)
+        message(WARNING
+                "Failed to checkout ${PHYSICS_MMM_REF}, using default branch. "
+                "git error: ${GIT_CHECKOUT_ERROR}")
+    endif()
 else()
-    message(STATUS "Directory ${DIR_TO_CHECK} already exists, skipping clone")
+    message(STATUS "Directory ${ATMOSPHERE_CORE_PHYSICS_MMM_DIR} already exists, skipping clone")
 endif()
 
 set(ATMOSPHERE_CORE_PHYSICS_MMM_SOURCES
@@ -171,7 +181,7 @@ set(ATMOSPHERE_CORE_PHYSICS_MMM_SOURCES
 list(TRANSFORM ATMOSPHERE_CORE_PHYSICS_MMM_SOURCES PREPEND physics/physics_mmm/)
 
 set(ATMOSPHERE_CORE_PHYSICS_UGWP_DIR ${CMAKE_CURRENT_SOURCE_DIR}/physics/physics_noaa/UGWP)
-
+set(PHYSICS_UGWP_REF "MPAS_20241223")
 if(NOT EXISTS ${ATMOSPHERE_CORE_PHYSICS_UGWP_DIR})
     set(PHYSICS_UGWP_REPO_URL "https://github.com/NOAA-GSL/UGWP.git")
     execute_process(COMMAND git clone ${PHYSICS_UGWP_REPO_URL} ${ATMOSPHERE_CORE_PHYSICS_UGWP_DIR}
@@ -181,9 +191,19 @@ if(NOT EXISTS ${ATMOSPHERE_CORE_PHYSICS_UGWP_DIR})
     if(NOT GIT_CLONE_RESULT EQUAL 0)
         message(FATAL_ERROR "Git clone failed with error: ${GIT_CLONE_ERROR}")
     endif()
-
+    # Checkout a specific tag or commit
+    execute_process(COMMAND git checkout ${PHYSICS_UGWP_REF}
+                    WORKING_DIRECTORY ${ATMOSPHERE_CORE_PHYSICS_UGWP_DIR}
+                    RESULT_VARIABLE GIT_CHECKOUT_RESULT
+                    OUTPUT_VARIABLE GIT_CHECKOUT_OUTPUT
+                    ERROR_VARIABLE GIT_CHECKOUT_ERROR)
+    if(NOT GIT_CHECKOUT_RESULT EQUAL 0)
+        message(WARNING
+                "Failed to checkout ${PHYSICS_UGWP_REF} (exit code ${GIT_CHECKOUT_RESULT}); "
+                "stdout: ${GIT_CHECKOUT_OUTPUT}; stderr: ${GIT_CHECKOUT_ERROR}. Using default branch.")
+    endif()
 else()
-    message(STATUS "Directory ${DIR_TO_CHECK} already exists, skipping clone")
+    message(STATUS "Directory ${ATMOSPHERE_CORE_PHYSICS_UGWP_DIR} already exists, skipping clone")
 endif()
 
 set(ATMOSPHERE_CORE_PHYSICS_UGWP_SOURCES

--- a/src/core_atmosphere/CMakeLists.txt
+++ b/src/core_atmosphere/CMakeLists.txt
@@ -138,7 +138,18 @@ set(ATMOSPHERE_CORE_PHYSICS_SMOKE_SOURCES
 list(TRANSFORM ATMOSPHERE_CORE_PHYSICS_SMOKE_SOURCES PREPEND physics/physics_noaa/SMOKE/)
 
 set(ATMOSPHERE_CORE_PHYSICS_MMM_DIR ${CMAKE_CURRENT_SOURCE_DIR}/physics/physics_mmm)
-set(PHYSICS_MMM_REF "20250616-MPASv8.3")
+
+# Read PHYSICS_MMM_REF from Externals.cfg [MMM-physics] section
+file(READ ${CMAKE_CURRENT_SOURCE_DIR}/Externals.cfg EXTERNALS_CFG_CONTENT)
+string(REGEX MATCH "\\[MMM-physics\\][^\[]*tag[ \t]*=[ \t]*([^\r\n]+)" _MMM_MATCH "${EXTERNALS_CFG_CONTENT}")
+if(_MMM_MATCH)
+    set(PHYSICS_MMM_REF "${CMAKE_MATCH_1}")
+    string(STRIP "${PHYSICS_MMM_REF}" PHYSICS_MMM_REF)
+    message(STATUS "Read MMM-physics tag from Externals.cfg: ${PHYSICS_MMM_REF}")
+else()
+    message(FATAL_ERROR "Could not find MMM-physics tag in Externals.cfg")
+endif()
+
 if(NOT EXISTS ${ATMOSPHERE_CORE_PHYSICS_MMM_DIR})
     set(PHYSICS_MMM_REPO_URL "https://github.com/NCAR/MMM-physics")
     execute_process(COMMAND git clone ${PHYSICS_MMM_REPO_URL} ${ATMOSPHERE_CORE_PHYSICS_MMM_DIR}
@@ -181,7 +192,17 @@ set(ATMOSPHERE_CORE_PHYSICS_MMM_SOURCES
 list(TRANSFORM ATMOSPHERE_CORE_PHYSICS_MMM_SOURCES PREPEND physics/physics_mmm/)
 
 set(ATMOSPHERE_CORE_PHYSICS_UGWP_DIR ${CMAKE_CURRENT_SOURCE_DIR}/physics/physics_noaa/UGWP)
-set(PHYSICS_UGWP_REF "MPAS_20241223")
+
+# Read PHYSICS_UGWP_REF from Externals.cfg [GSL_UGWP] section
+string(REGEX MATCH "\\[GSL_UGWP\\][^\[]*tag[ \t]*=[ \t]*([^\r\n]+)" _UGWP_MATCH "${EXTERNALS_CFG_CONTENT}")
+if(_UGWP_MATCH)
+    set(PHYSICS_UGWP_REF "${CMAKE_MATCH_1}")
+    string(STRIP "${PHYSICS_UGWP_REF}" PHYSICS_UGWP_REF)
+    message(STATUS "Read GSL_UGWP tag from Externals.cfg: ${PHYSICS_UGWP_REF}")
+else()
+    message(FATAL_ERROR "Could not find GSL_UGWP tag in Externals.cfg")
+endif()
+
 if(NOT EXISTS ${ATMOSPHERE_CORE_PHYSICS_UGWP_DIR})
     set(PHYSICS_UGWP_REPO_URL "https://github.com/NOAA-GSL/UGWP.git")
     execute_process(COMMAND git clone ${PHYSICS_UGWP_REPO_URL} ${ATMOSPHERE_CORE_PHYSICS_UGWP_DIR}


### PR DESCRIPTION
As discussed in PR #230 , `CMake` always check out the latest branch of `physics_mmm` and `UGWP`.
Apparently some recent changes in `physics_mmm` break the CMake build system as reported in #228 

The expected good solution will be that we use `git submodule` universally to manage all MPAS-Model submodules and retire all other nonstandard methods. But it is uncertain when this will happen.

Before that, this PR provides a hotfix on `src/core_atmosphere/CMakeLists.txt` to enable it to checkout frozen references for `physics_mmm` and `UGWP` so that we can compile MPAS-Model successfully using CMake.

### Mandatory Questions
* Does this PR include any additions or changes to external inputs (e.g., microphysics lookup tables, static data for gravity-wave drag -- things like that)?
  - no
* Does this PR require updating one or more baselines for the CI tests? If so, what?
  - no

### Priority Reviewers
- @clark-evans 
- @dustinswales 
