### PR TITLE
add a new stream property 'output_done_marker'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MPAS-v8.3.1-2.31
+MPAS-v8.3.1-2.32
 ====
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for

--- a/src/framework/mpas_stream_list_types.inc
+++ b/src/framework/mpas_stream_list_types.inc
@@ -38,6 +38,7 @@
         integer :: clobber_mode
         integer :: gattr_update = 1
         integer :: io_type
+        integer :: output_done_marker = 0
         type (MPAS_TimeInterval_type), pointer :: recordInterval => null()
         type (MPAS_stream_list_type), pointer :: alarmList_in => null()
         type (MPAS_stream_list_type), pointer :: alarmList_out => null()

--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -1812,6 +1812,9 @@ module mpas_stream_manager
                   case (MPAS_STREAM_PROPERTY_IOTYPE)
                       stream_cursor % io_type = propertyValue
 
+                  case (MPAS_STREAM_PROPERTY_DONE_MARKER)
+                      stream_cursor % output_done_marker = propertyValue
+
                   case default
                       STREAM_ERROR_WRITE('MPAS_stream_mgr_set_property(): No such property $i' COMMA intArgs=(/propertyName/))
                       STREAM_ERROR_WRITE('    or specified property is not of type integer.')
@@ -3515,6 +3518,11 @@ module mpas_stream_manager
 
            if ( swapRecords ) then
                stream % nRecords = tempRecord
+           end if
+
+           ! Write done marker file if enabled for this stream
+           if (stream % output_done_marker == 1) then
+               call write_done_marker(stream % filename, manager % ioContext % dminfo, stream % blockWrite)
            end if
         end if
 
@@ -6460,7 +6468,7 @@ subroutine stream_mgr_set_property_c(manager_c, streamID_c, propertyName_c, prop
     use mpas_c_interfacing, only : mpas_c_to_f_string
     use iso_c_binding, only : c_char, c_int, c_ptr, c_f_pointer
     use mpas_derived_types, only : MPAS_streamManager_type, MPAS_STREAM_MGR_NOERR, &
-                                   MPAS_STREAM_PROPERTY_OUTPUT_TIMELEVELS
+                                   MPAS_STREAM_PROPERTY_OUTPUT_TIMELEVELS, MPAS_STREAM_PROPERTY_DONE_MARKER
     use mpas_stream_manager, only : MPAS_stream_mgr_set_property
     use mpas_kind_types, only : StrKIND
 
@@ -6487,6 +6495,8 @@ subroutine stream_mgr_set_property_c(manager_c, streamID_c, propertyName_c, prop
     ! Map property name string to constant
     if (trim(propertyName) == 'output_timelevels') then
         call MPAS_stream_mgr_set_property(manager, streamID, MPAS_STREAM_PROPERTY_OUTPUT_TIMELEVELS, propertyValue, ierr=ierr)
+    else if (trim(propertyName) == 'output_done_marker') then
+        call MPAS_stream_mgr_set_property(manager, streamID, MPAS_STREAM_PROPERTY_DONE_MARKER, 1, ierr=ierr)
     end if
 
     if (ierr == MPAS_STREAM_MGR_NOERR) then
@@ -6601,3 +6611,47 @@ subroutine stream_mgr_add_variable_output_alarm_c(manager_c, streamID_c, ierr_c)
     end if
 
 end subroutine stream_mgr_add_variable_output_alarm_c !}}}
+
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  subroutine write_done_marker
+!
+!> \brief Write a done marker file to indicate output file completion
+!> \author Guoqing Ge
+!> \date March 2026  
+!> \details
+!>  Creates a file with .done extension after output file is closed.
+!>  Only called if output_done_marker property is true for the stream.
+!
+!-----------------------------------------------------------------------
+subroutine write_done_marker(filename, dminfo, blockWrite)!{{{
+
+    use mpas_derived_types, only : dm_info
+    use mpas_dmpar, only : IO_NODE
+
+    implicit none
+
+    character(len=*), intent(in) :: filename
+    type (dm_info), intent(in) :: dminfo
+    logical, intent(in) :: blockWrite
+
+    character(len=1024) :: marker_filename
+    character(len=8) :: date_str
+    character(len=10) :: time_str
+    integer :: unit_num
+
+    ! For the blockWrite mode, each rank writes its own file so each creates a marker
+    ! For normal parallel I/O, all ranks write same file so only rank 0 creates marker
+    if (blockWrite .or. dminfo % my_proc_id == IO_NODE) then
+        marker_filename = trim(filename) // '.done'
+        unit_num = 99
+        call date_and_time(date=date_str, time=time_str)
+        open(unit=unit_num, file=trim(marker_filename), status='replace', action='write')
+        ! Write timestamp: YYYY-MM-DD HH:MM:SS
+        write(unit_num, '(A)') date_str(1:4)//'-'//date_str(5:6)//'-'//date_str(7:8)//' '// &
+                               time_str(1:2)//':'//time_str(3:4)//':'//time_str(5:6)
+        close(unit_num)
+    end if
+
+end subroutine write_done_marker!}}}

--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -6621,7 +6621,7 @@ end subroutine stream_mgr_add_variable_output_alarm_c !}}}
 !> \author Guoqing Ge
 !> \date March 2026  
 !> \details
-!>  Creates a file with .done extension after output file is closed.
+!>  Creates a file with .done extension after a successful write completes for the current output file.
 !>  Only called if output_done_marker property is true for the stream.
 !
 !-----------------------------------------------------------------------

