### PR TITLE
Correct the equation of time

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MPAS-v8.3.1-2.32
+MPAS-v8.3.1-2.33
 ====
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for

--- a/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_sw.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_sw.F
@@ -10204,9 +10204,9 @@ CONTAINS
        !    eot is based on the second equation at https://gml.noaa.gov/grad/solcalc/solareqns.PDF
        !    do not call rrtmg_sw is night-time:
        dorrsw = .true.
-       da=6.2831853071795862*(julian-1.)/365.
+       da=6.2831853071795862*(julian-0.5)/365.
        eot=(0.000075+0.001868*cos(da)-0.032077*sin(da) &
-            -0.014615*cos(2*da)-0.04089*sin(2*da))*(229.18)
+            -0.014615*cos(2*da)-0.040849*sin(2*da))*(229.18)
        xt24 = mod(xtime+radt*0.5,1440.)+eot
        tloctm = gmt + xt24/60. + xlong(i,j)/15.
        hrang = 15. * (tloctm-12.) * degrad


### PR DESCRIPTION
This PR implements https://github.com/wrf-model/WRF/pull/2334 for RRTMG shortwave, correcting two parameters in the equation of time that we implemented with #201.

### Mandatory Questions

* Does this PR include any additions or changes to external inputs (e.g., microphysics lookup tables, static data for gravity-wave drag -- things like that)?
  - no
* Does this PR require updating one or more baselines for the CI tests? If so, what?
  - no

### Reviews

* Is this PR currently draft, still being worked on, or ready for review?
  - ready for review
* For when this PR begins review, please list the developers/collaborators you'd like to prioritize for review; e.g.,:
  - @dustinswales 
  - @AndersJensen-NOAA 
  - @haiqinli 
