### PR TITLE
Fix broken CI tests due to gsl/develop renaming to noaa/develop

### DIFF
--- a/.github/workflows/bld_mpas_images.yaml
+++ b/.github/workflows/bld_mpas_images.yaml
@@ -4,8 +4,8 @@ run-name: CI Image Build for MPAS-A
 on:
   push:
     branches:
-      # Only build containers when pushing to gsl/develop
-      - "gsl/develop"
+      # Only build containers when pushing to noaa/develop
+      - "noaa/develop"
 
 jobs:
   docker:

--- a/.github/workflows/run_mpas.yml
+++ b/.github/workflows/run_mpas.yml
@@ -29,9 +29,9 @@ on: [push, pull_request, workflow_dispatch]
 # 1/7)   MPAS-Dev:v8.3.0                       mesoscale_reference           Release/Debug
 # 2/8)   MPAS-Dev:v8.3.0                       convection_permitting         Release/Debug
 # 3/9)   MPAS-Dev:v8.3.0                       mesoscale_reference_noahmp    Release/Debug
-# 4/10)  ufs-community:gsl/develop             mesoscale_reference           Release/Debug
-# 5/11)  ufs-community:gsl/develop             convection_permitting         Release/Debug
-# 6/12)  ufs-community:gsl/develop             mesoscale_reference_noahmp    Release/Debug
+# 4/10)  ufs-community:noaa/develop            mesoscale_reference           Release/Debug
+# 5/11)  ufs-community:noaa/develop            convection_permitting         Release/Debug
+# 6/12)  ufs-community:noaa/develop            mesoscale_reference_noahmp    Release/Debug
 #
 #############################################################################################
 jobs:
@@ -43,11 +43,11 @@ jobs:
         f-compiler: [gfortran]#,ifx]
         physics:    [mesoscale_reference, convection_permitting, mesoscale_reference_noahmp]
         repo:       [ufs-community, MPAS-Dev]
-        branch:     [gsl/develop, v8.3.0]
+        branch:     [noaa/develop, v8.3.0]
         build-type: [Debug, Release]
         exclude:
           - repo: MPAS-Dev
-            branch: gsl/develop
+            branch: noaa/develop
           - repo: ufs-community
             branch: v8.3.0
         include:

--- a/.github/workflows/run_mpas_hrrr.yml
+++ b/.github/workflows/run_mpas_hrrr.yml
@@ -22,9 +22,9 @@ on: [push, pull_request, workflow_dispatch]
 #
 # Tests:
 #        Baseline Codebase Repository:Branch  Physics   IC source   season   build-type
-# 1/4)   ufs-community:gsl/develop            hrrrv5    gfs         winter   Release/Debug
-# 2/5)   ufs-community:gsl/develop            hrrrv5    rap         summer   Release/Debug
-# 3/6)   ufs-community:gsl/develop            hrrrv5    rap         winter   Release/Debug
+# 1/4)   ufs-community:noaa/develop           hrrrv5    gfs         winter   Release/Debug
+# 2/5)   ufs-community:noaa/develop           hrrrv5    rap         summer   Release/Debug
+# 3/6)   ufs-community:noaa/develop           hrrrv5    rap         winter   Release/Debug
 #
 #############################################################################################
 jobs:
@@ -90,7 +90,7 @@ jobs:
       if: contains(matrix.build-type, 'Debug')
       run: |
         cd ${runner_ROOT}
-        git clone --recursive --branch gsl/develop https://github.com/ufs-community/MPAS-Model.git MPAS-Model-BL
+        git clone --recursive --branch noaa/develop https://github.com/ufs-community/MPAS-Model.git MPAS-Model-BL
         cd ${mpas_bl_ROOT}
         make ${{matrix.bld_target}} CORE=atmosphere DEBUG=true
 
@@ -98,7 +98,7 @@ jobs:
       if: contains(matrix.build-type, 'Release')
       run: |
         cd ${runner_ROOT}
-        git clone --recursive --branch gsl/develop https://github.com/ufs-community/MPAS-Model.git MPAS-Model-BL
+        git clone --recursive --branch noaa/develop https://github.com/ufs-community/MPAS-Model.git MPAS-Model-BL
         cd ${mpas_bl_ROOT}
         make ${{matrix.bld_target}} CORE=atmosphere
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MPAS-v8.3.1-2.26
+MPAS-v8.3.1-2.27
 ====
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for


### PR DESCRIPTION
This PR updates the CI tests to change all references of gsl/develop to noaa/develop. @dustinswales, if this passes the CI tests and looks good to you, I suggest we merge ASAP. I've already taken the liberty of updating the version number accordingly. 

* Does this PR include any additions or changes to external inputs (e.g., microphysics lookup tables, static data for gravity-wave drag -- things like that)?
  - no
* Does this PR require updating one or more baselines for the CI tests? If so, what?
  - no

### Reviews

* Is this PR currently draft, still being worked on, or ready for review?
  - ready for review
* For when this PR begins review, please list the developers/collaborators you'd like to prioritize for review; e.g.,:
  - @dustinswales 
