### PR TITLE
Add mmm physics as submobule.

### DIFF
--- a/.github/workflows/build_mpas_intel.yml
+++ b/.github/workflows/build_mpas_intel.yml
@@ -1,6 +1,6 @@
 name: Build (Intel) MPAS Standalone
 
-on: [pull_request,workflow_dispatch]
+on: [push,pull_request,workflow_dispatch]
 
 jobs:
   build_mpas_intel:

--- a/.github/workflows/build_mpas_intel.yml
+++ b/.github/workflows/build_mpas_intel.yml
@@ -1,6 +1,6 @@
 name: Build (Intel) MPAS Standalone
 
-on: [push,pull_request,workflow_dispatch]
+on: [pull_request,workflow_dispatch]
 
 jobs:
   build_mpas_intel:

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,7 +19,3 @@
 [submodule "src/core_atmosphere/physics/physics_noaa/MYNN-SFC"]
 	path = src/core_atmosphere/physics/physics_noaa/MYNN-SFC
 	url = https://github.com/NCAR/MYNN-SFC.git
-[submodule "src/core_atmosphere/physics/physics_mmm"]
-        path = src/core_atmosphere/physics/physics_mmm
-	url = https://github.com/NCAR/MMM-physics.git
-	tag = 20250616-MPASv8.3

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,7 @@
 [submodule "src/core_atmosphere/physics/physics_noaa/MYNN-SFC"]
 	path = src/core_atmosphere/physics/physics_noaa/MYNN-SFC
 	url = https://github.com/NCAR/MYNN-SFC.git
+[submodule "src/core_atmosphere/physics/physics_mmm"]
+        path = src/core_atmosphere/physics/physics_mmm
+	url = https://github.com/NCAR/MMM-physics.git
+	tag = 20250616-MPASv8.3

--- a/.gitmodules
+++ b/.gitmodules
@@ -22,4 +22,3 @@
 [submodule "src/core_atmosphere/physics/physics_mmm"]
 	path = src/core_atmosphere/physics/physics_mmm
 	url = https://github.com/NCAR/MMM-physics.git
-	tag = 20250616-MPASv8.3

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,7 @@
 [submodule "src/core_atmosphere/physics/physics_noaa/MYNN-SFC"]
 	path = src/core_atmosphere/physics/physics_noaa/MYNN-SFC
 	url = https://github.com/NCAR/MYNN-SFC.git
+[submodule "src/core_atmosphere/physics/physics_mmm"]
+	path = src/core_atmosphere/physics/physics_mmm
+	url = https://github.com/NCAR/MMM-physics.git
+	tag = 20250616-MPASv8.3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MPAS-v8.3.1-2.19
+MPAS-v8.3.1-2.20
 ====
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for

--- a/src/core_atmosphere/physics/.gitignore
+++ b/src/core_atmosphere/physics/.gitignore
@@ -1,5 +1,4 @@
 *.f90
 physics_wrf/*.f90
 physics_wrf/files/
-physics_mmm
 UGWP


### PR DESCRIPTION
This adds mmm_physics as a submodule to the repository.
This is an alternate solution to #231 

Future updates to mmm_physics will be handled by updating the submodule hash., just as all other physics submodules. This removes the need for Manage_externals in our fork.

### Mandatory Questions

* Does this PR include any additions or changes to external inputs (e.g., microphysics lookup tables, static data for gravity-wave drag -- things like that)?
No
* Does this PR require updating one or more baselines for the CI tests? If so, what?
No

### Priority Reviewers
@guoqing-noaa 