--- a/src/framework/mpas_stream_manager_types.inc
+++ b/src/framework/mpas_stream_manager_types.inc
@@ -22,7 +22,8 @@
                                   MPAS_STREAM_PROPERTY_CLOBBER       = 12, &
                                   MPAS_STREAM_PROPERTY_IOTYPE        = 13, &
                                   MPAS_STREAM_PROPERTY_GATTR_UPDATE  = 14, &
-                                  MPAS_STREAM_PROPERTY_OUTPUT_TIMELEVELS = 15
+                                  MPAS_STREAM_PROPERTY_OUTPUT_TIMELEVELS = 15, &
+                                  MPAS_STREAM_PROPERTY_DONE_MARKER   = 16
 
     integer, public, parameter :: MPAS_STREAM_CLOBBER_NEVER     = 100, &
                                   MPAS_STREAM_CLOBBER_APPEND    = 101, &

--- a/src/framework/xml_stream_parser.c
+++ b/src/framework/xml_stream_parser.c
@@ -1112,6 +1112,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 	immutable = 1;
 	for (stream_xml = ezxml_child(streams, "immutable_stream"); stream_xml; stream_xml = ezxml_next(stream_xml)) {
 		const char *output_timelevels;
+		const char *output_done_marker;
 		streamID = ezxml_attr(stream_xml, "name");
 		direction = ezxml_attr(stream_xml, "type");
 		filename_template = ezxml_attr(stream_xml, "filename_template");
@@ -1128,6 +1129,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 		clobber = ezxml_attr(stream_xml, "clobber_mode");
 		gattr_update = ezxml_attr(stream_xml, "gattr_update");
 		iotype = ezxml_attr(stream_xml, "io_type");
+		output_done_marker = ezxml_attr(stream_xml, "output_done_marker");
 
 		/* Extract the input interval, if it refer to other streams */
 		if ( interval_in ) {
@@ -1390,6 +1392,16 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 				return;
 			}
 		}
+		/* If output_done_marker is specified, set it as a property */
+		if (output_done_marker != NULL && strstr(output_done_marker, "yes") != NULL) {
+			stream_mgr_set_property_c(manager, streamID, "output_done_marker", "1", &err);
+			if (err != 0) {
+				*status = 1;
+				return;
+			}
+			snprintf(msgbuf, MSGSIZE, "        %-20s%s", "output done marker:", "yes");
+			mpas_log_write_c(msgbuf, "MPAS_LOG_OUT");
+		}
 
 		/* Possibly add an input alarm for this stream */
 		if (itype == 3 || itype == 1) {
@@ -1471,6 +1483,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 	immutable = 0;
 	for (stream_xml = ezxml_child(streams, "stream"); stream_xml; stream_xml = ezxml_next(stream_xml)) {
 		const char *output_timelevels;
+		const char *output_done_marker;
 		streamID = ezxml_attr(stream_xml, "name");
 		direction = ezxml_attr(stream_xml, "type");
 		filename_template = ezxml_attr(stream_xml, "filename_template");
@@ -1487,6 +1500,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 		clobber = ezxml_attr(stream_xml, "clobber_mode");
 		gattr_update = ezxml_attr(stream_xml, "gattr_update");
 		iotype = ezxml_attr(stream_xml, "io_type");
+		output_done_marker = ezxml_attr(stream_xml, "output_done_marker");
 
 		/* Extract the input interval, if it refer to other streams */
 		if ( interval_in ) {
@@ -1749,6 +1763,17 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 				return;
 			}
 			snprintf(msgbuf, MSGSIZE, "        %-20s%s", "output timelevels:", output_timelevels);
+			mpas_log_write_c(msgbuf, "MPAS_LOG_OUT");
+		}
+
+		/* If output_done_marker is specified, set it as a property */
+		if (output_done_marker != NULL && strstr(output_done_marker, "yes") != NULL) {
+			stream_mgr_set_property_c(manager, streamID, "output_done_marker", "1", &err);
+			if (err != 0) {
+				*status = 1;
+				return;
+			}
+			snprintf(msgbuf, MSGSIZE, "        %-20s%s", "output done marker:", "yes");
 			mpas_log_write_c(msgbuf, "MPAS_LOG_OUT");
 		}
 

--- a/testing_and_setup/ufs-community/cases/ufscommunity.hrrrv5.rap.summer/streams.atmosphere
+++ b/testing_and_setup/ufs-community/cases/ufscommunity.hrrrv5.rap.summer/streams.atmosphere
@@ -13,6 +13,7 @@
 <stream name="output"
         type="output"
         filename_template="history.$Y-$M-$D_$h.$m.$s.nc"
+        output_done_marker="yes"
         output_interval="0:12:00" >
 
 	<file name="stream_list.atmosphere.output"/>


### PR DESCRIPTION
This PR adds a new stream property `output_done_marker`.

By default, `output_done_marker` takes a value of `no`. When set to `yes` (i.e., `output_done_marker="yes"`), MPAS-Model writes a corresponding `${filename_template}.done` file (for example, `history.2024-08-16_00.00.00.nc.done`) after the associated forecast-hour output file has been completely written.

This greatly simplifies the rrfs-workflow (v2) logic to trigger new tasks only after a forecast file has been fully written. It helps prevent hard-to-debug workflow failures due to incomplete forecast files (sometimes only a few bytes away from a completion).

Resolve #237 

### Mandatory Questions

* Does this PR include any additions or changes to external inputs (e.g., microphysics lookup tables, static data for gravity-wave drag -- things like that)?
  - no
* Does this PR require updating one or more baselines for the CI tests? If so, what?
  - no

### Reviews

* Is this PR currently draft, still being worked on, or ready for review?
  - ready for review, tested and worked as expected
* For when this PR begins review, please list the developers/collaborators you'd like to prioritize for review; e.g.,:
  - @clark-evans 
  - @dustinswales 
