### PR TITLE
NoahMP ten-layer configuration changes

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_initialize_real.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_initialize_real.F
@@ -321,6 +321,9 @@
  !case('ruc')
  !  if(config_nsoillevels .ne. 9) &
  !     call physics_error_fatal('RUC lsm uses only 9 soil layers currently. Correct config_nsoillevels.')
+ !case('noahmp')
+ !  if(config_nsoillevels .ne. 10) &
+ !     call physics_error_fatal('This version of Noah-MP lsm uses 10 soil layers. Correct config_nsoillevels.')
  !end select
 
  selectcase (config_nsoillevels)
@@ -376,6 +379,38 @@
      dzs(nSoilLevels,iCell) = zs2(nSoilLevels) - zs2(nSoilLevels-1) 
    enddo
    deallocate(zs2)
+
+ case( 10 )
+ do iCell = 1, nCellsSolve
+    iSoil = 1
+    zs_fg(iSoil,iCell) = 0.5_RKIND * dzs_fg(iSoil,iCell)
+    do iSoil = 2, nFGSoilLevels
+       zs_fg(iSoil,iCell) = zs_fg(iSoil-1,iCell)        &
+                          + 0.5_RKIND * dzs_fg(iSoil-1,iCell) &
+                          + 0.5_RKIND * dzs_fg(iSoil,iCell)
+    enddo
+ enddo
+
+ do iCell = 1, nCellsSolve
+    dzs(1,iCell)  = 0.05_RKIND
+    dzs(2,iCell)  = 0.10_RKIND
+    dzs(3,iCell)  = 0.10_RKIND
+    dzs(4,iCell)  = 0.10_RKIND
+    dzs(5,iCell)  = 0.30_RKIND
+    dzs(6,iCell)  = 0.35_RKIND
+    dzs(7,iCell)  = 0.50_RKIND
+    dzs(8,iCell)  = 1.00_RKIND
+    dzs(9,iCell)  = 1.00_RKIND
+    dzs(10,iCell) = 1.50_RKIND
+
+    iSoil = 1
+    zs(iSoil,iCell) = 0.5_RKIND * dzs(iSoil,iCell)
+    do iSoil = 2, nSoilLevels
+       zs(iSoil,iCell) = zs(iSoil-1,iCell) &
+                       + 0.5_RKIND * dzs(iSoil-1,iCell) &
+                       + 0.5_RKIND * dzs(iSoil,iCell)
+    enddo
+ enddo
  end select
 
  end subroutine init_soil_layers_depth
@@ -447,6 +482,8 @@
  num_st = 0
  do iCell = 1, nCellsSolve
     do ifgSoil = 1, nFGSoilLevels
+       if(st_fg(ifgSoil,iCell) .le. 0._RKIND) st_fg(ifgSoil,iCell) = tmn(iCell)
+       if(sm_fg(ifgSoil,iCell) .le. 0._RKIND) sm_fg(ifgSoil,iCell) = 0.20
        if(st_fg(ifgSoil,iCell) .le. 0._RKIND) num_st = num_st + 1
        if(sm_fg(ifgSoil,iCell) .lt. 0._RKIND) num_sm = num_sm + 1
     enddo
@@ -467,6 +504,11 @@
    !if(config_nsoillevels .ne. 9) &
    !   call physics_error_fatal('RUC lsm uses 9 soil layers. Correct config_nsoillevels.')
    call init_soil_properties_ruc(mesh, fg, dminfo, dims, configs)
+
+ case ( 10 )
+  ! if(config_nsoillevels .ne. 10) &
+  !    call physics_error_fatal('This version of Noah-MP lsm uses 10 soil layers. Correct config_nsoillevels.')
+   call init_soil_properties_noah(mesh, fg, dminfo, dims, configs)
 
  end select
 end subroutine init_soil_layers_properties
@@ -536,7 +578,16 @@ end subroutine init_soil_layers_properties
        sm_input(ifgSoil+1,iCell) = sm_fg(ifgSoil,iCell)
     enddo
 
