### PR TITLE
Changed default value of 'config_lbc_w' to 'zero'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MPAS-v8.3.1-2.25
+MPAS-v8.3.1-2.26
 ====
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -314,7 +314,7 @@
                      description="Whether to apply lateral boundary conditions"
                      possible_values="true or false; this option must be set to true for limited-area simulations and false for global simulations"/>
 
-                <nml_option name="config_lbc_w" type="character" default_value="nearest"
+                <nml_option name="config_lbc_w" type="character" default_value="zero"
                      units="-"
                      description="Options for w on lateral boundaries"
                      possible_values="`nearest',`zero'"/>


### PR DESCRIPTION
This pull request changes the default value of the 'namelist.atmosphere' variable 'config_lbc_w' from 'nearest' to 'zero'.  This conforms with NCAR's release-v8.4.0 in which the vertical velocity in the specified zone of a regional mesh is hardwired to "w=0".  The change from 'nearest neighbor' to 'zero' solves the problem with instabilities associated with incoming convection to the upstream lateral boundaries when running on a high resolution (~1km) horizontal mesh.  The nature of the convection in simulations that don't blow up (resolution 3km and above) is insensitive to the choice of 'config_lbc_w', however, setting the default to 'zero' will reduce the possibility of users encountering instabilities in high-resolution regional simulations.  See this [slide presentation](https://docs.google.com/presentation/d/1x4T3FVLQOiXM04NzSazkH5r1JrfmCZl2vI9kERsqP0Q/edit?slide=id.g3c4c0577025_0_19#slide=id.g3c4c0577025_0_19) for support of the preferred 'zero' setting.


### Mandatory Questions

* Does this PR include any additions or changes to external inputs (e.g., microphysics lookup tables, static data for gravity-wave drag -- things like that)?
  - No.
* Does this PR require updating one or more baselines for the CI tests? If so, what?
  - Yes.  This PR will change the baseline for regional simulations.

### Priority Reviewers

@joeolson42 
@AndersJensen-NOAA 

