### PR TITLE
Revert RUC LSM soil resistance to evaporation lower-limit removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MPAS-v8.3.1-2.24
+MPAS-v8.3.1-2.25
 ====
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for


### PR DESCRIPTION
This PR reverts #86, which removed the lower limit on soil resistance to evaporation in the RUC LSM. That change was made to dry the lower troposphere relative to what we thought was a moist-biased initial state in our real-time forecasts (based on RAP) at that point. With very different performance for RRFS-initialized forecasts, plus the questionable physicalness of removing the lower limit, we now believe this change should be reverted.

Testing and relations to other Pull Requests should be added as subsequent comments.

See the below examples for more information.
https://github.com/MPAS-Dev/MPAS/pull/930
https://github.com/MPAS-Dev/MPAS/pull/931

### Mandatory Questions

* Does this PR include any additions or changes to external inputs (e.g., microphysics lookup tables, static data for gravity-wave drag -- things like that)?
  - no
* Does this PR require updating one or more baselines for the CI tests? If so, what?
  - no

### Priority Reviewers

* Please list the developers/collaborators you'd like to prioritize for review
* Example:
  - @joeolson42 
  - @XiaSun-Atmos 