-    zhave(nFGSoilLevels+2,iCell) = 300._RKIND/100._RKIND
+!... block to determine max depth (based on 2-m for Noah and 5-m for NoahMP)
+!    can get away without an else block because this subroutine is only
+!    called if nSoilLevels is either 4 or 10
+    if(nSoilLevels .eq. 4) then
+       zhave(nFGSoilLevels+2,iCell) = 300._RKIND/100._RKIND
+    elseif(nSoilLevels .eq. 10) then
+       zhave(nFGSoilLevels+2,iCell) = 600._RKIND/100._RKIND
+    else
+
+    endif
     st_input(nFGSoilLevels+2,iCell) = tmn(iCell)
     sm_input(nFGSoilLevels+2,iCell) = sm_input(nFGSoilLevels,iCell)
 

--- a/src/core_atmosphere/physics/physics_noahmp/parameters/NoahmpTable.TBL
+++ b/src/core_atmosphere/physics/physics_noahmp/parameters/NoahmpTable.TBL
@@ -157,7 +157,7 @@
  ! MRP: microbial respiration parameter (umol CO2/kgC/s)
  MRP      =  0.00,  0.23,  0.23,  0.23,  0.23,  0.23,  0.17,  0.19,  0.19,  0.40,  0.40,  0.37,  0.23,  0.37,  0.30,  0.00,  0.17,  0.40,  0.00,  0.17,  0.23,  0.20,  0.00,  0.00,  0.20,  0.00,  0.00,
  ! NROOT: number of soil layers with root present
- NROOT    =     1,     3,     3,     3,     3,     3,     3,     3,     3,     3,     4,     4,     4,     4,     4,     0,     2,     2,     1,     3,     3,     3,     2,     1,     1,     0,     0,
+ NROOT    =     2,     6,     6,     6,     6,     6,     6,     6,     6,     6,     8,     8,     8,     8,     8,     0,     4,     4,     2,     6,     6,     6,     4,     2,     2,     0,     0,
  ! RGL: Parameter used in radiation stress function
  RGL      = 999.0, 100.0, 100.0, 100.0, 100.0,  65.0, 100.0, 100.0, 100.0,  65.0,  30.0,  30.0,  30.0,  30.0,  30.0,  30.0, 100.0,  30.0, 999.0, 100.0, 100.0, 100.0, 100.0, 999.0, 100.0, 999.0, 999.0,
  ! RS: Minimum stomatal resistance (s/m)
@@ -353,7 +353,7 @@
  ! MRP: microbial respiration parameter (umol CO2/kgC/s)
  MRP      =  0.37,   0.23,   0.37,   0.40,   0.30,   0.19,   0.19,   0.19,   0.40,   0.17,  0.285,   0.23,   0.00,   0.23,   0.00,   0.00,   0.00,   0.23,   0.20,   0.00,
  ! NROOT: number of soil layers with root present
- NROOT    =     4,      4,      4,      4,      4,      3,      3,      3,      3,      3,      2,      3,      1,      3,      1,      1,      0,      3,      3,      2,     
+ NROOT    =     8,      8,      8,      8,      8,      6,      6,      6,      6,      6,      4,      6,      2,      6,      2,      2,      0,      6,      6,      4,     
  ! RGL: Parameter used in radiation stress function
  RGL      =  30.0,   30.0,   30.0,   30.0,   30.0,  100.0,  100.0,  100.0,   65.0,  100.0,   65.0,  100.0,  999.0,  100.0,  999.0,  999.0,   30.0,  100.0,  100.0,  100.0,
  ! RS: Minimum stomatal resistance (s/m)

--- a/src/core_atmosphere/physics/physics_noahmp/parameters/NoahmpTable.TBL
+++ b/src/core_atmosphere/physics/physics_noahmp/parameters/NoahmpTable.TBL
@@ -157,7 +157,7 @@
  ! MRP: microbial respiration parameter (umol CO2/kgC/s)
  MRP      =  0.00,  0.23,  0.23,  0.23,  0.23,  0.23,  0.17,  0.19,  0.19,  0.40,  0.40,  0.37,  0.23,  0.37,  0.30,  0.00,  0.17,  0.40,  0.00,  0.17,  0.23,  0.20,  0.00,  0.00,  0.20,  0.00,  0.00,
  ! NROOT: number of soil layers with root present
