### PR TITLE
hotfix - safeguard invalid scalar indices to prevent segmentation faults during LBC/IC generation

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -7256,8 +7256,8 @@ call mpas_log_write('Done with soil consistency check')
          if (associated(index_smoke_fine  ) ) sorted_arrQ11(:,:) = -999.0
          if (associated(index_dust_fine   ) ) sorted_arrQ12(:,:) = -999.0
          if (associated(index_dust_coarse ) ) sorted_arrQ13(:,:) = -999.0
-         scalars(index_nwfa,:,iCell) = 0._RKIND
-         scalars(index_nifa,:,iCell) = 0._RKIND
+         if (index_nwfa > 0) scalars(index_nwfa,:,iCell) = 0._RKIND
+         if (index_nifa > 0) scalars(index_nifa,:,iCell) = 0._RKIND
          scalars(index_qc,:,iCell) = 0._RKIND
          scalars(index_qr,:,iCell) = 0._RKIND
          scalars(index_qi,:,iCell) = 0._RKIND
@@ -7342,9 +7342,9 @@ call mpas_log_write('Done with soil consistency check')
 
          do k = nVertLevels, 1, -1
             target_z = 0.5 * (zgrid(k,iCell) + zgrid(k+1,iCell))
-            scalars(index_nwfa,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
+            if (index_nwfa > 0) scalars(index_nwfa,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                         sorted_arrQ9(:,1:nfglevels_actual-1), order=1, extrap=0)
-            scalars(index_nifa,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
+            if (index_nifa > 0) scalars(index_nifa,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                         sorted_arrQ10(:,1:nfglevels_actual-1), order=1, extrap=0)
             scalars(index_qc,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                         sorted_arrQ1(:,1:nfglevels_actual-1), order=1, extrap=0)
@@ -8567,18 +8567,18 @@ call mpas_log_write('Done with soil consistency check')
          if (associated(index_smoke_fine  )) sorted_arrQ11(:,:) = -999.0
          if (associated(index_dust_fine   )) sorted_arrQ12(:,:) = -999.0
          if (associated(index_dust_coarse )) sorted_arrQ13(:,:) = -999.0
-         scalars(index_nwfa,:,iCell) = 0._RKIND
-         scalars(index_nifa,:,iCell) = 0._RKIND
-         scalars(index_qc,:,iCell) = 0._RKIND
-         scalars(index_qr,:,iCell) = 0._RKIND
-         scalars(index_qi,:,iCell) = 0._RKIND
-         scalars(index_qs,:,iCell) = 0._RKIND
-         scalars(index_qg,:,iCell) = 0._RKIND
-         scalars(index_nc,:,iCell) = 0._RKIND
-         scalars(index_ni,:,iCell) = 0._RKIND
-         scalars(index_nr,:,iCell) = 0._RKIND
-         scalars(index_ns,:,iCell) = 0._RKIND
-         scalars(index_ng,:,iCell) = 0._RKIND
+         if (index_nwfa > 0) scalars(index_nwfa,:,iCell) = 0._RKIND
+         if (index_nifa > 0) scalars(index_nifa,:,iCell) = 0._RKIND
+         if (index_qc > 0) scalars(index_qc,:,iCell) = 0._RKIND
+         if (index_qr > 0) scalars(index_qr,:,iCell) = 0._RKIND
+         if (index_qi > 0) scalars(index_qi,:,iCell) = 0._RKIND
+         if (index_qs > 0) scalars(index_qs,:,iCell) = 0._RKIND
+         if (index_qg > 0) scalars(index_qg,:,iCell) = 0._RKIND
+         if (index_nc > 0) scalars(index_nc,:,iCell) = 0._RKIND
+         if (index_ni > 0) scalars(index_ni,:,iCell) = 0._RKIND
+         if (index_nr > 0) scalars(index_nr,:,iCell) = 0._RKIND
+         if (index_ns > 0) scalars(index_ns,:,iCell) = 0._RKIND
+         if (index_ng > 0) scalars(index_ng,:,iCell) = 0._RKIND
 ! Chemistry
          if (associated(index_smoke_fine   )) then
             if (index_smoke_fine > 0   )  scalars(index_smoke_fine,:,iCell) = 0._RKIND
@@ -8653,25 +8653,25 @@ call mpas_log_write('Done with soil consistency check')
          if (associated(index_dust_coarse ))        call mpas_quicksort(nfglevels_actual, sorted_arrQ13)
          do k = nVertLevels, 1, -1
             target_z = 0.5 * (zgrid(k,iCell) + zgrid(k+1,iCell))
-            scalars(index_nwfa,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
+            if (index_nwfa > 0) scalars(index_nwfa,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                         sorted_arrQ9(:,1:nfglevels_actual-1), order=1, extrap=0)
-            scalars(index_nifa,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
+            if (index_nifa > 0) scalars(index_nifa,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                         sorted_arrQ10(:,1:nfglevels_actual-1), order=1, extrap=0)
-            scalars(index_qc,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
+            if (index_qc > 0) scalars(index_qc,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                         sorted_arrQ1(:,1:nfglevels_actual-1), order=1, extrap=0)
-            scalars(index_qr,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
+            if (index_qr > 0) scalars(index_qr,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                         sorted_arrQ2(:,1:nfglevels_actual-1), order=1, extrap=0)
-            scalars(index_qi,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
+            if (index_qi > 0) scalars(index_qi,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                         sorted_arrQ3(:,1:nfglevels_actual-1), order=1, extrap=0)
-            scalars(index_qs,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
+            if (index_qs > 0) scalars(index_qs,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                         sorted_arrQ4(:,1:nfglevels_actual-1), order=1, extrap=0)
-            scalars(index_qg,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
+            if (index_qg > 0) scalars(index_qg,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                         sorted_arrQ5(:,1:nfglevels_actual-1), order=1, extrap=0)
-            scalars(index_nc,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
+            if (index_nc > 0) scalars(index_nc,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                         sorted_arrQ6(:,1:nfglevels_actual-1), order=1, extrap=0)
-            scalars(index_ni,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
+            if (index_ni > 0) scalars(index_ni,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                         sorted_arrQ7(:,1:nfglevels_actual-1), order=1, extrap=0)
-            scalars(index_nr,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
+            if (index_nr > 0) scalars(index_nr,k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                         sorted_arrQ8(:,1:nfglevels_actual-1), order=1, extrap=0)
 ! JLS
             if ( associated(index_smoke_fine )) then
@@ -8687,18 +8687,18 @@ call mpas_log_write('Done with soil consistency check')
                                         sorted_arrQ13(:,1:nfglevels_actual-1), order=1, extrap=0)
             endif
             if (target_z < z_fg(1,iCell) .and. k < nVertLevels) then
-                scalars(index_nwfa,k,iCell) = scalars(index_nwfa,k+1,iCell)
-                scalars(index_nifa,k,iCell) = scalars(index_nifa,k+1,iCell)
-                scalars(index_qc,k,iCell) = scalars(index_qc,k+1,iCell)
-                scalars(index_qr,k,iCell) = scalars(index_qr,k+1,iCell)
-                scalars(index_qi,k,iCell) = scalars(index_qi,k+1,iCell)
-                scalars(index_qs,k,iCell) = scalars(index_qs,k+1,iCell)
-                scalars(index_qg,k,iCell) = scalars(index_qg,k+1,iCell)
-                scalars(index_nc,k,iCell) = scalars(index_nc,k+1,iCell)
-                scalars(index_ni,k,iCell) = scalars(index_ni,k+1,iCell)
-                scalars(index_nr,k,iCell) = scalars(index_nr,k+1,iCell)
-                scalars(index_ns,k,iCell) = scalars(index_ns,k+1,iCell)
-                scalars(index_ng,k,iCell) = scalars(index_ng,k+1,iCell)
+                if (index_nwfa > 0) scalars(index_nwfa,k,iCell) = scalars(index_nwfa,k+1,iCell)
+                if (index_nifa > 0) scalars(index_nifa,k,iCell) = scalars(index_nifa,k+1,iCell)
+                if (index_qc > 0) scalars(index_qc,k,iCell) = scalars(index_qc,k+1,iCell)
+                if (index_qr > 0) scalars(index_qr,k,iCell) = scalars(index_qr,k+1,iCell)
+                if (index_qi > 0) scalars(index_qi,k,iCell) = scalars(index_qi,k+1,iCell)
+                if (index_qs > 0) scalars(index_qs,k,iCell) = scalars(index_qs,k+1,iCell)
+                if (index_qg > 0) scalars(index_qg,k,iCell) = scalars(index_qg,k+1,iCell)
+                if (index_nc > 0) scalars(index_nc,k,iCell) = scalars(index_nc,k+1,iCell)
+                if (index_ni > 0) scalars(index_ni,k,iCell) = scalars(index_ni,k+1,iCell)
+                if (index_nr > 0) scalars(index_nr,k,iCell) = scalars(index_nr,k+1,iCell)
+                if (index_ns > 0) scalars(index_ns,k,iCell) = scalars(index_ns,k+1,iCell)
+                if (index_ng > 0) scalars(index_ng,k,iCell) = scalars(index_ng,k+1,iCell)
 ! Chemistry
                 if ( associated(index_smoke_fine  )) then
                    if (index_smoke_fine > 0   ) scalars(index_smoke_fine,k,iCell) = scalars(index_smoke_fine,k+1,iCell)


### PR DESCRIPTION
@Keenan and I got the same lbc task crash on Hera recently. All lbc files were generated correctly but the task failed due to `segmentation fault occurred`:
```
+2s exrrfs_lbc.sh[101]: srun ./init_atmosphere_model.x
forrtl: severe (174): SIGSEGV, segmentation fault occurred
Image              PC                Routine            Line        Source
libpthread-2.28.s  000014DB92A91990  Unknown               Unknown  Unknown
libc-2.28.so       000014DB923C2811  cfree                 Unknown  Unknown
libpnetcdf.so.4.0  000014DB9D9D5198  for_deallocate_ha     Unknown  Unknown
init_atmosphere_m  00000000006491D8  Unknown               Unknown  Unknown
init_atmosphere_m  0000000000658966  Unknown               Unknown  Unknown
init_atmosphere_m  000000000065877A  Unknown               Unknown  Unknown
init_atmosphere_m  0000000000643855  Unknown               Unknown  Unknown
init_atmosphere_m  00000000005B38D5  Unknown               Unknown  Unknown
init_atmosphere_m  0000000000408FC0  Unknown               Unknown  Unknown
init_atmosphere_m  0000000000408BC6  Unknown               Unknown  Unknown
init_atmosphere_m  0000000000408B3D  Unknown               Unknown  Unknown
libc-2.28.so       000014DB92361865  __libc_start_main     Unknown  Unknown
init_atmosphere_m  0000000000408A5E  Unknown               Unknown  Unknown
forrtl: severe (174): SIGSEGV, segmentation fault occurred
```
It looks similar to the behavior we met before when running the model where the executable just could not terminate correctly.

I tried a debug build and identified that the crash happened at line 8577 of `mpas_init_atm_cases.F`:
```
+2s exrrfs_lbc.sh[101]: srun ./init_atmosphere_model.x
forrtl: severe (408): fort: (3): Subscript #1 of the array SCALARS has value -1 which is less than the lower bound of 1

Image              PC                Routine            Line        Source
init_atmosphere_m  000000000081DDE8  init_atm_cases_mp        8577  mpas_init_atm_cases.F
init_atmosphere_m  0000000000556207  init_atm_cases_mp         404  mpas_init_atm_cases.F
init_atmosphere_m  000000000054C788  init_atm_core_mp_          92  mpas_init_atm_core.F
init_atmosphere_m  000000000040E70C  mpas_subdriver_mp         417  mpas_subdriver.F
init_atmosphere_m  00000000004085CD  MAIN__                     20  mpas.F
init_atmosphere_m  00000000004084FD  Unknown               Unknown  Unknown
libc-2.28.so       000014ED04092865  __libc_start_main     Unknown  Unknown
init_atmosphere_m  000000000040841E  Unknown               Unknown  Unknown
forrtl: severe (408): fort: (3): Subscript #1 of the array SCALARS has value -1 which is less than the lower bound of 1
``` 
and lines 8577-8581 read as follows:
```
        scalars(index_nc,:,iCell) = 0._RKIND
        scalars(index_ni,:,iCell) = 0._RKIND
        scalars(index_nr,:,iCell) = 0._RKIND
        scalars(index_ns,:,iCell) = 0._RKIND
        scalars(index_ng,:,iCell) = 0._RKIND
```
So it suggested a `-1` of `index_nc` caused the crash.

In `src/core_init_atmosphere/Registry.xml`, we can find that when `lbc_hydrometeors_gfs` is true while `lbc_hydrometeors_rrfs` is false, we only have `lbc_qv, lbc_qc, lbc_qr, lbc_qi, lbc_qs, lbc_qg`, do not have `lbc_nc/ni,....`. Hence we will of course get `-1` for their indexes (index_nc, ect).
```
                <var_array name="lbc_scalars" type="real" dimensions="nVertLevels nCells Time" packages="lbcs">
                        <var name="lbc_qv" array_group="moist" units="kg kg^{-1}"
                             description="Water vapor mixing ratio on lateral boundary cells"/>

                        <var name="lbc_qc" array_group="moist" units="kg kg^{-1}"
                             description="Cloud water mixing ratio on lateral boundary cells"
                             packages="lbc_hydrometeors_rrfs;lbc_hydrometeors_gfs"/>

                        <var name="lbc_qr" array_group="moist" units="kg kg^{-1}"
                             description="Rain water mixing ratio on lateral boundary cells"
                             packages="lbc_hydrometeors_rrfs;lbc_hydrometeors_gfs"/>

                        <var name="lbc_qi" array_group="moist" units="kg kg^{-1}"
                             description="Lateral boundary tendency of ice mixing ratio"
                             packages="lbc_hydrometeors_rrfs;lbc_hydrometeors_gfs"/>

                        <var name="lbc_qs" array_group="moist" units="kg kg^{-1}"
                             description="Lateral boundary tendency of snow mixing ratio"
                             packages="lbc_hydrometeors_rrfs;lbc_hydrometeors_gfs"/>

                        <var name="lbc_qg" array_group="moist" units="kg kg^{-1}"
                             description="Lateral boundary tendency of graupel mixing ratio"
                             packages="lbc_hydrometeors_rrfs;lbc_hydrometeors_gfs"/>

                        <var name="lbc_qh" array_group="moist"  units="kg kg^{-1} s^{-1}"
                             description="Lateral boundary tendency of hail mixing ratio"
                             packages="lbc_hydrometeors_rrfs"/>

                        <var name="lbc_nr" array_group="number" units="kg^{-1}"
                             description="Lateral boundary tendency of rain number concentration"
                             packages="lbc_hydrometeors_rrfs"/>

                        <var name="lbc_ni" array_group="number" units="kg^{-1}"
                             description="Lateral boundary tendency of ice number concentration"
                             packages="lbc_hydrometeors_rrfs"/>

                        <var name="lbc_nc" array_group="number" units="kg^{-1}"
                             description="Lateral boundary tendency of droplet number concentration"
                             packages="lbc_hydrometeors_rrfs"/>
......
......
```

This PR provides a hotfix by checking `if (index_nc > 0)` before setting `scalars(index_nc,:,iCell) = 0._RKIND`.
Similar safeguards are applied to IC generation where `index_nwfa` and `index_nifa` are only available for specific packages.

I don't have a full answer to why this only crashes on Hera but not on other machines. 
Different machines have different memory/heap layout,  the out-of-bounds address may still be within a valid memory page, so no SIGSEGV occurs and the program finishes "successfully".

### Mandatory Questions

* Does this PR include any additions or changes to external inputs (e.g., microphysics lookup tables, static data for gravity-wave drag -- things like that)?
  - no
* Does this PR require updating one or more baselines for the CI tests? If so, what?
  - no

### Reviews

* Is this PR currently draft, still being worked on, or ready for review?
  - ready for review
* For when this PR begins review, please list the developers/collaborators you'd like to prioritize for review; e.g.,:
  - @clark-evans 
  - @dustinswales 