- NROOT    =     2,     6,     6,     6,     6,     6,     6,     6,     6,     6,     8,     8,     8,     8,     8,     0,     4,     4,     2,     6,     6,     6,     4,     2,     2,     0,     0,
+ NROOT    =     1,     3,     3,     3,     3,     3,     3,     3,     3,     3,     4,     4,     4,     4,     4,     0,     2,     2,     1,     3,     3,     3,     2,     1,     1,     0,     0,
  ! RGL: Parameter used in radiation stress function
  RGL      = 999.0, 100.0, 100.0, 100.0, 100.0,  65.0, 100.0, 100.0, 100.0,  65.0,  30.0,  30.0,  30.0,  30.0,  30.0,  30.0, 100.0,  30.0, 999.0, 100.0, 100.0, 100.0, 100.0, 999.0, 100.0, 999.0, 999.0,
  ! RS: Minimum stomatal resistance (s/m)
@@ -353,7 +353,7 @@
  ! MRP: microbial respiration parameter (umol CO2/kgC/s)
  MRP      =  0.37,   0.23,   0.37,   0.40,   0.30,   0.19,   0.19,   0.19,   0.40,   0.17,  0.285,   0.23,   0.00,   0.23,   0.00,   0.00,   0.00,   0.23,   0.20,   0.00,
  ! NROOT: number of soil layers with root present
- NROOT    =     8,      8,      8,      8,      8,      6,      6,      6,      6,      6,      4,      6,      2,      6,      2,      2,      0,      6,      6,      4,     
+ NROOT    =     4,      4,      4,      4,      4,      3,      3,      3,      3,      3,      2,      3,      1,      3,      1,      1,      0,      3,      3,      2,     
  ! RGL: Parameter used in radiation stress function
  RGL      =  30.0,   30.0,   30.0,   30.0,   30.0,  100.0,  100.0,  100.0,   65.0,  100.0,   65.0,  100.0,  999.0,  100.0,  999.0,  999.0,   30.0,  100.0,  100.0,  100.0,
  ! RS: Minimum stomatal resistance (s/m)


### PR DESCRIPTION
These changes are based on guidance from Cenlin He and the NoahMP team at NSF NCAR-RAL to implement a ten-layer, 5-m--deep NoahMP LSM configuration in MPAS. Summarizing the changes:

- The hard-coded four- and nine-layer abort checks for Noah and RUC LSM, respectively, were already commented out. I added a hard-coded ten-layer abort check for NoahMP LSM, but commented it out for consistency with the others and with the guidance from RAL.
- A new block of soil-layer thicknesses for a ten-layer soil configuration to five-meter depth is added. It is wrapped around a case (10) block to match how the existing case(4) and case(9) blocks are handled. (The numbers here represent different values for the namelist.init_atmosphere nSoilLevels parameter).
- The init_soil_properties_noah subroutine in src/core_atmosphere/physics/mpas_atmphys_initialize_real.F is modified to extend the deep-soil interpolation boundary from 3 m (for a 2-m Noah or NoahMP LSM depth) to 6 m (for a 5-m NoahMP LSM depth). (Note that this subroutine was added when RUC LSM was added and thus is different from the MPAS-Dev implementation.)
- Safety checks were added in the nfgSoilLevels --> nSoilLevels interpolation to prevent negative soil moisture and negative soil temperature after interpolating from a different LSM input dataset.
- NROOT in the NoahMP parameter table has been doubled for all soil types to reflect the extension from a 2-m to a 5-m depth.

### Mandatory Questions

* Does this PR include any additions or changes to external inputs (e.g., microphysics lookup tables, static data for gravity-wave drag -- things like that)?
  - no
* Does this PR require updating one or more baselines for the CI tests? If so, what?
  - yes, new init files for the noahmp tests will need to be generated (the current mpas.init.nc files in the mpasdev tests are based on a four-layer soil configuration)

Note: the changes to the NoahMP parameter table cause the NoahMP baselines to fail. (The changes to mpas_atmphys_initialize_real.F are based on config_nSoilLevels rather than the chosen LSM, so a four-layer NoahMP configuration to a 2-m depth would still work in the context of that file.) Because we do not run init_atmosphere as part of the CI tests, new mpas.init.nc files would be needed.

### Priority Reviewers

* Please list the developers/collaborators you'd like to prioritize for review
* Example:
  - @joeolson42 
  - @XiaSun-Atmos 
  - plus Julia, once we can get her in this repo
